### PR TITLE
Tighten schema guidance to reduce post-flight retries

### DIFF
--- a/src/watchdog/skills/watchdog-ingest-subagent.md
+++ b/src/watchdog/skills/watchdog-ingest-subagent.md
@@ -135,6 +135,10 @@ Build this JSON exactly:
 }
 ```
 
+Correct `roles` entry: `{"relationship": "Director of", "target_id": "acme-corp", "target_type": "company", "target_name": "Acme Corp", "page": 3, "confidence": "high", "date_range": null}`
+
+Wrong: `"Director of Acme Corp"` — plain strings are rejected.
+
 `morgue_entity_id`: the document's subject — debtor for bankruptcy, company for annual report, defendant for court order.
 
 Common mistakes that will cause post-flight to reject the extraction:
@@ -143,6 +147,8 @@ Common mistakes that will cause post-flight to reject the extraction:
 - `morgue_document_type` is required — a type slug like `annual-report`, `court-order`, `bankruptcy-filing`
 - Every `confidence` value must be exactly one of: `high`, `medium`, `low`, `disputed`
 - `match_id` must be omitted entirely for new entities — do not set it to `null` or `""`
+
+Before writing, verify in-context: (1) every `roles` entry is an object with all required keys, not a plain string; (2) `morgue_entity_id` is present and non-empty; (3) `morgue_document_type` is present; (4) every `confidence` value is exactly `high`, `medium`, `low`, or `disputed`; (5) `match_id` is omitted (not null) for new entities. Fix any issues before proceeding.
 
 Write to `.watchdog/tmp/wdg_ex_{SHA256}.json` using the Write tool. Then run post-flight:
 


### PR DESCRIPTION
## Summary

- Adds a concrete correct/wrong `roles` example inline in the Step 8 JSON template — the most common rejection cause is plain strings instead of objects
- Adds a pre-write self-check instruction covering the five documented rejection causes, so the subagent verifies its JSON in-context before the Write tool call (no extra tool turns)

Both changes target the happy path: one shot through post-flight without a retry loop.

Closes #91

## Test plan

- [ ] Verify the roles example appears after the JSON template and shows both correct and wrong forms
- [ ] Verify the self-check paragraph appears before the `Write to .watchdog/tmp/...` line
- [ ] Confirm `postflight._validate` strictness is unchanged
- [ ] Run an ingest on a representative fixture set and measure retry rate before/after