### PR TITLE
Fold contradiction-check note reads into pre-flight output (#90)

### DIFF
--- a/src/watchdog/pipeline/preflight.py
+++ b/src/watchdog/pipeline/preflight.py
@@ -11,6 +11,50 @@ import sys
 from pathlib import Path
 
 
+def _digest_events(events: list[dict]) -> list[dict]:
+    """Comparison-relevant fields of an entity's timeline events."""
+    return [
+        {"date": e.get("date"), "event": e.get("event"), "confidence": e.get("confidence")}
+        for e in events
+    ]
+
+
+def _digest_roles(roles: list[dict]) -> list[dict]:
+    """Comparison-relevant fields of an entity's relationships."""
+    return [
+        {
+            "relationship": r.get("relationship"),
+            "target_name": r.get("target_name"),
+            "target_type": r.get("target_type"),
+            "date_range": r.get("date_range"),
+            "confidence": r.get("confidence"),
+        }
+        for r in roles
+    ]
+
+
+def _existing_analysis(vault: Path, note_path: str) -> str:
+    """Return the existing '## Analysis' section of an entity note.
+
+    The Analysis section holds any prior [!contradiction] callouts, so supplying
+    it lets the subagent run the contradiction check without reading note files.
+    Returns '' if the note or the section is absent.
+    """
+    if not note_path:
+        return ""
+    p = vault / f"{note_path}.md"
+    if not p.exists():
+        return ""
+    content = p.read_text(encoding="utf-8", errors="replace")
+    idx = content.find("## Analysis")
+    if idx == -1:
+        return ""
+    start = idx + len("## Analysis")
+    nxt = content.find("\n## ", start)
+    body = content[start:nxt] if nxt != -1 else content[start:]
+    return body.strip()
+
+
 def run(vault: Path, sha256: str) -> dict:
     queue_file = vault / ".watchdog" / "queue" / f"{sha256}.json"
     if not queue_file.exists():
@@ -23,6 +67,16 @@ def run(vault: Path, sha256: str) -> dict:
         p.get("markdown", "") for p in queue.get("pages", [])
     ).lower()
 
+    # Full registry, read once — supplies each candidate's timeline/roles digest so
+    # the subagent can run the contradiction check without reading note files.
+    entities_reg: dict = {}
+    entities_file = vault / ".watchdog" / "Registry" / "entities.json"
+    if entities_file.exists():
+        try:
+            entities_reg = json.loads(entities_file.read_text(encoding="utf-8"))
+        except Exception:
+            entities_reg = {}
+
     # Candidate entities: manifest entries whose name or any alias appears in the text
     candidates: list[dict] = []
     manifest_file = vault / ".watchdog" / "Registry" / "manifest.json"
@@ -31,12 +85,17 @@ def run(vault: Path, sha256: str) -> dict:
         for eid, entry in manifest.items():
             names = [entry.get("name", "")] + entry.get("aliases", [])
             if any(n and n.lower() in text_lower for n in names):
+                note_path = entry.get("note_path", "")
+                reg = entities_reg.get(eid, {})
                 candidates.append({
                     "id": eid,
                     "name": entry.get("name", ""),
                     "type": entry.get("type", ""),
                     "aliases": entry.get("aliases", []),
-                    "note_path": entry.get("note_path", ""),
+                    "note_path": note_path,
+                    "timeline_events": _digest_events(reg.get("timeline_events", [])),
+                    "roles": _digest_roles(reg.get("roles", [])),
+                    "analysis": _existing_analysis(vault, note_path),
                 })
 
     # Check if already extracted

--- a/src/watchdog/skills/watchdog-ingest-subagent.md
+++ b/src/watchdog/skills/watchdog-ingest-subagent.md
@@ -19,7 +19,7 @@ The stdout output is **metadata only** — it does not include page content. Rea
 - `sha256`, `page_count`
 - `already_extracted` — if true, return the SKIPPED block immediately
 - `near_dup.near_duplicates`, `near_dup.top_similarity`
-- `existing_entities[]` — entities already in vault whose names appear in this document: `{id, name, type, aliases, note_path}`
+- `existing_entities[]` — entities already in vault whose names appear in this document: `{id, name, type, aliases, note_path, timeline_events, roles, analysis}`. `timeline_events` and `roles` are the vault's current values for that entity; `analysis` is its existing Analysis section (including any prior `[!contradiction]` callouts). These are supplied so the contradiction check (Step 7) needs no note reads.
 - `pages_path` — path to a markdown file containing all pages separated by `<!-- PAGE N -->` markers and `---` dividers
 
 If `already_extracted` is true, stop and return:
@@ -81,7 +81,7 @@ Never upgrade a claim past its weakest element.
 
 ## Step 7 — Contradiction check
 
-For each entity that matched an entry in PRE_FLIGHT.existing_entities, read its vault note at `{note_path}.md`.
+For each entity that matched an entry in PRE_FLIGHT.existing_entities, compare what this document states against that entry's `timeline_events`, `roles`, and `analysis` fields — all supplied by pre-flight. **Do not read entity note files.**
 
 Compare key dates, roles, and relationships against what this document states. Flag material discrepancies where both sides are `high` or `medium` confidence. Format contradiction callouts as:
 
