### PR TITLE
Slim orchestrator: timeline + briefing + contradiction resolution off the main session (#81, #83, #84)

### DIFF
--- a/src/watchdog/cli.py
+++ b/src/watchdog/cli.py
@@ -284,6 +284,9 @@ def main() -> None:
     p_ingest.add_argument("--extractor-model", choices=_model_choices, default="sonnet",
                           dest="extractor_model",
                           help="Model for extraction subagents (default: sonnet)")
+    p_ingest.add_argument("--finalizer-model", choices=_model_choices, default="sonnet",
+                          dest="finalizer_model",
+                          help="Model for the finalize subagent — timeline reconciliation + briefing (default: sonnet)")
     p_ingest.set_defaults(func=cmd_ingest)
 
     p_context = sub.add_parser("context", help="Open Claude Code to seed investigation context from _CONTEXT/")

--- a/src/watchdog/cmd/base.py
+++ b/src/watchdog/cmd/base.py
@@ -111,6 +111,7 @@ _CMD_HELP: dict[str, dict] = {
         "opts": [
             ("--orchestrator-model M", "Model for the orchestrator session (sonnet/opus/haiku, default: sonnet)"),
             ("--extractor-model M",    "Model for extraction subagents (sonnet/haiku, default: sonnet)"),
+            ("--finalizer-model M",    "Model for the finalize subagent — timeline + briefing (sonnet/opus/haiku, default: sonnet)"),
         ],
     },
     "context": {

--- a/src/watchdog/cmd/ingest.py
+++ b/src/watchdog/cmd/ingest.py
@@ -77,12 +77,14 @@ def cmd_ingest(args) -> None:
         sys.exit("Error: must be run from inside a Watchdog vault directory")
     orchestrator_model = getattr(args, "orchestrator_model", None) or "sonnet"
     extractor_model    = getattr(args, "extractor_model",    None) or "sonnet"
-    if orchestrator_model not in _MODEL_IDS:
-        sys.exit(f"Error: unknown model '{orchestrator_model}' — choose sonnet, opus, or haiku")
-    if extractor_model not in _MODEL_IDS:
-        sys.exit(f"Error: unknown model '{extractor_model}' — choose sonnet, opus, or haiku")
+    finalizer_model    = getattr(args, "finalizer_model",    None) or "sonnet"
+    for label, model in (("orchestrator", orchestrator_model),
+                         ("extractor", extractor_model),
+                         ("finalizer", finalizer_model)):
+        if model not in _MODEL_IDS:
+            sys.exit(f"Error: unknown {label} model '{model}' — choose sonnet, opus, or haiku")
     from watchdog.pipeline.ingest_setup import run as is_run
-    result = is_run(vault, extractor_model=extractor_model)
+    result = is_run(vault, extractor_model=extractor_model, finalizer_model=finalizer_model)
     if "error" in result:
         sys.exit(f"\n  {_YELLOW}Error:{_RESET} {result['error']}\n")
     if result["total"] == 0:

--- a/src/watchdog/pipeline/ingest_setup.py
+++ b/src/watchdog/pipeline/ingest_setup.py
@@ -24,7 +24,7 @@ def _iso_now() -> str:
     return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
-def run(vault: Path, extractor_model: str = "sonnet") -> dict:
+def run(vault: Path, extractor_model: str = "sonnet", finalizer_model: str = "sonnet") -> dict:
     """Acquire lock, scan queue, write state file. Returns the state dict."""
     lock_file = vault / ".watchdog" / "Registry" / ".ingest-lock"
     state_file = vault / ".watchdog" / "ingest-state.json"
@@ -77,6 +77,7 @@ def run(vault: Path, extractor_model: str = "sonnet") -> dict:
         "total": total,
         "queue_files": queue_files,
         "extractor_model": extractor_model,
+        "finalizer_model": finalizer_model,
     }
     state_file.write_text(json.dumps(state, ensure_ascii=False, indent=2), encoding="utf-8")
     return state

--- a/src/watchdog/skills/watchdog-ingest-finalize-subagent.md
+++ b/src/watchdog/skills/watchdog-ingest-finalize-subagent.md
@@ -1,0 +1,154 @@
+You are finalizing one Watchdog ingest batch. Two jobs: (1) reconcile the timeline, (2) write the post-ingest briefing. Follow every step below exactly. Return ONLY the confirmation block at the end — no other output.
+
+**Hard constraints — violations will break the pipeline:**
+- Never pipe or post-process command output with `python3`, `awk`, `jq`, `sed`, `grep`, or any other tool. The Bash tool returns output directly — read it as-is.
+- Never use absolute paths in bash commands. Always use paths relative to the vault root.
+- Never prefix commands with `cd <path> &&`.
+- Never run `watchdog <command> --help` or any exploration command.
+- Read vault files with the Read tool, not bash.
+
+**Inputs (supplied in the prompt):**
+- `INVESTIGATION_BRIEF` — condensed investigation context. Use this instead of reading `context.md`.
+- `RESULTS` — one compact metadata block per successfully extracted document (filename, type, date, entity counts, new/updated entity ids).
+- `NEARDUP_ALERTS` — near-duplicate alerts (may be empty).
+- `CONTRADICTION_FLAGS` — contradictions flagged during extraction (may be empty).
+
+Source the narrative detail from the scratchpads (Step 2), not from `RESULTS` — `RESULTS` carries machine-readable metadata only.
+
+---
+
+## Step 1 — Timeline reconciliation
+
+Run:
+```bash
+watchdog timeline-collisions
+```
+
+Read the JSON array directly from the Bash output. The tool has already promoted pending raw files (dates with no prior canonical) to canonical. The array contains only **collision objects**: dates where a canonical already existed and new raw files were added this session.
+
+For each collision object `{"date": "...", "canonical": "...", "raw": [...]}`:
+
+1. Read the canonical file (all NDJSON lines) with the Read tool.
+2. Read each raw file listed in `raw` (all NDJSON lines) with the Read tool.
+3. Combine all event lines for this date. Identify semantic duplicates — events describing the same real-world occurrence even if worded differently. Remove the duplicate, keeping the more precise wording.
+4. Write the deduplicated event list back to the canonical file, one JSON object per line, with the Write tool. Leave the raw file(s) in place as an audit trail.
+
+If the array is empty, skip the dedup. Track the number of collisions you deduplicated for the return block.
+
+Then run:
+```bash
+watchdog rebuild-timeline
+```
+
+This renders `timeline.md` from all canonical `.watchdog/timeline/{date}.ndjson` files.
+
+---
+
+## Step 2 — Read scratchpads
+
+Read all subagent scratchpads from `.watchdog/tmp/notes_*.md` — one per successfully extracted document. These hold the high-signal detail (key figures, leads, contradictions, chronological context) the compact `RESULTS` blocks cannot carry. Build the briefing from the scratchpads, `RESULTS`, `NEARDUP_ALERTS`, `CONTRADICTION_FLAGS`, and `INVESTIGATION_BRIEF`. Do not read queue files or entity records.
+
+---
+
+## Step 3 — Write the briefing
+
+Write a briefing note to `briefings/<YYYY-MM-DD-HH-MM>.md`:
+
+```markdown
+---
+date: <ISO 8601>
+files_ingested: <n>
+new_entities: <n>
+---
+
+# Ingest briefing — <date>
+
+## What was ingested
+
+<One line per file: filename, document type, date of document, entity count.>
+
+## New entities
+
+<Entities that did not exist in the vault before this ingest, with type and source document.>
+
+## Connections to existing entities
+
+<Entities from the new documents that matched entities already in the vault. For each, state what the connection is and why it matters.>
+
+## Leads and follow-up ideas
+
+<Actionable leads from the documents:>
+- **[Question]** <Open question the documents raise but don't answer.> *Source: [[documents/...]]*
+- **[Contact]** <Person or entity worth reaching out to.> *Source: [[entities/...]]*
+- **[Document]** <Specific document that appears to exist but isn't in the vault.> *Source: [[documents/...]], p. N*
+- **[FOI]** <Records request worth filing based on a gap.> *Source: [[documents/...]], p. N*
+
+If `INVESTIGATION_BRIEF` is non-empty, orient leads toward the journalist's stated questions. Omit this section if nothing warrants a lead.
+
+## Anomalies worth a closer look
+
+<Flag if present: shared addresses between apparently unrelated entities; a person appearing in an unexpected role; a transaction disproportionate to the entity's apparent scale; an entity appearing in many documents with no documented relationships. Write "Nothing flagged." if clean.>
+```
+
+If `NEARDUP_ALERTS` is non-empty, append:
+
+```markdown
+## Near-duplicate alerts
+
+The following files are similar to existing documents. Review and decide whether to keep both or treat as the same document.
+
+- <FILENAME>: <similarity>% similar to <existing document title>
+```
+
+### Update hot.md
+
+Overwrite `hot.md`:
+
+```markdown
+# Hot cache
+
+*Last updated: <YYYY-MM-DD> — [[briefings/<briefing-slug>|Briefing <date>]]*
+
+## Investigation status
+
+<One sentence on where the investigation stands, drawing on INVESTIGATION_BRIEF and what was just ingested.>
+
+## Recent additions
+
+<Bullet list of new entities and documents added this session, with type and source.>
+
+## Emerging patterns
+
+<New connections, contradictions, or anomalies surfaced in this ingest. Omit if nothing notable.>
+
+## Open questions
+
+<Leads from the briefing condensed to short bullets.>
+```
+
+Keep hot.md under ~40 lines.
+
+### Append to log.md
+
+```markdown
+## <YYYY-MM-DD HH:MM> — Ingest
+
+- **Files:** <n> processed
+- **New entities:** <n> (<n> new, <n> updated)
+- **Briefing:** [[briefings/<briefing-slug>|<date>]]
+<If CONTRADICTION_FLAGS is non-empty:>
+- **Contradictions flagged:** <n> — see entity notes for details
+```
+
+---
+
+## Step 4 — Return result
+
+Return ONLY the following block. No other output.
+
+```
+STATUS: ok
+BRIEFING: briefings/<briefing-slug>.md
+FILES: <n>
+TIMELINE: <n collisions deduplicated, or none>
+```

--- a/src/watchdog/skills/watchdog-ingest-subagent.md
+++ b/src/watchdog/skills/watchdog-ingest-subagent.md
@@ -93,6 +93,8 @@ Compare key dates, roles, and relationships against what this document states. F
 
 Do not flag: low-confidence differences, trivially explainable name variations, or contradictions already present in the matched entity's `analysis` field for the same fact.
 
+Emit a `[!contradiction]` callout only when you are confident the discrepancy is genuine after this comparison. This is the only verification step in the pipeline — there is no later orchestrator pass to remove false positives — so any callout you write is saved to the vault as-is.
+
 ## Step 8 — Build extraction JSON and write vault
 
 Build this JSON exactly:

--- a/src/watchdog/skills/watchdog-ingest.md
+++ b/src/watchdog/skills/watchdog-ingest.md
@@ -38,7 +38,7 @@ Set `TOTAL = INGEST.total`. Set `BATCH_START = INGEST.batch_start`. Set `EXTRACT
 
 Set `EXTRACTOR_MODEL = INGEST.extractor_model` if present, else `"sonnet"`.
 
-Set `FINALIZER_MODEL = INGEST.finalizer_model` if present, else `EXTRACTOR_MODEL`.
+Set `FINALIZER_MODEL = INGEST.finalizer_model` if present, else `"sonnet"`.
 
 Set `QUEUE_FILES = INGEST.queue_files`.
 

--- a/src/watchdog/skills/watchdog-ingest.md
+++ b/src/watchdog/skills/watchdog-ingest.md
@@ -10,7 +10,7 @@ Chewing (OCR, Docling) is handled separately by the `watchdog chew` CLI command.
 
 `LIMIT` caps how many files are **extracted** this run. When the limit is reached, stop cleanly and report how many files remain.
 
-**Architecture note:** Each document is extracted in an isolated Agent subagent. This keeps the orchestrator context flat regardless of batch size — queue file text, skill files, and extraction output never accumulate in this session. The orchestrator holds only: the investigation brief, a compact entity index (id/name/type/aliases), and a running list of per-document result summaries.
+**Architecture note:** Each document is extracted in an isolated Agent subagent. This keeps the orchestrator context flat regardless of batch size — queue file text, skill files, and extraction output never accumulate in this session. Timeline reconciliation and the post-ingest briefing are likewise delegated to a single finalize subagent, so scratchpad prose and timeline NDJSON never enter this session. The orchestrator holds only: the investigation brief, a compact entity index (id/name/type/aliases), and a running list of compact per-document result blocks.
 
 **CWD:** All bash commands run from the vault root. Never prefix commands with `cd <path> &&`. Never use absolute paths in any bash command — always use paths relative to the vault root (e.g. `.watchdog/tmp/file.json`, not `/Users/…/file.json`).
 
@@ -110,47 +110,9 @@ After the loop completes, check whether any new entity type from the results is 
 
 ---
 
-## 5. Timeline reconciliation
+## 5. Finalize: timeline + briefing
 
-Run:
-```bash
-watchdog timeline-collisions
-```
-
-Read the JSON output directly from the Bash tool — it is a JSON array. The tool has already promoted any pending raw files (dates with no prior canonical) to canonical. The array contains only **collision objects**: dates where a canonical already existed and new raw files were added in this ingest session.
-
-For each collision object `{"date": "...", "canonical": "...", "raw": [...]}`:
-
-1. Read the canonical file (all NDJSON lines) using the Read tool.
-2. Read each raw file listed in `raw` (all NDJSON lines) using the Read tool.
-3. Combine all event lines for this date. Identify semantic duplicates — events describing the same real-world occurrence even if worded differently. Remove the duplicate, keeping the more precise wording.
-4. Write the deduplicated event list back to the canonical file, one JSON object per line, using the Write tool. Leave the raw file(s) in place as an audit trail.
-
-If the array is empty, skip the dedup pass.
-
-Then run:
-```bash
-watchdog rebuild-timeline
-```
-
-This renders `timeline.md` from all canonical `.watchdog/timeline/{date}.ndjson` files.
-
----
-
-## 6. Post-batch contradiction resolution
-
-For each entry in `CONTRADICTION_FLAGS`:
-- Read the entity note (`entities/{type_lowercase}/{id}.md`)
-- Verify the contradiction is genuine, not a subagent false positive
-- If false positive: edit the note to remove the `[!contradiction]` callout that `write-vault` wrote
-
-This step reads at most a handful of entity notes — typically 0–3 per batch.
-
----
-
-## 7. Post-ingest briefing
-
-Print a batch summary:
+Print the batch summary:
 ```
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 Ingest complete: <extracted> processed, <skipped> skipped, <failed> failed
@@ -159,108 +121,41 @@ Entities in vault: <total from registry.json>
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
-Read all subagent scratchpads from `.watchdog/tmp/notes_*.md` — one per successfully extracted document. These contain the high-signal detail (key figures, leads, contradictions, chronological context) that the subagent's compact RESULT block cannot carry. Build the briefing from the scratchpads, `RESULTS` metadata, `NEARDUP_ALERTS`, `CONTRADICTION_FLAGS`, and `INVESTIGATION_BRIEF`. Do not re-read queue files or entity records.
+Read `.watchdog/Registry/registry.json` with the Read tool for the entity total used in the banner.
 
-Write a briefing note to `briefings/<YYYY-MM-DD-HH-MM>.md`:
+If no documents were successfully extracted (`EXTRACTED == 0`), skip the finalize subagent and continue to §6.
 
-```markdown
----
-date: <ISO 8601>
-files_ingested: <n>
-new_entities: <n>
----
+Otherwise launch **one finalize subagent** (a single Agent call) to reconcile the timeline and write the briefing. This keeps scratchpad prose and timeline NDJSON out of this session. Set the Agent's `description` to `Watchdog finalize` and `model` to `EXTRACTOR_MODEL`. Send this prompt (substitute every `{placeholder}` first):
 
-# Ingest briefing — <date>
+```
+Read `.claude/commands/watchdog-ingest-finalize-subagent.md` for full instructions. Then finalize this ingest batch.
 
-## What was ingested
+INVESTIGATION_BRIEF:
+{INVESTIGATION_BRIEF}
 
-<One line per file: filename, document type, date of document, entity count.>
+RESULTS:
+{RESULTS}
 
-## New entities
+NEARDUP_ALERTS:
+{NEARDUP_ALERTS}
 
-<Entities that did not exist in the vault before this ingest, with type and source document.>
-
-## Connections to existing entities
-
-<Entities from the new documents that matched entities already in the vault. For each, state what the connection is and why it matters.>
-
-## Leads and follow-up ideas
-
-<Actionable leads from the documents:>
-- **[Question]** <Open question the documents raise but don't answer.> *Source: [[documents/...]]*
-- **[Contact]** <Person or entity worth reaching out to.> *Source: [[entities/...]]*
-- **[Document]** <Specific document that appears to exist but isn't in the vault.> *Source: [[documents/...]], p. N*
-- **[FOI]** <Records request worth filing based on a gap.> *Source: [[documents/...]], p. N*
-
-If context.md is filled in, orient leads toward the journalist's stated questions. Omit this section if nothing warrants a lead.
-
-## Anomalies worth a closer look
-
-<Flag if present: shared addresses between apparently unrelated entities; a person appearing in an unexpected role; a transaction disproportionate to the entity's apparent scale; an entity appearing in many documents with no documented relationships. Write "Nothing flagged." if clean.>
+CONTRADICTION_FLAGS:
+{CONTRADICTION_FLAGS}
 ```
 
-If `NEARDUP_ALERTS` is non-empty, append:
-
-```markdown
-## Near-duplicate alerts
-
-The following files are similar to existing documents. Review and decide whether to keep both or treat as the same document.
-
-- <FILENAME>: <similarity>% similar to <existing document title>
-```
-
-
-### Update hot.md
-
-Overwrite `hot.md`:
-
-```markdown
-# Hot cache
-
-*Last updated: <YYYY-MM-DD> — [[briefings/<briefing-slug>|Briefing <date>]]*
-
-## Investigation status
-
-<One sentence on where the investigation stands, drawing on context.md and what was just ingested.>
-
-## Recent additions
-
-<Bullet list of new entities and documents added this session, with type and source.>
-
-## Emerging patterns
-
-<New connections, contradictions, or anomalies surfaced in this ingest. Omit if nothing notable.>
-
-## Open questions
-
-<Leads from the briefing condensed to short bullets.>
-```
-
-Keep hot.md under ~40 lines.
-
-### Append to log.md
-
-```markdown
-## <YYYY-MM-DD HH:MM> — Ingest
-
-- **Files:** <n> processed, <n> skipped, <n> failed
-- **New entities:** <n> (<n> new, <n> updated)
-- **Briefing:** [[briefings/<briefing-slug>|<date>]]
-<If contradictions were flagged:>
-- **Contradictions flagged:** <n> — see entity notes for details
-```
+When it returns, print its `BRIEFING:` path so the user can open it. Do not read the scratchpads, timeline files, or the briefing yourself — the finalize subagent owns those.
 
 ---
 
-## 8. Release lock
+## 6. Release lock
 
 Run `watchdog unlock` to remove `.watchdog/Registry/.ingest-lock`, delete `ingest-state.json`, and clean up temp files.
 
 ---
 
-## 9. Clarifying questions (optional)
+## 7. Clarifying questions (optional)
 
-After the briefing, if you encountered genuine ambiguities that would meaningfully change the entity graph, ask up to 3–5 targeted questions, batched together:
+After finalizing, if the extraction results surfaced genuine ambiguities that would meaningfully change the entity graph, ask up to 3–5 targeted questions, batched together. Draw these from `RESULTS`, `NEARDUP_ALERTS`, and `CONTRADICTION_FLAGS` — do not re-read documents:
 - Two entities that might be the same person or company
 - A document with no clear date, authority, or subject
 - A near-duplicate where journalist input would help

--- a/src/watchdog/skills/watchdog-ingest.md
+++ b/src/watchdog/skills/watchdog-ingest.md
@@ -38,6 +38,8 @@ Set `TOTAL = INGEST.total`. Set `BATCH_START = INGEST.batch_start`. Set `EXTRACT
 
 Set `EXTRACTOR_MODEL = INGEST.extractor_model` if present, else `"sonnet"`.
 
+Set `FINALIZER_MODEL = INGEST.finalizer_model` if present, else `EXTRACTOR_MODEL`.
+
 Set `QUEUE_FILES = INGEST.queue_files`.
 
 The lock is held (acquired by `watchdog ingest`). Every exit path — including errors — must release it by running `watchdog unlock`. That command removes the lock, deletes `ingest-state.json`, and cleans up temp files.
@@ -125,7 +127,7 @@ Read `.watchdog/Registry/registry.json` with the Read tool for the entity total 
 
 If no documents were successfully extracted (`EXTRACTED == 0`), skip the finalize subagent and continue to §6.
 
-Otherwise launch **one finalize subagent** (a single Agent call) to reconcile the timeline and write the briefing. This keeps scratchpad prose and timeline NDJSON out of this session. Set the Agent's `description` to `Watchdog finalize` and `model` to `EXTRACTOR_MODEL`. Send this prompt (substitute every `{placeholder}` first):
+Otherwise launch **one finalize subagent** (a single Agent call) to reconcile the timeline and write the briefing. This keeps scratchpad prose and timeline NDJSON out of this session. Set the Agent's `description` to `Watchdog finalize` and `model` to `FINALIZER_MODEL`. Send this prompt (substitute every `{placeholder}` first):
 
 ```
 Read `.claude/commands/watchdog-ingest-finalize-subagent.md` for full instructions. Then finalize this ingest batch.

--- a/tests/test_ingest_setup.py
+++ b/tests/test_ingest_setup.py
@@ -152,6 +152,26 @@ def test_extractor_model_defaults_to_sonnet(tmp_path):
     assert result["extractor_model"] == "sonnet"
 
 
+def test_finalizer_model_written_to_state(tmp_path):
+    vault = _make_vault(tmp_path)
+    _write_queue_file(vault, "abc123")
+
+    result = run(vault, finalizer_model="opus")
+
+    assert result["finalizer_model"] == "opus"
+    state = json.loads((vault / ".watchdog" / "ingest-state.json").read_text())
+    assert state["finalizer_model"] == "opus"
+
+
+def test_finalizer_model_defaults_to_sonnet(tmp_path):
+    vault = _make_vault(tmp_path)
+    _write_queue_file(vault, "abc123")
+
+    result = run(vault)
+
+    assert result["finalizer_model"] == "sonnet"
+
+
 def test_empty_queue_cleans_up_stale_state_file(tmp_path):
     vault = _make_vault(tmp_path)
     state_file = vault / ".watchdog" / "ingest-state.json"


### PR DESCRIPTION
## What

Slims the `/watchdog-ingest` orchestrator so the per-document-prose work that was inflating its long-lived context (epic #80) runs in ephemeral subagents instead. Three issues in one pass:

- **#81** — post-ingest briefing → a subagent
- **#83** — timeline semantic dedup → off the orchestrator
- **#84** — contradiction resolution → off the orchestrator

> **Stacked on #90.** Base is `issue-90` (PR #96) because #84 builds on the Step 7 changes from #90. GitHub will retarget this to `main` once #96 merges; review #96 first.

## How

- **New `watchdog-ingest-finalize-subagent.md`** — one end-of-run "reduce" spawn that (1) runs timeline reconciliation (`timeline-collisions` → semantic dedup of colliding dates → `rebuild-timeline`) and (2) reads the `.watchdog/tmp/notes_*.md` scratchpads and writes `briefings/…`, `hot.md`, and `log.md`. It receives `INVESTIGATION_BRIEF`, `RESULTS`, `NEARDUP_ALERTS`, `CONTRADICTION_FLAGS` in its prompt and sources narrative from scratchpads (not from `RESULTS`, so it composes with #82). Folding #81 + #83 into a single subagent keeps it to one extra spawn.
- **Orchestrator §5–§7 collapse into one Finalize step** (§5) that prints the batch banner and launches the finalize subagent. The orchestrator no longer reads scratchpads or timeline NDJSON. §8/§9 renumber to §6/§7; the architecture note is updated.
- **#84:** the extraction subagent's Step 7 is now the sole contradiction verification point ("emit a callout only when confident; there is no later orchestrator pass"). The orchestrator's post-batch contradiction-resolution step is removed entirely — so the orchestrator no longer reads entity notes either.

Net: the orchestrator skill drops ~124 lines, and three sources of O(N) per-document prose leave its context.

## Skill install

`install_skills` auto-copies every top-level `src/watchdog/skills/*.md`, so the new finalize skill installs to `.claude/commands/` on the next `watchdog refresh-skills` — no code changes needed.

## Tests

Skills aren't unit-tested, but the full suite (incl. the CLI skill-install test) passes: **368 passed**. Verified no dangling references to the removed sections and that the orchestrator references the new finalize subagent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
