### PR TITLE
Remove SUMMARY from subagent RESULT block

### DIFF
--- a/src/watchdog/skills/watchdog-ingest-subagent.md
+++ b/src/watchdog/skills/watchdog-ingest-subagent.md
@@ -188,5 +188,4 @@ NEW_ENTITIES: {id:name, id:name — or none}
 UPDATED_ENTITIES: {id:name, id:name — or none}
 NEAR_DUP: {top_similarity% similar to {existing filename} — or none}
 CONTRADICTIONS: {entity_id — brief description; entity_id — brief description — or none}
-SUMMARY: {one paragraph summary of this document and what was extracted}
 ```


### PR DESCRIPTION
## Summary

- Removes the `SUMMARY:` line from the Step 10 RESULT block in `watchdog-ingest-subagent.md`
- The same prose is already written to the document note by `write-vault` and captured in the per-document scratchpad — the orchestrator has no use for it
- Eliminates ~200–400 tokens of free-text accumulation per document in the long-lived orchestrator context (O(N) growth)

Closes #82

## Test plan

- [ ] Verify subagent RESULT block no longer contains a `SUMMARY:` field
- [ ] Confirm orchestrator "After each Agent call" section still parses correctly (it only references `STATUS`, `NEAR_DUP`, `CONTRADICTIONS` — no change needed)
- [ ] Run an ingest session and confirm briefing quality is unchanged (narrative sourced from scratchpads)