@@ -91,9 +91,7 @@ Compare key dates, roles, and relationships against what this document states. F
 > - **<new value>** — [[documents/<new-slug>|<title>]], p. <n> (confidence: <level>)
 ```
 
-Do not flag: low-confidence differences, trivially explainable name variations, contradictions already in the note for the same fact.
-
-Read entity notes **only for matched entities** — do not read notes for new entities.
+Do not flag: low-confidence differences, trivially explainable name variations, or contradictions already present in the matched entity's `analysis` field for the same fact.
 
 ## Step 8 — Build extraction JSON and write vault
 

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -1,0 +1,105 @@
+import json
+from pathlib import Path
+
+from watchdog.pipeline import preflight
+
+
+def _vault(tmp_path: Path) -> Path:
+    vault = tmp_path / "vault"
+    reg = vault / ".watchdog" / "Registry"
+    reg.mkdir(parents=True)
+    (vault / ".watchdog" / "queue").mkdir()
+    return vault
+
+
+def _write_queue(vault: Path, sha: str, text: str) -> None:
+    queue = {
+        "sha256": sha,
+        "filename": "doc.pdf",
+        "page_count": 1,
+        "pages": [{"page": 1, "markdown": text}],
+        "near_dup": {},
+    }
+    (vault / ".watchdog" / "queue" / f"{sha}.json").write_text(json.dumps(queue))
+
+
+def _write_registry(vault: Path) -> None:
+    reg = vault / ".watchdog" / "Registry"
+    manifest = {
+        "alice-smith": {"name": "Alice Smith", "type": "Person",
+                        "aliases": ["A. Smith"], "note_path": "entities/person/alice-smith"},
+        "bob-jones": {"name": "Bob Jones", "type": "Person",
+                      "aliases": [], "note_path": "entities/person/bob-jones"},
+    }
+    (reg / "manifest.json").write_text(json.dumps(manifest))
+    entities = {
+        "alice-smith": {
+            "id": "alice-smith", "name": "Alice Smith", "type": "Person",
+            "timeline_events": [
+                {"date": "2020-03-15", "event": "Appointed director",
+                 "page": 2, "confidence": "high", "source_sha256": "x"},
+            ],
+            "roles": [
+                {"relationship": "Director of", "target_id": "acme",
+                 "target_name": "Acme Corp", "target_type": "Company",
+                 "date_range": "2020–", "confidence": "high",
+                 "source_sha256": "x", "is_reverse": False, "page": 2},
+            ],
+        },
+    }
+    (reg / "entities.json").write_text(json.dumps(entities))
+    (reg / "documents.json").write_text("{}")
+
+    note = vault / "entities" / "person" / "alice-smith.md"
+    note.parent.mkdir(parents=True)
+    note.write_text(
+        "---\nid: alice-smith\n---\n\n# Alice Smith\n\n"
+        "## Summary\n\nA director.\n\n"
+        "## Analysis\n\n> [!contradiction] role mismatch\n> - foo\n\n"
+        "## Timeline\n\n- timeline stuff\n"
+    )
+
+
+def test_candidate_enriched_with_digest_and_analysis(tmp_path):
+    vault = _vault(tmp_path)
+    _write_registry(vault)
+    _write_queue(vault, "doc1", "Alice Smith is a director of Acme Corp.")
+
+    result = preflight.run(vault, "doc1")
+    by_id = {e["id"]: e for e in result["existing_entities"]}
+
+    assert "alice-smith" in by_id          # name appears in text
+    assert "bob-jones" not in by_id        # name absent from text
+
+    a = by_id["alice-smith"]
+    # timeline_events trimmed to comparison fields (no page / source_sha256)
+    assert a["timeline_events"] == [
+        {"date": "2020-03-15", "event": "Appointed director", "confidence": "high"}
+    ]
+    # roles trimmed to comparison fields
+    assert a["roles"] == [
+        {"relationship": "Director of", "target_name": "Acme Corp",
+         "target_type": "Company", "date_range": "2020–", "confidence": "high"}
+    ]
+    # analysis carries prior contradiction callouts, scoped to the Analysis section
+    assert "[!contradiction] role mismatch" in a["analysis"]
+    assert "timeline stuff" not in a["analysis"]
+
+
+def test_candidate_without_registry_entry_has_empty_digest(tmp_path):
+    vault = _vault(tmp_path)
+    reg = vault / ".watchdog" / "Registry"
+    (reg / "manifest.json").write_text(json.dumps({
+        "ghost": {"name": "Ghost Co", "type": "Company", "aliases": [],
+                  "note_path": "entities/company/ghost"},
+    }))
+    (reg / "entities.json").write_text("{}")
+    (reg / "documents.json").write_text("{}")
+    _write_queue(vault, "doc2", "Ghost Co appears here.")
+
+    result = preflight.run(vault, "doc2")
+    a = result["existing_entities"][0]
+    assert a["id"] == "ghost"
+    assert a["timeline_events"] == []
+    assert a["roles"] == []
+    assert a["analysis"] == ""


### PR DESCRIPTION
## What

Part of the extraction-cost epic (#87). Folds the contradiction-check note reads into pre-flight output so the extraction subagent no longer reads entity note files during Step 7.

Closes #90.

## Why

Step 7 (contradiction check) had the subagent read each matched entity's `{note_path}.md` from disk — one `Read` per matched entity, and every subagent turn re-sends the accumulated context, so those reads inflate cache cost (see #87). Pre-flight already knows which entities matched, so it can supply the comparison data once, in Python, for free.

## How

- `preflight.py` now enriches each `existing_entities` candidate with:
  - `timeline_events` and `roles` — trimmed to comparison-relevant fields, from `entities.json` (read once per pre-flight call).
  - `analysis` — the entity note's existing `## Analysis` section, which carries any prior `[!contradiction]` callouts (so the subagent won't re-flag them).
- `watchdog-ingest-subagent.md` Step 7 now compares against those fields and **no longer reads note files**; the Step 1 field list documents the new shape.

The vault write path and registry are unchanged — this only moves where the contradiction-check inputs come from.

## Tests

- New `tests/test_preflight.py`: candidate enrichment (digest trimming + Analysis extraction scoped to the section) and the no-registry-entry fallback.
- Full suite: **368 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
