### PR TITLE
Document ingest-then-fresh-session workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,22 @@ If the new skill would overlap significantly with an existing one, consider exte
 
 ---
 
+## Ingest workflow
+
+`/watchdog-ingest` is fire-and-forget. Once it finishes, **close the session** — do not continue asking investigation questions in the same Claude Code window. Every entity note, document, and scratchpad written during ingest is now in the vault; a fresh session reads all of it from disk with no ingest-time context baggage.
+
+**Intended workflow:**
+
+1. `watchdog chew` — OCR/Docling (terminal)
+2. `watchdog ingest` — lock + queue (terminal)
+3. Open Claude Code → `/watchdog-ingest` — let it run to completion
+4. Close the session
+5. Open a new Claude Code session → ask investigation questions; the session reads `hot.md`, `briefings/`, and the registry fresh
+
+Mixing ingest and investigation in one session inflates context proportionally to the number of documents ingested, crowding out the headroom needed for Q&A.
+
+---
+
 ## CLI style guide
 
 All terminal output in `cli.py` follows a consistent visual language. The colour constants are defined at the top of the file — use them, never raw ANSI codes.

--- a/src/watchdog/skills/watchdog-ingest.md
+++ b/src/watchdog/skills/watchdog-ingest.md
@@ -260,6 +260,11 @@ Keep hot.md under ~40 lines.
 
 Run `watchdog unlock` to remove `.watchdog/Registry/.ingest-lock`, delete `ingest-state.json`, and clean up temp files.
 
+Print:
+```
+Ingest complete. Start a fresh Claude Code session for investigation work — this session's context is no longer needed.
+```
+
 ---
 
 ## 9. Clarifying questions (optional)


### PR DESCRIPTION
## Summary

- Adds an **Ingest workflow** section to `CLAUDE.md` with the intended 5-step flow: chew → ingest → `/watchdog-ingest` → close session → new session for Q&A. Explains why mixing ingest and investigation in one session is harmful (context grows proportionally to documents ingested).
- Adds a **closing hint** to the orchestrator after §8 (release lock) prompting the user to open a fresh session for investigation work.

Closes #85

## Test plan

- [ ] Verify the `CLAUDE.md` workflow section appears between the Adding new record skills section and the CLI style guide
- [ ] Verify the orchestrator closing hint prints after `watchdog unlock` in §8