### PR TITLE
Runaway guard + cleanup for stuck extraction subagents (#104)

### DIFF
--- a/src/watchdog/cmd/base.py
+++ b/src/watchdog/cmd/base.py
@@ -57,6 +57,7 @@ _PIPELINE_COMMANDS = {
     "write-entity":  ("watchdog.pipeline.write_entity", "watchdog-write-entity"),
     "section-plan":  ("watchdog.pipeline.section",      "watchdog-section-plan"),
     "merge-sections":("watchdog.pipeline.merge",        "watchdog-merge-sections"),
+    "ingest-abort":  ("watchdog.pipeline.abort",        "watchdog-ingest-abort"),
 }
 
 _TEMPLATES_DIR = Path(__file__).parent.parent / "templates" / "vault"
@@ -74,6 +75,7 @@ _VAULT_PERMISSIONS = [
     "Bash(watchdog rebuild-timeline)",
     "Bash(watchdog section-plan *)",
     "Bash(watchdog merge-sections *)",
+    "Bash(watchdog ingest-abort *)",
     # shell utilities
     "Bash(find .watchdog/queue/ *)",
     # internal vault state

--- a/src/watchdog/pipeline/abort.py
+++ b/src/watchdog/pipeline/abort.py
@@ -1,0 +1,93 @@
+"""
+watchdog ingest-abort <sha256> — clean up after a runaway or failed extraction.
+
+When a subagent gives up (its runaway guard fires) or returns an unparseable
+result, the document must be left in a clean state so it can be re-ingested
+later. A clean bail happens *before* the vault write, so the only state to undo
+is the per-document staging in `.watchdog/tmp/` (and any raw timeline files), plus
+moving the queue file out of the active queue into a holding area.
+
+This never touches the vault registry, entity/document notes, or the morgue: if
+post-flight had run, the extraction succeeded and this command would not be
+called. The source file stays in `_INCOMING/` (post-flight never moved it).
+
+Re-ingest later: move the queue file back —
+  mv .watchdog/queue/_failed/<sha>.json .watchdog/queue/
+then run `watchdog ingest` again.
+"""
+
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def run(vault: Path, sha256: str) -> dict:
+    tmp = vault / ".watchdog" / "tmp"
+    timeline = vault / ".watchdog" / "timeline"
+    queue = vault / ".watchdog" / "queue"
+    removed: list[str] = []
+
+    # Per-document staging files in .watchdog/tmp/
+    fixed = [
+        tmp / f"wdg_ex_{sha256}.json",
+        tmp / f"wdg_nd_{sha256}.json",
+        tmp / f"notes_{sha256}.md",
+        tmp / f"preflight_{sha256}_pages.md",
+    ]
+    globs = [f"section_{sha256}_*.md", f"section_ex_{sha256}_*.json"]
+    for p in fixed:
+        if p.exists():
+            p.unlink()
+            removed.append(str(p.relative_to(vault)))
+    if tmp.exists():
+        for pattern in globs:
+            for p in sorted(tmp.glob(pattern)):
+                p.unlink()
+                removed.append(str(p.relative_to(vault)))
+
+    # Raw timeline files for this sha (named {date}_{sha[:7]}.ndjson). Canonical
+    # files have no sha suffix, so they are never matched here.
+    if timeline.exists():
+        for p in sorted(timeline.glob(f"*_{sha256[:7]}.ndjson")):
+            p.unlink()
+            removed.append(str(p.relative_to(vault)))
+
+    # Move the queue file out of the active queue into a holding area so it is
+    # preserved (re-ingestable) but not retried automatically.
+    requeue_path = None
+    queue_file = queue / f"{sha256}.json"
+    if queue_file.exists():
+        failed_dir = queue / "_failed"
+        failed_dir.mkdir(parents=True, exist_ok=True)
+        dest = failed_dir / queue_file.name
+        queue_file.replace(dest)
+        requeue_path = str(dest.relative_to(vault))
+
+    log = vault / ".watchdog" / "Registry" / "ingest.log"
+    try:
+        log.parent.mkdir(parents=True, exist_ok=True)
+        with open(log, "a", encoding="utf-8") as f:
+            f.write(f"[{_iso_now()}] ABORT {sha256} — removed {len(removed)} artifact(s)\n")
+    except OSError:
+        pass
+
+    return {"ok": True, "sha256": sha256, "removed": removed, "requeue_path": requeue_path}
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        sys.exit("Usage: watchdog ingest-abort <sha256>")
+    vault = Path(".").resolve()
+    if not (vault / ".watchdog").is_dir():
+        sys.exit("Error: must be run from inside a Watchdog vault directory")
+    result = run(vault, sys.argv[1])
+    print(json.dumps(result, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/watchdog/skills/watchdog-ingest-finalize-subagent.md
+++ b/src/watchdog/skills/watchdog-ingest-finalize-subagent.md
@@ -7,6 +7,8 @@ You are finalizing one Watchdog ingest batch. Two jobs: (1) reconcile the timeli
 - Never run `watchdog <command> --help` or any exploration command.
 - Read vault files with the Read tool, not bash.
 
+**Stop conditions (runaway guard).** Finish in a bounded number of steps. If a step can't complete — a collision file won't parse, a scratchpad won't read — skip that item and move on rather than retrying it repeatedly. Always reach Step 4 and return; write the briefing with whatever you have. Do not loop. (There is no vault state to undo here — the briefing and timeline are regenerable.)
+
 **Inputs (supplied in the prompt):**
 - `INVESTIGATION_BRIEF` — condensed investigation context. Use this instead of reading `context.md`.
 - `RESULTS` — one compact metadata block per successfully extracted document (filename, type, date, entity counts, new/updated entity ids).

--- a/src/watchdog/skills/watchdog-ingest-section-subagent.md
+++ b/src/watchdog/skills/watchdog-ingest-section-subagent.md
@@ -7,6 +7,8 @@ You are extracting **one page-range section** of a large document for the Watchd
 - Never prefix commands with `cd <path> &&`. Never run any `--help` or exploration command.
 - **You do NOT write to the vault.** No `post-flight`, no entity/document notes, no timeline files. You only write your section JSON and append to the scratchpad. The merge + post-flight happen after all sections finish.
 
+**Stop conditions (runaway guard).** Finish in a bounded number of steps. If you cannot make progress — pre-flight errors, your section file is empty or too garbled to extract, or you are repeating the same action without new information — **stop instead of looping** and return the FAILED block (Step 9). You write no vault state, so there is nothing to undo; the orchestrator runs `watchdog ingest-abort` to clear this document's section files and aborts the rest of the document.
+
 **Inputs (from the prompt):** `SHA256`, `FILENAME`, `DOMAIN_SKILL_PATH`, `SECTION_INDEX` (`i of N`), `SECTION_LABEL` (e.g. `pages 12–34` or `part 2 of 5`), `SECTION_PAGES_PATH`, `SCRATCHPAD_PATH`, `OUTPUT_PATH`, `INVESTIGATION_BRIEF`.
 
 ---
@@ -111,4 +113,12 @@ Or, if section 1 and already extracted:
 ```
 STATUS: skipped
 REASON: already extracted (SHA-256 match)
+```
+
+Or, if a stop condition fired:
+
+```
+STATUS: failed
+SECTION: {SECTION_INDEX}
+REASON: <one line — why you stopped>
 ```

--- a/src/watchdog/skills/watchdog-ingest-subagent.md
+++ b/src/watchdog/skills/watchdog-ingest-subagent.md
@@ -7,6 +7,13 @@ You are extracting one document for the Watchdog investigative research system. 
 - Never prefix commands with `cd <path> &&`.
 - Never run `watchdog <command> --help` or any exploration command.
 
+**Stop conditions (runaway guard).** Finish in a bounded number of steps. If you cannot make progress, **stop cleanly instead of looping** and return the FAILED block (Step 10):
+- **Unreadable document** — pre-flight errors, or `pages_path` is empty or too garbled to extract: don't retry more than once.
+- **Repeated rejection** — post-flight keeps rejecting the JSON after two fixes (see Step 8).
+- **No progress** — you find yourself repeating the same read/edit/command without new information.
+
+When you give up, **do not run `watchdog post-flight`** — bail before the vault write so nothing is committed. A clean bail leaves only temp files, which the orchestrator removes with `watchdog ingest-abort` so the document re-ingests cleanly later.
+
 ---
 
 ## Step 1 — Pre-flight
@@ -158,7 +165,7 @@ Write to `.watchdog/tmp/wdg_ex_{SHA256}.json` using the Write tool. Then run pos
 watchdog post-flight --extraction .watchdog/tmp/wdg_ex_{SHA256}.json
 ```
 
-Post-flight validates, applies entity merges, writes the vault, writes timeline events (from the `timeline_events` in your extraction JSON — you do **not** write any `.watchdog/timeline/` files yourself), and cleans up temp files. If it prints errors, fix the JSON and run it again. Do not run `--help` or any exploration command to debug schema errors.
+Post-flight validates, applies entity merges, writes the vault, writes timeline events (from the `timeline_events` in your extraction JSON — you do **not** write any `.watchdog/timeline/` files yourself), and cleans up temp files. If it prints errors, fix the JSON and re-run — **at most twice**. If post-flight still rejects after two fixes, stop and return the FAILED block (Step 10); do not keep editing. Do not run `--help` or any exploration command to debug schema errors.
 
 ## Step 9 — Write scratchpad
 
@@ -196,4 +203,12 @@ NEW_ENTITIES: {id:name, id:name — or none}
 UPDATED_ENTITIES: {id:name, id:name — or none}
 NEAR_DUP: {top_similarity% similar to {existing filename} — or none}
 CONTRADICTIONS: {entity_id — brief description; entity_id — brief description — or none}
+```
+
+If a stop condition fired and you gave up before writing the vault, return this instead:
+
+```
+STATUS: failed
+FILENAME: {FILENAME}
+REASON: <one line — why you stopped (unreadable / repeated post-flight rejection / no progress)>
 ```

--- a/src/watchdog/skills/watchdog-ingest.md
+++ b/src/watchdog/skills/watchdog-ingest.md
@@ -109,6 +109,11 @@ Parse the returned block:
 
 **`STATUS: ok`** — add the full result to `RESULTS`. If `NEAR_DUP` is not `none`, add to `NEARDUP_ALERTS`. If `CONTRADICTIONS` is not `none`, add to `CONTRADICTION_FLAGS`.
 
+**`STATUS: failed`** (the subagent's runaway guard fired) **or an unparseable / errored result** — run `watchdog ingest-abort {SHA256}` to clear the document's staging files and move its queue file to the `_failed/` holding area, log the `REASON` to `.watchdog/Registry/ingest.log`, count it as failed, and continue. Leave nothing half-written; the document re-ingests cleanly once moved back into the queue. Print:
+```
+[<N>/<TOTAL>] Failed: <FILENAME> — <REASON> (aborted, cleaned up)
+```
+
 Print:
 ```
 [<N>/<TOTAL>] Done: <FILENAME> — <ENTITY_COUNT> entities (<new_count> new) | ETA: ~<rolling estimate>s
@@ -127,6 +132,7 @@ For each LARGE file (`SHA256`, `FILENAME`, `DOMAIN_SKILL_PATH` from §2):
    - Otherwise you have `sections: [{index, label, paginated, pages_path}, …]` (`label` is e.g. `"pages 12–34"` or `"part 2 of 5"`).
 2. Extract the sections **strictly in order, one at a time** — launch a section subagent, wait for it to return, then launch the next. Do **not** parallelize them: each section reads the scratchpad the previous one wrote. Use the SECTION SUBAGENT PROMPT TEMPLATE below; set the Agent `description` to `Watchdog section {index}/{count}: <FILENAME clamped to 40 chars>` and `model` to `EXTRACTOR_MODEL`.
    - If **section 1** returns `STATUS: skipped`, the document is already extracted — skip the whole file; do not process the remaining sections.
+   - If **any section** returns `STATUS: failed` (its runaway guard fired), **abort the whole document**: run `watchdog ingest-abort {SHA256}` (clears the section files and moves the queue file to `_failed/`), log the `REASON`, count it as failed, and move to the next document — do not run the remaining sections, `merge-sections`, or `post-flight`.
    - From the section returns, remember `NEAR_DUP` (from section 1) and any `CONTRADICTIONS` (union across sections).
 3. After every section has returned, run `watchdog merge-sections {SHA256}` and read the JSON: `extraction_path`, `entity_count`, `new_entities`, `updated_entities`.
 4. Run `watchdog post-flight --extraction {extraction_path}`. If it reports `errors`, log to `.watchdog/Registry/ingest.log` and continue to the next document.
@@ -225,9 +231,11 @@ Frame questions as optional. If deferred, note the uncertainty in the relevant n
 
 ## Error handling
 
-If a subagent exits with an error or returns an unparseable result:
-1. Log to `.watchdog/Registry/ingest.log`: `[<ISO 8601>] ERROR <filename>: <error>`
-2. Move the queue file to `_INCOMING/_FAILED/` if possible
-3. Continue to the next file
+If a subagent returns `STATUS: failed`, exits with an error, or returns an unparseable result:
+1. Run `watchdog ingest-abort {SHA256}` — this removes the document's staging files (and any raw timeline files) and moves its queue file to `.watchdog/queue/_failed/`, leaving the vault registry untouched (a clean bail never wrote to it).
+2. Log to `.watchdog/Registry/ingest.log`: `[<ISO 8601>] FAILED <filename>: <reason>`
+3. Continue to the next file.
+
+The aborted document is in a clean state for a future ingest: its source is still in `_INCOMING/` and its chewed queue file is preserved in `_failed/`. To retry it, move the queue file back (`mv .watchdog/queue/_failed/<sha>.json .watchdog/queue/`) and run `watchdog ingest` again.
 
 Always release the lock at the end, even if every file failed.

--- a/tests/test_abort.py
+++ b/tests/test_abort.py
@@ -1,0 +1,64 @@
+import json
+from pathlib import Path
+
+from watchdog.pipeline import abort
+
+
+def _vault(tmp_path: Path) -> Path:
+    vault = tmp_path / "vault"
+    for sub in ("tmp", "timeline", "queue", "Registry"):
+        (vault / ".watchdog" / sub).mkdir(parents=True)
+    return vault
+
+
+def test_abort_removes_staging_and_moves_queue_file(tmp_path):
+    vault = _vault(tmp_path)
+    sha = "abc1234def5678"
+    tmp = vault / ".watchdog" / "tmp"
+    tl = vault / ".watchdog" / "timeline"
+
+    # staging artifacts for this sha
+    (tmp / f"wdg_ex_{sha}.json").write_text("{}")
+    (tmp / f"notes_{sha}.md").write_text("notes")
+    (tmp / f"preflight_{sha}_pages.md").write_text("pages")
+    (tmp / f"section_{sha}_01.md").write_text("sec")
+    (tmp / f"section_ex_{sha}_01.json").write_text("{}")
+    (tl / f"2020-01-01_{sha[:7]}.ndjson").write_text("{}")          # raw, this sha
+    (tl / "2020-01-01.ndjson").write_text("{}")                     # canonical — keep
+    (tmp / "wdg_ex_otherSHA.json").write_text("{}")                 # other doc — keep
+    (vault / ".watchdog" / "queue" / f"{sha}.json").write_text("{}")
+
+    result = abort.run(vault, sha)
+
+    assert result["ok"] is True
+    # this sha's staging gone
+    assert not (tmp / f"wdg_ex_{sha}.json").exists()
+    assert not (tmp / f"notes_{sha}.md").exists()
+    assert not (tmp / f"section_{sha}_01.md").exists()
+    assert not (tmp / f"section_ex_{sha}_01.json").exists()
+    assert not (tl / f"2020-01-01_{sha[:7]}.ndjson").exists()
+    # canonical timeline + other doc untouched
+    assert (tl / "2020-01-01.ndjson").exists()
+    assert (tmp / "wdg_ex_otherSHA.json").exists()
+    # queue file moved to holding area, not deleted
+    assert not (vault / ".watchdog" / "queue" / f"{sha}.json").exists()
+    assert (vault / ".watchdog" / "queue" / "_failed" / f"{sha}.json").exists()
+    assert result["requeue_path"].endswith(f"_failed/{sha}.json")
+
+
+def test_abort_never_touches_vault_registry(tmp_path):
+    vault = _vault(tmp_path)
+    entities = vault / ".watchdog" / "Registry" / "entities.json"
+    entities.write_text(json.dumps({"acme": {"id": "acme", "name": "Acme"}}))
+
+    abort.run(vault, "somesha")
+
+    assert json.loads(entities.read_text()) == {"acme": {"id": "acme", "name": "Acme"}}
+
+
+def test_abort_is_noop_when_nothing_staged(tmp_path):
+    vault = _vault(tmp_path)
+    result = abort.run(vault, "missing")
+    assert result["ok"] is True
+    assert result["removed"] == []
+    assert result["requeue_path"] is None


### PR DESCRIPTION
Closes #104.

## The mechanism question

The issue asks whether this is "an argument we can pass, or upfront instruction to the model." Claude Code's Agent/Task tool **does not expose a per-subagent turn or token cap** to a skill — there's no argument to bound a runaway subagent from the orchestrator. So the guard has to be three things working together:

1. **Prompt-driven self-termination** — the subagent recognizes it's stuck and stops.
2. **A deterministic cleanup command** — undo the staging so the doc re-ingests cleanly.
3. **Orchestrator detection** — react to a failed subagent without derailing the batch.

## What this adds

**Stop conditions (runaway guard)** in the extraction and section subagents (and a lighter one in finalize). The subagent bails — returning `STATUS: failed` with a one-line `REASON` — when it hits:
- an unreadable / empty / garbled document,
- repeated post-flight rejection (now **capped at 2 fixes**, where it previously said "fix and run it again" open-endedly),
- or no-progress looping (same read/edit/command without new information).

Crucially it bails **before** the vault write, so nothing is committed — the only state to undo is per-document staging in `.watchdog/tmp/`.

**`watchdog ingest-abort <sha>`** (`pipeline/abort.py`) — deterministic cleanup:
- removes the document's staging files (`wdg_ex_`, `notes_`, `preflight_`, `section_*`, `section_ex_*`) and any raw timeline files (`*_{sha[:7]}.ndjson` — never canonical),
- moves the chewed queue file to `.watchdog/queue/_failed/` (preserved, out of the active queue so it isn't auto-retried forever),
- **never touches the vault registry, notes, or morgue** (a clean bail never wrote there).

Re-ingest later = `mv .watchdog/queue/_failed/<sha>.json .watchdog/queue/` then `watchdog ingest`. The source is still in `_INCOMING/`.

**Orchestrator** now handles `STATUS: failed` (and unparseable/errored results): run `ingest-abort`, log the reason, count it failed, continue. A failed *section* aborts the whole document (skip remaining sections, no merge/post-flight). The old ad-hoc "move queue file to `_INCOMING/_FAILED/`" step is replaced by `ingest-abort`.

## Tests

`tests/test_abort.py`: removes this sha's staging + raw timeline, keeps canonical timeline and other docs, moves the queue file to `_failed/`, and never mutates `entities.json`. Full suite: **403 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
