### PR TITLE
Reconcile duplicate entity slugs from parallel subagents

### DIFF
--- a/src/watchdog/pipeline/entity_norm.py
+++ b/src/watchdog/pipeline/entity_norm.py
@@ -1,0 +1,25 @@
+"""
+Canonical entity-name normalization.
+
+Shared by both duplicate-reconciliation paths so they collapse the same spelling
+variants to the same comparison key:
+  * write_vault — reconciling near-duplicate slugs coined by parallel subagents
+  * merge      — folding id drift across sections of one large document
+"""
+
+import re
+
+
+def normalize_entity_name(name: str) -> str:
+    """Collapse a name to a comparison key for duplicate-entity detection.
+
+    Deterministic and conservative: lowercase, ``&`` → ``and``, strip
+    punctuation, collapse whitespace. It catches spelling/punctuation variants
+    (``Ernst & Young Inc.`` == ``Ernst and Young Inc``) but deliberately does
+    **not** catch abbreviation or missing-token differences
+    (``chief-justice-gb-morawetz`` ≠ ``chief-justice-morawetz``) — auto-merging
+    those carries real false-positive risk.
+    """
+    s = (name or "").lower().replace("&", "and")
+    s = re.sub(r"[^\w\s]", "", s)
+    return re.sub(r"\s+", " ", s).strip()

