### PR TITLE
Sectioned extraction for large documents (#92)

### DIFF
--- a/src/watchdog/cmd/base.py
+++ b/src/watchdog/cmd/base.py
@@ -52,9 +52,11 @@ _ALIASES = {
 }
 
 _PIPELINE_COMMANDS = {
-    "near-dup":    ("watchdog.pipeline.near_dup",     "watchdog-near-dup"),
-    "write-vault": ("watchdog.pipeline.write_vault",  "watchdog-write-vault"),
-    "write-entity":("watchdog.pipeline.write_entity", "watchdog-write-entity"),
+    "near-dup":      ("watchdog.pipeline.near_dup",     "watchdog-near-dup"),
+    "write-vault":   ("watchdog.pipeline.write_vault",  "watchdog-write-vault"),
+    "write-entity":  ("watchdog.pipeline.write_entity", "watchdog-write-entity"),
+    "section-plan":  ("watchdog.pipeline.section",      "watchdog-section-plan"),
+    "merge-sections":("watchdog.pipeline.merge",        "watchdog-merge-sections"),
 }
 
 _TEMPLATES_DIR = Path(__file__).parent.parent / "templates" / "vault"
@@ -70,6 +72,8 @@ _VAULT_PERMISSIONS = [
     "Bash(watchdog unlock*)",
     "Bash(watchdog timeline-collisions)",
     "Bash(watchdog rebuild-timeline)",
+    "Bash(watchdog section-plan *)",
+    "Bash(watchdog merge-sections *)",
     # shell utilities
     "Bash(find .watchdog/queue/ *)",
     # internal vault state

--- a/src/watchdog/pipeline/ingest_setup.py
+++ b/src/watchdog/pipeline/ingest_setup.py
@@ -17,6 +17,11 @@ import time
 from datetime import datetime, timezone
 from pathlib import Path
 
+from watchdog.pipeline.section import (
+    section_token_threshold as _section_token_threshold,
+    est_tokens_from_pages as _est_tokens_from_pages,
+)
+
 STALE_SECONDS = 30 * 60
 
 
@@ -57,6 +62,8 @@ def run(vault: Path, extractor_model: str = "sonnet", finalizer_model: str = "so
                 "sha256": qf.stem,
                 "filename": data.get("filename", qf.stem),
                 "document_type": data.get("document_type"),
+                "page_count": data.get("page_count") or len(data.get("pages", [])),
+                "est_tokens": _est_tokens_from_pages(data.get("pages", [])),
             })
 
     total = len(queue_files)
@@ -78,6 +85,7 @@ def run(vault: Path, extractor_model: str = "sonnet", finalizer_model: str = "so
         "queue_files": queue_files,
         "extractor_model": extractor_model,
         "finalizer_model": finalizer_model,
+        "section_token_threshold": _section_token_threshold(),
     }
     state_file.write_text(json.dumps(state, ensure_ascii=False, indent=2), encoding="utf-8")
     return state

--- a/src/watchdog/pipeline/merge.py
+++ b/src/watchdog/pipeline/merge.py
@@ -1,0 +1,203 @@
+"""
+Watchdog section merge — deterministically combine per-section extraction JSONs
+into one document-level extraction JSON.
+
+Sectioned extraction carries a running scratchpad forward, so each section
+reuses the entity ids found by earlier sections. That makes this merge a pure
+set-union — no LLM reasoning:
+
+  * entities grouped by id; aliases / timeline_events / roles unioned
+  * a normalized-name pass folds any id drift (OCR variance) onto one id
+  * document key_facts concatenated and deduped
+
+The output is shape-identical to a single-document extraction JSON, so it feeds
+straight into `watchdog post-flight` unchanged.
+"""
+
+import json
+import re
+import sys
+from pathlib import Path
+
+
+def _norm(text: str) -> str:
+    """Normalized surface form for drift dedup."""
+    return re.sub(r"[^a-z0-9]+", " ", (text or "").lower()).strip()
+
+
+def _event_key(ev: dict) -> str:
+    return f"{ev.get('date', '')}|{(ev.get('event') or '')[:80].lower()}"
+
+
+def _role_key(role: dict) -> tuple:
+    return ((role.get("relationship") or "").lower(), role.get("target_id"))
+
+
+def _merge_into(acc: list, incoming: list, key_fn) -> None:
+    seen = {key_fn(x) for x in acc}
+    for item in incoming:
+        k = key_fn(item)
+        if k not in seen:
+            acc.append(item)
+            seen.add(k)
+
+
+def _dedup_key_facts(facts: list) -> list:
+    out, seen = [], set()
+    for f in facts:
+        k = (f.get("fact") or "")[:120].lower()
+        if k and k not in seen:
+            seen.add(k)
+            out.append(f)
+    return out
+
+
+def merge_extractions(sections: list[dict]) -> dict:
+    """Merge a list of partial extraction dicts into one extraction dict."""
+    docs = [s.get("document") or {} for s in sections]
+    document = next((dict(d) for d in docs if d), {})
+
+    key_facts: list = []
+    for d in docs:
+        key_facts.extend(d.get("key_facts", []))
+
+    by_id: dict[str, dict] = {}
+    norm_index: dict[str, str] = {}   # normalized surface form -> canonical id
+    morgue_entity_id = None
+    morgue_document_type = None
+
+    for sec in sections:
+        morgue_entity_id = morgue_entity_id or sec.get("morgue_entity_id")
+        morgue_document_type = morgue_document_type or sec.get("morgue_document_type")
+
+        for ent in sec.get("entities", []):
+            eid = ent.get("id")
+            if not eid:
+                continue
+            surfaces = [ent.get("name", "")] + list(ent.get("aliases", []))
+
+            # Fold id drift: reuse an existing id that shares a surface form.
+            for nm in surfaces:
+                k = _norm(nm)
+                if k and k in norm_index:
+                    eid = norm_index[k]
+                    break
+
+            cur = by_id.get(eid)
+            if cur is None:
+                cur = {
+                    "id": eid,
+                    "name": ent.get("name", ""),
+                    "type": ent.get("type", ""),
+                    "_surfaces": set(),
+                    "summary": None,
+                    "analysis": None,
+                    "timeline_events": [],
+                    "roles": [],
+                }
+                by_id[eid] = cur
+
+            if len(ent.get("name", "")) > len(cur["name"]):
+                cur["name"] = ent["name"]
+            cur["type"] = cur["type"] or ent.get("type", "")
+            cur["summary"] = cur["summary"] or ent.get("summary")
+
+            analysis = ent.get("analysis")
+            if analysis and (not cur["analysis"] or analysis not in cur["analysis"]):
+                cur["analysis"] = (
+                    (cur["analysis"] + "\n\n" + analysis).strip()
+                    if cur["analysis"] else analysis
+                )
+
+            for nm in surfaces:
+                if nm:
+                    cur["_surfaces"].add(nm)
+            _merge_into(cur["timeline_events"], ent.get("timeline_events", []), _event_key)
+            _merge_into(cur["roles"], ent.get("roles", []), _role_key)
+
+            for nm in surfaces:
+                k = _norm(nm)
+                if k:
+                    norm_index.setdefault(k, eid)
+
+    entities = []
+    for cur in by_id.values():
+        surfaces = cur.pop("_surfaces")
+        name_lower = cur["name"].lower()
+        aliases, seen = [], set()
+        for nm in surfaces:
+            low = nm.lower()
+            if low == name_lower or low in seen:
+                continue
+            seen.add(low)
+            aliases.append(nm)
+        cur["aliases"] = aliases
+        if not cur["summary"]:
+            cur.pop("summary")
+        if not cur["analysis"]:
+            cur.pop("analysis")
+        entities.append(cur)
+
+    document.pop("key_facts", None)
+    document["key_facts"] = _dedup_key_facts(key_facts)
+
+    return {
+        "document": document,
+        "entities": entities,
+        "morgue_entity_id": morgue_entity_id,
+        "morgue_document_type": morgue_document_type,
+    }
+
+
+def run(vault: Path, sha256: str) -> dict:
+    tmp = vault / ".watchdog" / "tmp"
+    section_files = sorted(tmp.glob(f"section_ex_{sha256}_*.json"))
+    if not section_files:
+        return {"error": f"no section extraction files found for sha256 {sha256}"}
+
+    sections = []
+    for f in section_files:
+        try:
+            sections.append(json.loads(f.read_text(encoding="utf-8")))
+        except json.JSONDecodeError as e:
+            return {"error": f"invalid section JSON {f.name}: {e}"}
+
+    merged = merge_extractions(sections)
+    out = tmp / f"wdg_ex_{sha256}.json"
+    out.write_text(json.dumps(merged, ensure_ascii=False, indent=2), encoding="utf-8")
+
+    # New-vs-updated split, computed against the registry *before* post-flight writes.
+    registry: dict = {}
+    reg_path = vault / ".watchdog" / "Registry" / "entities.json"
+    if reg_path.exists():
+        try:
+            registry = json.loads(reg_path.read_text(encoding="utf-8"))
+        except Exception:
+            registry = {}
+    new_entities = {e["id"]: e["name"] for e in merged["entities"] if e["id"] not in registry}
+    updated_entities = {e["id"]: e["name"] for e in merged["entities"] if e["id"] in registry}
+
+    return {
+        "ok": True,
+        "extraction_path": str(out.relative_to(vault)),
+        "entity_count": len(merged["entities"]),
+        "new_entities": new_entities,
+        "updated_entities": updated_entities,
+        "sections_merged": len(sections),
+    }
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        sys.exit("Usage: watchdog merge-sections <sha256>")
+    vault = Path(".").resolve()
+    if not (vault / ".watchdog").is_dir():
+        sys.exit("Error: must be run from inside a Watchdog vault directory")
+    result = run(vault, sys.argv[1])
+    if "error" in result:
+        sys.exit(f"Error: {result['error']}")
+    print(json.dumps(result, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/watchdog/pipeline/section.py
+++ b/src/watchdog/pipeline/section.py
@@ -1,0 +1,167 @@
+"""
+Watchdog section planner — split a large queued document into sections for
+sectioned (sequential) extraction.
+
+Large documents don't fit comfortably in one extraction subagent's context, and
+the cost of a single huge context grows with its size. This splits a document
+into overlapping sections of roughly `section_token_budget` estimated tokens
+each. The orchestrator extracts the sections in reading order, carrying a
+running scratchpad forward, then merges the per-section results with
+`watchdog merge-sections`.
+
+The trigger is **estimated tokens**, not page count: page count is a poor proxy
+because density varies several-fold (a table-heavy financial page is far denser
+than prose) and non-paginated files (.txt/.csv/.md) are a single "page"
+regardless of size. Token estimation is a cheap chars/4 heuristic.
+
+Splitting:
+  * paginated documents (page_count > 1) split on **page boundaries** —
+    pages-per-section derived from the document's average density — so page
+    citations are preserved.
+  * non-paginated documents split the single page's text into **character
+    windows**; citations for that content carry no page number.
+
+Threshold-gated: documents whose estimated tokens are at or below
+`section_token_threshold` are not sectioned (the caller uses the whole-document
+path).
+"""
+
+import json
+import sys
+from pathlib import Path
+
+DEFAULT_TOKEN_THRESHOLD = 120_000   # est tokens; at/under this, no sectioning
+DEFAULT_TOKEN_BUDGET = 60_000       # target est tokens per section
+DEFAULT_OVERLAP_TOKENS = 4_000      # est-token overlap between consecutive sections
+_CHARS_PER_TOKEN = 4                # cheap heuristic
+
+
+def _config_get(key: str, default):
+    try:
+        cfg = json.loads((Path.home() / ".watchdog" / "config.json").read_text())
+    except Exception:
+        cfg = {}
+    return cfg.get(key, default)
+
+
+def section_token_threshold() -> int:
+    """Estimated-token count at/under which a document is not sectioned."""
+    return _config_get("section_token_threshold", DEFAULT_TOKEN_THRESHOLD)
+
+
+def est_tokens(text: str) -> int:
+    """Cheap estimate of the token count of a string (~4 chars/token)."""
+    return len(text or "") // _CHARS_PER_TOKEN
+
+
+def est_tokens_from_pages(pages: list) -> int:
+    return sum(est_tokens(p.get("markdown", "")) for p in pages)
+
+
+def plan_ranges(page_count: int, size: int, overlap: int) -> list[tuple[int, int]]:
+    """Return 1-based inclusive (start, end) page ranges covering the document.
+
+    Consecutive ranges overlap by `overlap` pages so a table straddling a
+    boundary is wholly visible in at least one section.
+    """
+    if page_count <= 0:
+        return []
+    size = max(1, size)
+    overlap = max(0, min(overlap, size - 1))  # guard against non-advancing ranges
+    ranges: list[tuple[int, int]] = []
+    start = 1
+    while start <= page_count:
+        end = min(start + size - 1, page_count)
+        ranges.append((start, end))
+        if end >= page_count:
+            break
+        start = end - overlap + 1
+    return ranges
+
+
+def char_windows(total: int, size: int, overlap: int) -> list[tuple[int, int]]:
+    """Return (start, end) character offsets (end exclusive) covering [0, total)."""
+    if total <= 0:
+        return []
+    size = max(1, size)
+    overlap = max(0, min(overlap, size - 1))
+    windows: list[tuple[int, int]] = []
+    start = 0
+    while start < total:
+        end = min(start + size, total)
+        windows.append((start, end))
+        if end >= total:
+            break
+        start = end - overlap
+    return windows
+
+
+def run(vault: Path, sha256: str) -> dict:
+    queue_file = vault / ".watchdog" / "queue" / f"{sha256}.json"
+    if not queue_file.exists():
+        return {"error": f"queue file not found for sha256 {sha256}"}
+
+    queue = json.loads(queue_file.read_text(encoding="utf-8"))
+    pages = queue.get("pages", [])
+    page_count = queue.get("page_count") or len(pages)
+    total_tokens = est_tokens_from_pages(pages)
+
+    threshold = section_token_threshold()
+    budget = _config_get("section_token_budget", DEFAULT_TOKEN_BUDGET)
+    overlap_tokens = _config_get("section_overlap_tokens", DEFAULT_OVERLAP_TOKENS)
+
+    if total_tokens <= threshold:
+        return {"sectioned": False, "page_count": page_count, "est_tokens": total_tokens}
+
+    tmp = vault / ".watchdog" / "tmp"
+    tmp.mkdir(parents=True, exist_ok=True)
+    sections = []
+
+    if page_count > 1 and len(pages) > 1:
+        # Paginated: derive pages-per-section from average density, split on pages.
+        avg = max(1, total_tokens // page_count)
+        pages_per = max(1, round(budget / avg))
+        overlap_pages = min(pages_per - 1, max(0, round(overlap_tokens / avg)))
+        by_num = {p.get("page"): p.get("markdown", "") for p in pages}
+        for idx, (start, end) in enumerate(plan_ranges(page_count, pages_per, overlap_pages), start=1):
+            parts = [f"<!-- PAGE {n} -->\n\n{by_num.get(n, '')}" for n in range(start, end + 1)]
+            path = tmp / f"section_{sha256}_{idx:02d}.md"
+            path.write_text("\n\n---\n\n".join(parts), encoding="utf-8")
+            sections.append({
+                "index": idx,
+                "label": f"pages {start}–{end}",
+                "paginated": True,
+                "pages_path": str(path.relative_to(vault)),
+            })
+    else:
+        # Non-paginated (text/csv/md, or a single huge page): split on characters.
+        text = pages[0].get("markdown", "") if pages else ""
+        windows = char_windows(len(text), budget * _CHARS_PER_TOKEN, overlap_tokens * _CHARS_PER_TOKEN)
+        for idx, (cstart, cend) in enumerate(windows, start=1):
+            path = tmp / f"section_{sha256}_{idx:02d}.md"
+            path.write_text(text[cstart:cend], encoding="utf-8")
+            sections.append({
+                "index": idx,
+                "label": f"part {idx} of {len(windows)}",
+                "paginated": False,
+                "pages_path": str(path.relative_to(vault)),
+            })
+
+    return {"sectioned": True, "page_count": page_count,
+            "est_tokens": total_tokens, "sections": sections}
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        sys.exit("Usage: watchdog section-plan <sha256>")
+    vault = Path(".").resolve()
+    if not (vault / ".watchdog").is_dir():
+        sys.exit("Error: must be run from inside a Watchdog vault directory")
+    result = run(vault, sys.argv[1])
+    if "error" in result:
+        sys.exit(f"Error: {result['error']}")
+    print(json.dumps(result, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/watchdog/skills/watchdog-ingest-section-subagent.md
+++ b/src/watchdog/skills/watchdog-ingest-section-subagent.md
@@ -1,0 +1,114 @@
+You are extracting **one page-range section** of a large document for the Watchdog research system. Long documents are split into sections that are processed in reading order; you carry a running scratchpad forward so later sections stay consistent with earlier ones. Follow every step exactly. Return the compact RESULT block at the end — no other output.
+
+**Hard constraints — violations will break the pipeline:**
+- Never pipe or post-process command output with `python3`, `awk`, `jq`, `sed`, `grep`, or any other tool. The Bash tool returns output directly — read it as-is.
+- Never use absolute paths in bash commands. Always use paths relative to the vault root.
+- Never read `.watchdog/Registry/manifest.json`, `entities.json`, or `documents.json` directly — entity candidates come from PRE_FLIGHT.existing_entities (Step 1).
+- Never prefix commands with `cd <path> &&`. Never run any `--help` or exploration command.
+- **You do NOT write to the vault.** No `post-flight`, no entity/document notes, no timeline files. You only write your section JSON and append to the scratchpad. The merge + post-flight happen after all sections finish.
+
+**Inputs (from the prompt):** `SHA256`, `FILENAME`, `DOMAIN_SKILL_PATH`, `SECTION_INDEX` (`i of N`), `SECTION_LABEL` (e.g. `pages 12–34` or `part 2 of 5`), `SECTION_PAGES_PATH`, `SCRATCHPAD_PATH`, `OUTPUT_PATH`, `INVESTIGATION_BRIEF`.
+
+---
+
+## Step 1 — Pre-flight (vault context)
+
+```bash
+watchdog pre-flight {SHA256}
+```
+
+Read the stdout directly. Use only these fields (ignore `pages_path` — you read your section file instead):
+- `already_extracted` — **only if `SECTION_INDEX` is 1**, and it is true, stop immediately and return the SKIPPED block. (Later sections: ignore.)
+- `near_dup.near_duplicates`, `near_dup.top_similarity`
+- `existing_entities[]` — vault entities with `{id, name, type, aliases, timeline_events, roles, analysis}`. Match against these for vault dedup (use the existing `id`) and for the contradiction check (Step 6).
+
+## Step 2 — Read the scratchpad (carry-forward)
+
+If `SCRATCHPAD_PATH` exists, read it. Its **Entities so far** block lists `id | name | type | aliases` for entities earlier sections already extracted — reuse those ids, and resolve back-references in your section (e.g. "the Company") against those names/aliases. Its **Observations** are prior salient notes. If the file does not exist (you are section 1), there is no carry-forward yet.
+
+## Step 3 — Read your section
+
+Read `SECTION_PAGES_PATH` in a single Read. A **paginated** section contains `<!-- PAGE N -->` markers — cite those page numbers in `page`. A **non-paginated** section (from a `.txt`/`.csv`/`.md` source) is a plain text slice with no markers — set `page` to `null` in every citation for this section. Overlapping content may repeat from the adjacent section — that is expected; the merge deduplicates.
+
+## Step 4 — Load domain skill
+
+If `DOMAIN_SKILL_PATH` is not `"none"`, read `.claude/commands/{DOMAIN_SKILL_PATH}` and use it. Otherwise scan your pages, identify the document type, and read the closest match in `.claude/commands/records/` (or `general-records.md`).
+
+## Step 5 — Extract entities (this section only)
+
+Extract every real-world entity that appears in your page range. Assign ids consistently:
+- matches a `PRE_FLIGHT.existing_entities` entry → use that entry's `id` (vault dedup)
+- matches an entry in the scratchpad's **Entities so far** → use that id (cross-section consistency)
+- otherwise → a new kebab-case slug
+
+For each entity: `id`, `name` (most complete form), `type`, `aliases` (every other surface form in this section, including resolved back-references like "the Company"), `timeline_events` (`date`, `event`, `page`, `confidence`), `roles` (`relationship`, `target_id`, `target_type`, `target_name`, `page`, `confidence`, `date_range`).
+
+Confidence: `high` (directly stated) / `medium` (one inference) / `low` (multi-statement inference) / `disputed` (contradicts the vault). Never upgrade a claim past its weakest element. **Do not set `match_id`** — ids are already canonical.
+
+## Step 6 — Key facts and contradictions
+
+Pull the most important facts from your section (`fact`, `page`, `confidence`). For any entity matching `PRE_FLIGHT.existing_entities`, compare against that entry's `timeline_events` / `roles` / `analysis`; emit a `[!contradiction]` callout in the entity's `analysis` only when you are confident the discrepancy is genuine (this is the sole verification step — no later pass removes false positives). Do not re-flag contradictions already in `analysis`.
+
+## Step 7 — Write your section JSON
+
+Write to `OUTPUT_PATH` exactly this shape (a partial extraction — your section's contribution):
+
+```json
+{
+  "document": {
+    "sha256": "<SHA256>", "filename": "<FILENAME>",
+    "original_path": "<source_path from queue JSON, section 1 only — else omit>",
+    "title": "<inferred, section 1 only — else omit>",
+    "document_type": "<inferred, section 1 only — else omit>",
+    "date_of_document": "<YYYY-MM-DD or null, section 1 only — else omit>",
+    "page_count": <total document page count, section 1 only — else omit>,
+    "summary": "<one paragraph for your section>",
+    "key_facts": [{"fact": "...", "page": <n or null>, "confidence": "..."}]
+  },
+  "entities": [
+    {"id": "...", "name": "...", "type": "...", "aliases": [...],
+     "summary": "<one sentence>", "analysis": "<contradictions/notes; omit if none>",
+     "timeline_events": [{"date": "...", "event": "...", "page": <n or null>, "confidence": "..."}],
+     "roles": [{"relationship": "...", "target_id": "...", "target_type": "...", "target_name": "...", "page": null, "confidence": "...", "date_range": null}]}
+  ],
+  "morgue_entity_id": "<the entity this document is *about* — section 1 only, else omit>",
+  "morgue_document_type": "<type slug — section 1 only, else omit>"
+}
+```
+
+The merge takes document metadata and `morgue_*` from the first section that provides them, so **section 1 must fill them in**; later sections may omit those fields and just supply `entities` + `document.key_facts` + `document.summary`.
+
+## Step 8 — Update the scratchpad
+
+Append to `SCRATCHPAD_PATH` (create it if you are section 1) so the next section inherits your context. Keep this structure — append, don't rewrite prior content:
+
+```markdown
+# Running notes — {FILENAME}
+
+## Entities so far
+- <id> | <name> | <type> | <aliases, comma-separated>
+
+## Observations
+- p.<N>: <something that stuck out — a figure, a relationship, an anomaly, a "see Note X" cross-reference>
+```
+
+Add any entities new to this section to **Entities so far**, and your salient notes to **Observations**. The Observations become the document's briefing notes, so keep them high-signal — what a reporter would jot down, not a summary.
+
+## Step 9 — Return result
+
+Return ONLY:
+
+```
+STATUS: ok
+SECTION: {SECTION_INDEX}
+ENTITY_COUNT: {entities extracted in this section}
+NEAR_DUP: {top_similarity% similar to {filename} — or none}
+CONTRADICTIONS: {entity_id — brief; … — or none}
+```
+
+Or, if section 1 and already extracted:
+
+```
+STATUS: skipped
+REASON: already extracted (SHA-256 match)
+```

--- a/src/watchdog/skills/watchdog-ingest.md
+++ b/src/watchdog/skills/watchdog-ingest.md
@@ -40,6 +40,8 @@ Set `EXTRACTOR_MODEL = INGEST.extractor_model` if present, else `"sonnet"`.
 
 Set `FINALIZER_MODEL = INGEST.finalizer_model` if present, else `"sonnet"`.
 
+Set `SECTION_TOKEN_THRESHOLD = INGEST.section_token_threshold` if present, else `120000`.
+
 Set `QUEUE_FILES = INGEST.queue_files`.
 
 The lock is held (acquired by `watchdog ingest`). Every exit path — including errors — must release it by running `watchdog unlock`. That command removes the lock, deletes `ingest-state.json`, and cleans up temp files.
@@ -64,9 +66,13 @@ Then **sort `QUEUE_FILES` by `document_type`** (nulls last). Files sharing a `do
 
 ## 3. Process each file
 
-Process files in **batches of up to 5**. Registry writes are serialized internally — concurrent subagents are safe.
+Partition `QUEUE_FILES` by estimated size: **LARGE** = files whose `est_tokens` is greater than `SECTION_TOKEN_THRESHOLD`; **NORMAL** = all others (including files with no `est_tokens`). Estimated tokens — not page count — is the trigger, so dense table-heavy reports and large non-paginated files (`.txt`/`.csv`/`.md`, which are a single page) are handled correctly. Process NORMAL files first (§3a), then LARGE files (§3b). The `LIMIT` check applies across both — if `LIMIT` is set and `EXTRACTED >= LIMIT`, stop before starting the next batch or document.
 
-Split `QUEUE_FILES` (already sorted by `document_type`) into batches of at most 5 files. For each batch:
+### 3a. Normal documents — parallel extraction
+
+Process NORMAL files in **batches of up to 5**. Registry writes are serialized internally — concurrent subagents are safe.
+
+Split the NORMAL files (already sorted by `document_type`) into batches of at most 5 files. For each batch:
 
 1. For each file in the batch, get its `SHA256`, `FILENAME`, and `DOMAIN_SKILL_PATH` (already resolved in §2).
 2. Print `[<N>/<TOTAL>] Launching: <FILENAME clamped to 50 chars> ...`
@@ -107,6 +113,48 @@ Print:
 ```
 [<N>/<TOTAL>] Done: <FILENAME> — <ENTITY_COUNT> entities (<new_count> new) | ETA: ~<rolling estimate>s
 ```
+
+---
+
+### 3b. Large documents — sequential sectioned extraction
+
+Each LARGE document is too big to extract in one context, so it is split into overlapping page-range sections, extracted **in reading order** with a running scratchpad carried forward, then merged deterministically. Process LARGE files **one at a time**.
+
+For each LARGE file (`SHA256`, `FILENAME`, `DOMAIN_SKILL_PATH` from §2):
+
+1. Run `watchdog section-plan {SHA256}` and read the JSON.
+   - If it returns `"sectioned": false`, the file isn't actually large — extract it via §3a instead.
+   - Otherwise you have `sections: [{index, label, paginated, pages_path}, …]` (`label` is e.g. `"pages 12–34"` or `"part 2 of 5"`).
+2. Extract the sections **strictly in order, one at a time** — launch a section subagent, wait for it to return, then launch the next. Do **not** parallelize them: each section reads the scratchpad the previous one wrote. Use the SECTION SUBAGENT PROMPT TEMPLATE below; set the Agent `description` to `Watchdog section {index}/{count}: <FILENAME clamped to 40 chars>` and `model` to `EXTRACTOR_MODEL`.
+   - If **section 1** returns `STATUS: skipped`, the document is already extracted — skip the whole file; do not process the remaining sections.
+   - From the section returns, remember `NEAR_DUP` (from section 1) and any `CONTRADICTIONS` (union across sections).
+3. After every section has returned, run `watchdog merge-sections {SHA256}` and read the JSON: `extraction_path`, `entity_count`, `new_entities`, `updated_entities`.
+4. Run `watchdog post-flight --extraction {extraction_path}`. If it reports `errors`, log to `.watchdog/Registry/ingest.log` and continue to the next document.
+5. Record this document in `RESULTS` (entity_count, new_entities, updated_entities, document metadata). If section 1's `NEAR_DUP` is not `none`, add to `NEARDUP_ALERTS`; if any section reported `CONTRADICTIONS`, add to `CONTRADICTION_FLAGS`. Increment `EXTRACTED` by 1. Print:
+   ```
+   [done] <FILENAME> — <entity_count> entities (<count> sections merged)
+   ```
+
+#### SECTION SUBAGENT PROMPT TEMPLATE
+
+Keep the stable prefix byte-identical across spawns; per-section values appear at the end. `OUTPUT_PATH` uses a two-digit zero-padded index (`01`, `02`, …) so `merge-sections` reads the sections in order.
+
+```
+Read `.claude/commands/watchdog-ingest-section-subagent.md` for full instructions. Then extract this section.
+
+SHA256: {SHA256}
+FILENAME: {FILENAME}
+DOMAIN_SKILL_PATH: {DOMAIN_SKILL_PATH}
+SECTION_INDEX: {index} of {count}
+SECTION_LABEL: {label}
+SECTION_PAGES_PATH: {pages_path}
+SCRATCHPAD_PATH: .watchdog/tmp/notes_{SHA256}.md
+OUTPUT_PATH: .watchdog/tmp/section_ex_{SHA256}_{index:02d}.json
+INVESTIGATION_BRIEF:
+{INVESTIGATION_BRIEF}
+```
+
+The running scratchpad (`notes_{SHA256}.md`) is the same per-document notes file the finalize subagent reads for the briefing — so a sectioned document's briefing notes are produced as a byproduct of carry-forward, with no extra step.
 
 ---
 

--- a/tests/test_ingest_setup.py
+++ b/tests/test_ingest_setup.py
@@ -172,6 +172,54 @@ def test_finalizer_model_defaults_to_sonnet(tmp_path):
     assert result["finalizer_model"] == "sonnet"
 
 
+def test_queue_files_include_page_count(tmp_path):
+    vault = _make_vault(tmp_path)
+    qf = vault / ".watchdog" / "queue" / "abc123.json"
+    qf.write_text(json.dumps({
+        "filename": "big.pdf", "metadata": {"source_type": "docling"},
+        "page_count": 312, "pages": [],
+    }))
+
+    result = run(vault)
+
+    assert result["queue_files"][0]["page_count"] == 312
+
+
+def test_queue_files_page_count_falls_back_to_len_pages(tmp_path):
+    vault = _make_vault(tmp_path)
+    qf = vault / ".watchdog" / "queue" / "abc123.json"
+    qf.write_text(json.dumps({
+        "filename": "x.pdf", "metadata": {"source_type": "docling"},
+        "pages": [{"page": 1, "markdown": ""}, {"page": 2, "markdown": ""}],
+    }))
+
+    result = run(vault)
+
+    assert result["queue_files"][0]["page_count"] == 2
+
+
+def test_state_includes_section_token_threshold(tmp_path):
+    vault = _make_vault(tmp_path)
+    _write_queue_file(vault, "abc123")
+
+    result = run(vault)
+
+    assert isinstance(result["section_token_threshold"], int)
+
+
+def test_queue_files_include_est_tokens(tmp_path):
+    vault = _make_vault(tmp_path)
+    qf = vault / ".watchdog" / "queue" / "abc123.json"
+    qf.write_text(json.dumps({
+        "filename": "x.pdf", "metadata": {"source_type": "docling"},
+        "pages": [{"page": 1, "markdown": "a" * 400}, {"page": 2, "markdown": "a" * 400}],
+    }))
+
+    result = run(vault)
+
+    assert result["queue_files"][0]["est_tokens"] == 200  # 800 chars / 4
+
+
 def test_empty_queue_cleans_up_stale_state_file(tmp_path):
     vault = _make_vault(tmp_path)
     state_file = vault / ".watchdog" / "ingest-state.json"

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -1,0 +1,129 @@
+import json
+from pathlib import Path
+
+from watchdog.pipeline import merge
+from watchdog.pipeline.merge import merge_extractions
+
+
+def test_merge_unions_entities_by_id():
+    sections = [
+        {"document": {"sha256": "x", "filename": "f",
+                      "key_facts": [{"fact": "A", "page": 1, "confidence": "high"}]},
+         "entities": [{"id": "acme", "name": "Acme Corp", "type": "Company",
+                       "aliases": ["the Company"],
+                       "timeline_events": [{"date": "2020", "event": "incorporated", "confidence": "high"}],
+                       "roles": []}],
+         "morgue_entity_id": "acme", "morgue_document_type": "annual-report"},
+        {"document": {"key_facts": [{"fact": "B", "page": 60, "confidence": "high"}]},
+         "entities": [
+             {"id": "acme", "name": "Acme Corp", "type": "Company", "aliases": [],
+              "timeline_events": [{"date": "2021", "event": "filed report", "confidence": "medium"}],
+              "roles": [{"relationship": "Director of", "target_id": "jane",
+                         "target_type": "Person", "target_name": "Jane", "page": 61,
+                         "confidence": "high", "date_range": None}]},
+             {"id": "jane", "name": "Jane Doe", "type": "Person", "aliases": [],
+              "timeline_events": [], "roles": []}],
+         "morgue_entity_id": None, "morgue_document_type": None},
+    ]
+    merged = merge_extractions(sections)
+    ents = {e["id"]: e for e in merged["entities"]}
+
+    assert set(ents) == {"acme", "jane"}
+    assert "the Company" in ents["acme"]["aliases"]
+    assert {ev["date"] for ev in ents["acme"]["timeline_events"]} == {"2020", "2021"}
+    assert len(ents["acme"]["roles"]) == 1
+    assert {f["fact"] for f in merged["document"]["key_facts"]} == {"A", "B"}
+    assert merged["document"]["sha256"] == "x"          # document from first non-empty
+    assert merged["morgue_entity_id"] == "acme"          # first non-null wins
+
+
+def test_merge_folds_id_drift_by_normalized_name():
+    sections = [
+        {"document": {"sha256": "x", "filename": "f"},
+         "entities": [{"id": "acme-corp", "name": "Acme Corp", "type": "Company",
+                       "aliases": [], "timeline_events": [], "roles": []}]},
+        {"document": {},
+         "entities": [{"id": "acme-corp-2", "name": "ACME  CORP", "type": "Company",
+                       "aliases": [], "timeline_events": [{"date": "2021", "event": "x", "confidence": "high"}],
+                       "roles": []}]},
+    ]
+    merged = merge_extractions(sections)
+    assert len(merged["entities"]) == 1                  # drift folded onto one id
+    assert merged["entities"][0]["id"] == "acme-corp"
+    assert len(merged["entities"][0]["timeline_events"]) == 1
+
+
+def test_merge_dedups_timeline_and_key_facts():
+    section = {
+        "document": {"sha256": "x", "key_facts": [{"fact": "Same fact", "page": 1, "confidence": "high"}]},
+        "entities": [{"id": "a", "name": "A", "type": "Person", "aliases": [],
+                      "timeline_events": [{"date": "2020", "event": "did thing", "confidence": "high"}],
+                      "roles": []}],
+    }
+    merged = merge_extractions([section, json.loads(json.dumps(section))])  # identical twice
+    assert len(merged["entities"][0]["timeline_events"]) == 1
+    assert len(merged["document"]["key_facts"]) == 1
+
+
+def test_merge_omits_empty_summary_and_analysis():
+    merged = merge_extractions([
+        {"document": {"sha256": "x"},
+         "entities": [{"id": "a", "name": "A", "type": "Person", "aliases": [],
+                       "timeline_events": [], "roles": []}]},
+    ])
+    ent = merged["entities"][0]
+    assert "summary" not in ent
+    assert "analysis" not in ent
+
+
+def test_run_merges_section_files(tmp_path):
+    vault = tmp_path / "vault"
+    tmp = vault / ".watchdog" / "tmp"
+    tmp.mkdir(parents=True)
+    (tmp / "section_ex_doc1_01.json").write_text(json.dumps({
+        "document": {"sha256": "doc1", "filename": "f"},
+        "entities": [{"id": "a", "name": "A", "type": "Person", "aliases": [],
+                      "timeline_events": [], "roles": []}],
+        "morgue_entity_id": "a", "morgue_document_type": "t"}))
+    (tmp / "section_ex_doc1_02.json").write_text(json.dumps({
+        "document": {},
+        "entities": [{"id": "b", "name": "B", "type": "Person", "aliases": [],
+                      "timeline_events": [], "roles": []}]}))
+
+    result = merge.run(vault, "doc1")
+    assert result["ok"] is True
+    assert result["entity_count"] == 2
+    assert result["sections_merged"] == 2
+
+    out = vault / result["extraction_path"]
+    assert out.exists()
+    data = json.loads(out.read_text())
+    assert {e["id"] for e in data["entities"]} == {"a", "b"}
+    assert data["morgue_entity_id"] == "a"
+
+
+def test_run_splits_new_vs_updated_against_registry(tmp_path):
+    vault = tmp_path / "vault"
+    tmp = vault / ".watchdog" / "tmp"
+    tmp.mkdir(parents=True)
+    reg = vault / ".watchdog" / "Registry"
+    reg.mkdir(parents=True)
+    reg.joinpath("entities.json").write_text(json.dumps({"a": {"id": "a", "name": "A"}}))
+
+    (tmp / "section_ex_doc1_01.json").write_text(json.dumps({
+        "document": {"sha256": "doc1", "filename": "f"},
+        "entities": [
+            {"id": "a", "name": "A", "type": "Person", "aliases": [], "timeline_events": [], "roles": []},
+            {"id": "b", "name": "B", "type": "Person", "aliases": [], "timeline_events": [], "roles": []},
+        ],
+        "morgue_entity_id": "a", "morgue_document_type": "t"}))
+
+    result = merge.run(vault, "doc1")
+    assert result["new_entities"] == {"b": "B"}        # not in registry
+    assert result["updated_entities"] == {"a": "A"}    # already in registry
+
+
+def test_run_no_section_files_errors(tmp_path):
+    vault = tmp_path / "vault"
+    (vault / ".watchdog" / "tmp").mkdir(parents=True)
+    assert "error" in merge.run(vault, "missing")

--- a/tests/test_section.py
+++ b/tests/test_section.py
@@ -1,0 +1,119 @@
+import json
+from pathlib import Path
+
+from watchdog.pipeline import section
+from watchdog.pipeline.section import plan_ranges, char_windows, est_tokens, est_tokens_from_pages
+
+
+# ── token estimation ────────────────────────────────────────────────────────
+
+def test_est_tokens_chars_over_four():
+    assert est_tokens("a" * 40) == 10
+    assert est_tokens("") == 0
+
+
+def test_est_tokens_from_pages_sums():
+    pages = [{"markdown": "a" * 40}, {"markdown": "b" * 80}]
+    assert est_tokens_from_pages(pages) == 30
+
+
+# ── plan_ranges (pages) ─────────────────────────────────────────────────────
+
+def test_plan_ranges_with_overlap_covers_every_page():
+    r = plan_ranges(120, 50, 3)
+    assert r[0] == (1, 50) and r[1] == (48, 97) and r[2] == (95, 120)
+    covered = set()
+    for s, e in r:
+        covered.update(range(s, e + 1))
+    assert covered == set(range(1, 121))
+
+
+def test_plan_ranges_overlap_capped_so_it_advances():
+    r = plan_ranges(10, 3, 5)
+    covered = set()
+    for s, e in r:
+        covered.update(range(s, e + 1))
+    assert covered == set(range(1, 11))
+
+
+# ── char_windows ────────────────────────────────────────────────────────────
+
+def test_char_windows_with_overlap():
+    assert char_windows(100, 40, 10) == [(0, 40), (30, 70), (60, 100)]
+
+
+def test_char_windows_single():
+    assert char_windows(30, 100, 10) == [(0, 30)]
+
+
+def test_char_windows_empty():
+    assert char_windows(0, 100, 10) == []
+
+
+# ── run (token-gated) ───────────────────────────────────────────────────────
+
+def _config(threshold=100, budget=200, overlap=0):
+    return lambda k, d: {"section_token_threshold": threshold,
+                         "section_token_budget": budget,
+                         "section_overlap_tokens": overlap}.get(k, d)
+
+
+def _vault(tmp_path: Path) -> Path:
+    vault = tmp_path / "vault"
+    (vault / ".watchdog" / "queue").mkdir(parents=True)
+    (vault / ".watchdog" / "tmp").mkdir(parents=True)
+    return vault
+
+
+def _write_queue(vault: Path, sha: str, pages: list, page_count: int):
+    (vault / ".watchdog" / "queue" / f"{sha}.json").write_text(
+        json.dumps({"filename": "f.pdf", "page_count": page_count, "pages": pages})
+    )
+
+
+def test_run_below_token_threshold_not_sectioned(tmp_path, monkeypatch):
+    monkeypatch.setattr(section, "_config_get", _config(threshold=100))
+    vault = _vault(tmp_path)
+    _write_queue(vault, "doc1", [{"page": 1, "markdown": "x" * 40},
+                                 {"page": 2, "markdown": "x" * 40}], 2)  # 20 est tokens
+    result = section.run(vault, "doc1")
+    assert result["sectioned"] is False
+    assert result["est_tokens"] == 20
+
+
+def test_run_paginated_splits_on_pages(tmp_path, monkeypatch):
+    monkeypatch.setattr(section, "_config_get", _config(threshold=100, budget=200, overlap=0))
+    vault = _vault(tmp_path)
+    pages = [{"page": n, "markdown": "x" * 400} for n in range(1, 11)]  # 100 tok/page, 1000 total
+    _write_queue(vault, "doc1", pages, 10)
+
+    result = section.run(vault, "doc1")
+    assert result["sectioned"] is True
+    secs = result["sections"]
+    assert all(s["paginated"] for s in secs)
+    assert secs[0]["label"] == "pages 1–2"        # budget 200 / 100 tok-per-page = 2 pages
+    first = (vault / secs[0]["pages_path"]).read_text()
+    assert "<!-- PAGE 1 -->" in first and "<!-- PAGE 2 -->" in first
+    assert "<!-- PAGE 3 -->" not in first
+
+
+def test_run_non_paginated_splits_on_chars(tmp_path, monkeypatch):
+    monkeypatch.setattr(section, "_config_get", _config(threshold=100, budget=200, overlap=0))
+    vault = _vault(tmp_path)
+    # single page (text file) of 1000 est tokens = 4000 chars
+    _write_queue(vault, "doc1", [{"page": 1, "markdown": "y" * 4000}], 1)
+
+    result = section.run(vault, "doc1")
+    assert result["sectioned"] is True
+    secs = result["sections"]
+    assert all(not s["paginated"] for s in secs)
+    assert secs[0]["label"].startswith("part 1 of")
+    body = (vault / secs[0]["pages_path"]).read_text()
+    assert "<!-- PAGE" not in body          # no page markers for non-paginated
+    assert len(body) == 800                 # budget 200 tokens * 4 chars
+
+
+def test_run_missing_queue_file_errors(tmp_path):
+    vault = tmp_path / "vault"
+    (vault / ".watchdog").mkdir(parents=True)
+    assert "error" in section.run(vault, "nope")


### PR DESCRIPTION
Closes #92.

## What

Adds sectioned extraction for large documents. A document over an estimated-token threshold is split into overlapping sections, extracted **sequentially with a running scratchpad carried forward**, then **merged deterministically** — so 300-page table-heavy reports stay within context and cost bounds.

## Why estimated tokens, not page count

Page count is a poor proxy: density varies several-fold (a table-heavy financial page ≈ 1,500–3,000 tokens vs ~700 for prose), and non-paginated files (`.txt`/`.csv`/`.md`) are a single "page" regardless of size, so a page threshold would never section a huge text file. The trigger is `est_tokens` (a cheap chars/4 estimate computed from the queue pages). Default threshold **120K tokens** — comfortably under Haiku's 200K window, and a sensible cost cap on Sonnet/Opus (1M).

## Design (sequential + scratchpad + deterministic merge)

- **`section.py` / `watchdog section-plan`** — estimate tokens, gate on threshold, write per-section files.
  - paginated docs split on **page boundaries** (pages-per-section derived from density; page citations preserved, tables protected by overlap)
  - non-paginated docs split on **character windows** (citations carry `page: null`)
- **`watchdog-ingest-section-subagent.md`** — extracts one section using its page/char range + the running scratchpad; writes a partial section JSON; **no vault write**.
- **`merge.py` / `watchdog merge-sections`** — because carry-forward keeps entity ids consistent across sections, the merge is a pure **set-union by id** (no LLM), with a normalized-name pass to fold any OCR drift. Reports new-vs-updated against the registry.
- **orchestrator §3** — partitions NORMAL (parallel batches, unchanged) from LARGE (sequential sections → `merge-sections` → `post-flight`). The running scratchpad *is* the per-document briefing notes file, so sectioned docs feed the briefing for free.

Config keys (all overridable in `~/.watchdog/config.json`): `section_token_threshold` (120K), `section_token_budget` (60K/section), `section_overlap_tokens` (4K).

## Tests

`tests/test_section.py`, `tests/test_merge.py`, extended `tests/test_ingest_setup.py`. Full suite: **392 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