--- a/src/watchdog/pipeline/merge.py
+++ b/src/watchdog/pipeline/merge.py
@@ -15,14 +15,10 @@ straight into `watchdog post-flight` unchanged.
 """
 
 import json
-import re
 import sys
 from pathlib import Path
 
-
-def _norm(text: str) -> str:
-    """Normalized surface form for drift dedup."""
-    return re.sub(r"[^a-z0-9]+", " ", (text or "").lower()).strip()
+from watchdog.pipeline.entity_norm import normalize_entity_name
 
 
 def _event_key(ev: dict) -> str:
@@ -78,7 +74,7 @@ def merge_extractions(sections: list[dict]) -> dict:
 
             # Fold id drift: reuse an existing id that shares a surface form.
             for nm in surfaces:
-                k = _norm(nm)
+                k = normalize_entity_name(nm)
                 if k and k in norm_index:
                     eid = norm_index[k]
                     break
@@ -116,7 +112,7 @@ def merge_extractions(sections: list[dict]) -> dict:
             _merge_into(cur["roles"], ent.get("roles", []), _role_key)
 
             for nm in surfaces:
-                k = _norm(nm)
+                k = normalize_entity_name(nm)
                 if k:
                     norm_index.setdefault(k, eid)
 

--- a/src/watchdog/pipeline/write_vault.py
+++ b/src/watchdog/pipeline/write_vault.py
@@ -56,6 +56,8 @@ from pathlib import Path
 
 import yaml
 
+from watchdog.pipeline.entity_norm import normalize_entity_name
+
 try:
     from fcntl import flock as _flock, LOCK_EX as _LOCK_EX, LOCK_UN as _LOCK_UN
     _HAS_FLOCK = True
@@ -90,11 +92,6 @@ def _doc_slug(filename: str) -> str:
     return slugify(Path(filename).stem) or "document"
 
 
-def _normalize_entity_name(name: str) -> str:
-    """Collapse a name to a comparison key for duplicate-entity reconciliation."""
-    s = name.lower().replace("&", "and")
-    s = re.sub(r"[^\w\s]", "", s)
-    return re.sub(r"\s+", " ", s).strip()
 
 
 def _reconcile_entity_ids(incoming_entities: list[dict], entities_reg: dict) -> None:
@@ -112,13 +109,13 @@ def _reconcile_entity_ids(incoming_entities: list[dict], entities_reg: dict) -> 
     norm_index: dict[tuple[str, str], str] = {}
     for eid, entry in entities_reg.items():
         for n in [entry["name"], *entry.get("aliases", [])]:
-            norm_index.setdefault((_normalize_entity_name(n), entry["type"]), eid)
+            norm_index.setdefault((normalize_entity_name(n), entry["type"]), eid)
 
     remap: dict[str, str] = {}
     for entity in incoming_entities:
         if entity["id"] in entities_reg:
             continue
-        key = (_normalize_entity_name(entity["name"]), entity["type"])
+        key = (normalize_entity_name(entity["name"]), entity["type"])
         existing_id = norm_index.get(key)
         if existing_id and existing_id != entity["id"]:
             remap[entity["id"]] = existing_id

--- a/src/watchdog/pipeline/write_vault.py
+++ b/src/watchdog/pipeline/write_vault.py
@@ -90,6 +90,50 @@ def _doc_slug(filename: str) -> str:
     return slugify(Path(filename).stem) or "document"
 
 
+def _normalize_entity_name(name: str) -> str:
+    """Collapse a name to a comparison key for duplicate-entity reconciliation."""
+    s = name.lower().replace("&", "and")
+    s = re.sub(r"[^\w\s]", "", s)
+    return re.sub(r"\s+", " ", s).strip()
+
+
+def _reconcile_entity_ids(incoming_entities: list[dict], entities_reg: dict) -> None:
+    """
+    Remap incoming entities that name an existing entity under a different slug.
+
+    Subagents extract in parallel from a pre-flight snapshot taken at launch, so two
+    documents referencing the same real-world entity can coin different ids (e.g.
+    'ernst-and-young-inc' vs 'ernst-young-inc'). write_vault runs inside the registry
+    lock with a fresh read of entities_reg — the one place that sees entities written
+    by sibling subagents earlier in the batch — so we reconcile here: any incoming
+    *new* entity whose normalized (name, type) matches an existing one is remapped to
+    that existing id, routing it through the merge path instead of creating a duplicate.
+    """
+    norm_index: dict[tuple[str, str], str] = {}
+    for eid, entry in entities_reg.items():
+        for n in [entry["name"], *entry.get("aliases", [])]:
+            norm_index.setdefault((_normalize_entity_name(n), entry["type"]), eid)
+
+    remap: dict[str, str] = {}
+    for entity in incoming_entities:
+        if entity["id"] in entities_reg:
+            continue
+        key = (_normalize_entity_name(entity["name"]), entity["type"])
+        existing_id = norm_index.get(key)
+        if existing_id and existing_id != entity["id"]:
+            remap[entity["id"]] = existing_id
+            entity["id"] = existing_id
+            # Preserve the variant spelling so the entity stays findable next time.
+            entity.setdefault("aliases", []).append(entity["name"])
+
+    # Keep intra-document role targets pointing at the reconciled ids.
+    if remap:
+        for entity in incoming_entities:
+            for role in entity.get("roles", []):
+                if role.get("target_id") in remap:
+                    role["target_id"] = remap[role["target_id"]]
+
+
 def _frontmatter(data: dict) -> str:
     return "---\n" + yaml.dump(
         data, default_flow_style=False, allow_unicode=True, sort_keys=False
@@ -558,6 +602,9 @@ def run(extraction_path: Path, vault_path: Path, skip_timeline: bool = False, ne
         )
 
         # ── 1. Update entity registry ─────────────────────────────────────────
+
+        # Reconcile near-duplicate slugs coined by parallel subagents before merging.
+        _reconcile_entity_ids(incoming_entities, entities_reg)
 
         modified: set[str] = set()
 

--- a/tests/test_write_vault.py
+++ b/tests/test_write_vault.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import pytest
 
-from watchdog.pipeline.write_vault import run, _doc_slug
+from watchdog.pipeline.write_vault import run, _doc_slug, _normalize_entity_name
 
 
 # ── Fixtures ──────────────────────────────────────────────────────────────────
@@ -865,3 +865,111 @@ def test_two_sequential_runs_merge_shared_entity(tmp_path):
     dates = {e["date"] for e in alice["timeline_events"]}
     assert "2020-01-01" in dates
     assert "2022-06-15" in dates
+
+
+# ── Duplicate-slug reconciliation (issue #79) ─────────────────────────────────
+
+@pytest.mark.parametrize("a,b", [
+    ("Ernst & Young Inc.", "Ernst and Young Inc"),
+    ("Ernst  and   Young  Inc", "ernst and young inc"),
+])
+def test_normalize_entity_name_collapses_variants(a, b):
+    assert _normalize_entity_name(a) == _normalize_entity_name(b)
+
+
+def test_normalize_entity_name_distinguishes_real_differences():
+    assert _normalize_entity_name("Acme Corp") != _normalize_entity_name("Acme Holdings")
+
+
+def _company_extraction(dirpath, sha, filename, eid, name):
+    return make_extraction(dirpath, overrides={
+        "document": {
+            "sha256": sha, "filename": filename,
+            "original_path": f"_INCOMING/{filename}",
+        },
+        "entities": [{
+            "id": eid, "name": name, "type": "Company",
+            "aliases": [], "summary": None, "analysis": None,
+            "timeline_events": [], "roles": [],
+        }],
+        "morgue_entity_id": eid,
+        "morgue_document_type": "annual-report",
+    })
+
+
+def test_parallel_slug_variants_reconciled(tmp_path):
+    """Two docs coining different slugs for the same entity must collapse to one."""
+    vault = make_vault(tmp_path)
+    (vault / "_INCOMING" / "doc-a.pdf").write_text("dummy")
+    (vault / "_INCOMING" / "doc-b.pdf").write_text("dummy")
+    dir_a, dir_b = tmp_path / "a", tmp_path / "b"
+    dir_a.mkdir(); dir_b.mkdir()
+
+    # First subagent wins the slug; second coins a near-duplicate id + name variant.
+    run(_company_extraction(dir_a, "sha-a", "doc-a.pdf",
+                            "ernst-and-young-inc", "Ernst & Young Inc."), vault)
+    run(_company_extraction(dir_b, "sha-b", "doc-b.pdf",
+                            "ernst-young-inc", "Ernst and Young Inc"), vault)
+
+    entities = json.loads((vault / ".watchdog" / "Registry" / "entities.json").read_text())
+    assert "ernst-and-young-inc" in entities
+    assert "ernst-young-inc" not in entities          # reconciled away, not a duplicate
+    ey = entities["ernst-and-young-inc"]
+    assert "sha-a" in ey["appears_in"] and "sha-b" in ey["appears_in"]
+    assert "Ernst and Young Inc" in ey["aliases"]     # variant folded in as alias
+
+
+def test_distinct_same_type_entities_not_merged(tmp_path):
+    """Reconciliation must not collapse genuinely different entities of the same type."""
+    vault = make_vault(tmp_path)
+    (vault / "_INCOMING" / "doc-a.pdf").write_text("dummy")
+    (vault / "_INCOMING" / "doc-b.pdf").write_text("dummy")
+    dir_a, dir_b = tmp_path / "a", tmp_path / "b"
+    dir_a.mkdir(); dir_b.mkdir()
+
+    run(_company_extraction(dir_a, "sha-a", "doc-a.pdf", "acme-corp", "Acme Corp"), vault)
+    run(_company_extraction(dir_b, "sha-b", "doc-b.pdf", "globex-corp", "Globex Corp"), vault)
+
+    entities = json.loads((vault / ".watchdog" / "Registry" / "entities.json").read_text())
+    assert "acme-corp" in entities
+    assert "globex-corp" in entities
+
+
+def test_reconcile_remaps_role_target_in_same_document(tmp_path):
+    """A role pointing at a reconciled entity in the same extraction is remapped too."""
+    vault = make_vault(tmp_path)
+    (vault / "_INCOMING" / "doc-a.pdf").write_text("dummy")
+    (vault / "_INCOMING" / "doc-b.pdf").write_text("dummy")
+    dir_a, dir_b = tmp_path / "a", tmp_path / "b"
+    dir_a.mkdir(); dir_b.mkdir()
+
+    # Doc A establishes the canonical company slug.
+    run(_company_extraction(dir_a, "sha-a", "doc-a.pdf",
+                            "ernst-and-young-inc", "Ernst & Young Inc."), vault)
+
+    # Doc B re-coins the company under a different slug AND references it from a person.
+    run(make_extraction(dir_b, overrides={
+        "document": {"sha256": "sha-b", "filename": "doc-b.pdf",
+                     "original_path": "_INCOMING/doc-b.pdf"},
+        "entities": [
+            {"id": "jane-doe", "name": "Jane Doe", "type": "Person",
+             "aliases": [], "summary": None, "analysis": None, "timeline_events": [],
+             "roles": [{
+                 "relationship": "Partner at", "target_id": "ernst-young-inc",
+                 "target_type": "Company", "target_name": "Ernst and Young Inc",
+                 "page": 1, "confidence": "high", "date_range": None,
+             }]},
+            {"id": "ernst-young-inc", "name": "Ernst and Young Inc", "type": "Company",
+             "aliases": [], "summary": None, "analysis": None,
+             "timeline_events": [], "roles": []},
+        ],
+        "morgue_entity_id": "jane-doe",
+        "morgue_document_type": "filing",
+    }), vault)
+
+    entities = json.loads((vault / ".watchdog" / "Registry" / "entities.json").read_text())
+    # Person's role now points at the canonical slug, not the orphaned one.
+    role = entities["jane-doe"]["roles"][0]
+    assert role["target_id"] == "ernst-and-young-inc"
+    # Reverse role landed on the canonical company entity.
+    assert any(r["target_id"] == "jane-doe" for r in entities["ernst-and-young-inc"]["roles"])

--- a/tests/test_write_vault.py
+++ b/tests/test_write_vault.py
@@ -5,7 +5,8 @@ from pathlib import Path
 
 import pytest
 
-from watchdog.pipeline.write_vault import run, _doc_slug, _normalize_entity_name
+from watchdog.pipeline.write_vault import run, _doc_slug
+from watchdog.pipeline.entity_norm import normalize_entity_name
 
 
 # ── Fixtures ──────────────────────────────────────────────────────────────────
@@ -874,11 +875,11 @@ def test_two_sequential_runs_merge_shared_entity(tmp_path):
     ("Ernst  and   Young  Inc", "ernst and young inc"),
 ])
 def test_normalize_entity_name_collapses_variants(a, b):
-    assert _normalize_entity_name(a) == _normalize_entity_name(b)
+    assert normalize_entity_name(a) == normalize_entity_name(b)
 
 
 def test_normalize_entity_name_distinguishes_real_differences():
-    assert _normalize_entity_name("Acme Corp") != _normalize_entity_name("Acme Holdings")
+    assert normalize_entity_name("Acme Corp") != normalize_entity_name("Acme Holdings")
 
 
 def _company_extraction(dirpath, sha, filename, eid, name):
@@ -973,3 +974,51 @@ def test_reconcile_remaps_role_target_in_same_document(tmp_path):
     assert role["target_id"] == "ernst-and-young-inc"
     # Reverse role landed on the canonical company entity.
     assert any(r["target_id"] == "jane-doe" for r in entities["ernst-and-young-inc"]["roles"])
+
+
+def test_reconcile_matches_against_existing_alias(tmp_path):
+    """A new slug matching an existing entity's *alias* (not its name) reconciles."""
+    vault = make_vault(tmp_path)
+    (vault / "_INCOMING" / "doc-a.pdf").write_text("dummy")
+    (vault / "_INCOMING" / "doc-b.pdf").write_text("dummy")
+    dir_a, dir_b = tmp_path / "a", tmp_path / "b"
+    dir_a.mkdir(); dir_b.mkdir()
+
+    # Doc A establishes the entity with an alias.
+    run(make_extraction(dir_a, overrides={
+        "document": {"sha256": "sha-a", "filename": "doc-a.pdf", "original_path": "_INCOMING/doc-a.pdf"},
+        "entities": [{"id": "ibm", "name": "IBM", "type": "Company",
+                      "aliases": ["International Business Machines"], "summary": None, "analysis": None,
+                      "timeline_events": [], "roles": []}],
+        "morgue_entity_id": "ibm", "morgue_document_type": "annual-report",
+    }), vault)
+
+    # Doc B coins a new slug whose name matches the *alias* above.
+    run(_company_extraction(dir_b, "sha-b", "doc-b.pdf",
+                            "international-business-machines", "International Business Machines"), vault)
+
+    entities = json.loads((vault / ".watchdog" / "Registry" / "entities.json").read_text())
+    assert "international-business-machines" not in entities   # reconciled onto the alias match
+    assert "sha-b" in entities["ibm"]["appears_in"]
+
+
+def test_reconcile_does_not_merge_across_types(tmp_path):
+    """Same normalized name but different entity types must stay separate."""
+    vault = make_vault(tmp_path)
+    (vault / "_INCOMING" / "doc-a.pdf").write_text("dummy")
+    (vault / "_INCOMING" / "doc-b.pdf").write_text("dummy")
+    dir_a, dir_b = tmp_path / "a", tmp_path / "b"
+    dir_a.mkdir(); dir_b.mkdir()
+
+    # A Person and a Company that normalize to the same key.
+    run(make_extraction(dir_a, overrides={
+        "document": {"sha256": "sha-a", "filename": "doc-a.pdf", "original_path": "_INCOMING/doc-a.pdf"},
+        "entities": [{"id": "morgan-person", "name": "Morgan", "type": "Person",
+                      "aliases": [], "summary": None, "analysis": None,
+                      "timeline_events": [], "roles": []}],
+        "morgue_entity_id": "morgan-person", "morgue_document_type": "filing",
+    }), vault)
+    run(_company_extraction(dir_b, "sha-b", "doc-b.pdf", "morgan-company", "Morgan"), vault)
+
+    entities = json.loads((vault / ".watchdog" / "Registry" / "entities.json").read_text())
+    assert "morgan-person" in entities and "morgan-company" in entities  # type-scoped, not merged


### PR DESCRIPTION
Fixes #79.

## Problem

Parallel extraction subagents each receive a pre-flight entity snapshot taken at launch. Two documents referencing the same real-world entity can each coin a different slug (e.g. `ernst-and-young-inc` vs `ernst-young-inc`). Both pass post-flight validation — neither is a duplicate at the moment it's written — so the vault ends up with duplicate entities that need manual `/watchdog-merge`.

## Fix

`write_vault.run()` already executes inside an exclusive per-vault registry lock and re-reads `entities.json` fresh inside it. That's the one place in the system that sees entities written by sibling subagents earlier in the same batch — so reconciliation belongs there, not in pre-flight (which only ever has the stale launch snapshot).

`_reconcile_entity_ids()` remaps any *new* incoming entity whose normalized `(name, type)` matches an existing entry to that existing id, routing it through the existing `_merge_entity` path instead of creating a duplicate. It also:

- records the variant spelling as an alias, so the entity is findable by pre-flight on future runs;
- remaps `target_id` on roles within the same extraction, so reconciliation never leaves a dangling relationship link.

Normalization (`_normalize_entity_name`) is deterministic and conservative: lowercase, `&`→`and`, strip punctuation, collapse whitespace, scoped by entity type. It catches the common spelling/punctuation variants. It deliberately does **not** catch abbreviation/missing-token differences (e.g. `chief-justice-gb-morawetz` vs `chief-justice-morawetz`) — auto-merging those carries real false-positive risk, so they remain for the orchestrator's post-batch slug flag to surface for human review.

No skill or orchestrator changes; no impact on parallelism.

## Tests

5 new tests in `test_write_vault.py`: normalization collapses variants / preserves real differences; the E&Y duplicate-slug scenario collapses to one entity; distinct same-type entities are not merged; intra-doc role targets are remapped (reverse role lands on the canonical entity).

Full suite: 364 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)