### PR TITLE
Carry domain-skill classification forward from section 1 (#113)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -168,9 +168,13 @@ extractor subagent reading the document** — not by a separate pre-pass.
   deleted an entire subsystem (the embedding cache, hashing, thresholds).
 - **Tradeoff.** `document_type` is `null` in the queue between chew and ingest; it is
   populated by extraction. Accepted — nothing downstream needs it earlier.
-- **Sections too.** Large documents are extracted in sections (§5); each section
-  subagent self-classifies from its own pages (consulting `_index.md`) rather than
-  receiving a precomputed type.
+- **Sections too.** Large documents are extracted in sections (§5). Section 1
+  classifies from its pages (consulting `_index.md`, falling back to
+  `general-records.md`) and records the chosen skill path as a `Domain skill:` line
+  in the running scratchpad. Sections 2..N read that line and load the same skill
+  rather than re-classifying — guaranteeing all sections of a document use the same
+  domain skill. If the scratchpad line is somehow absent, later sections fall back to
+  self-classifying.
 - **Note.** The fastembed model is still used for the **search index** (§11); only
   the classifier was removed.
 

--- a/src/watchdog/skills/watchdog-ingest-section-subagent.md
+++ b/src/watchdog/skills/watchdog-ingest-section-subagent.md
@@ -26,7 +26,7 @@ Read the stdout directly. Use only these fields (ignore `pages_path` — you rea
 
 ## Step 2 — Read the scratchpad (carry-forward)
 
-If `SCRATCHPAD_PATH` exists, read it. Its **Entities so far** block lists `id | name | type | aliases` for entities earlier sections already extracted — reuse those ids, and resolve back-references in your section (e.g. "the Company") against those names/aliases. Its **Observations** are prior salient notes. If the file does not exist (you are section 1), there is no carry-forward yet.
+If `SCRATCHPAD_PATH` exists, read it. Its **Entities so far** block lists `id | name | type | aliases` for entities earlier sections already extracted — reuse those ids, and resolve back-references in your section (e.g. "the Company") against those names/aliases. Its **Observations** are prior salient notes. **Also note the `Domain skill:` line if present** — you will use it in Step 4. If the file does not exist (you are section 1), there is no carry-forward yet.
 
 ## Step 3 — Read your section
 
@@ -34,7 +34,9 @@ Read `SECTION_PAGES_PATH` in a single Read. A **paginated** section contains `<!
 
 ## Step 4 — Load domain skill
 
-Scan your pages to identify the document type and read the closest match in `.claude/commands/records/`. The filenames are descriptive; consult `.claude/commands/records/_index.md` (a one-line description of every skill) if unsure, and fall back to `general-records.md` if nothing matches.
+**If you are section 1:** Scan your pages to identify the document type. Read the closest match in `.claude/commands/records/`. The filenames are descriptive; consult `.claude/commands/records/_index.md` (a one-line description of every skill) if unsure, and fall back to `general-records.md` if nothing matches. Note the resolved path (e.g. `records/corporate-filings.md`) — you will write it to the scratchpad as `Domain skill: <path>` in Step 8.
+
+**If you are section 2 or later:** Use the `Domain skill:` path you read from the scratchpad in Step 2 and load `.claude/commands/<that path>`. If no `Domain skill:` line was present in the scratchpad (unexpected fallback), self-classify from your pages as section 1 would.
 
 ## Step 5 — Extract entities (this section only)
 
@@ -87,12 +89,16 @@ Append to `SCRATCHPAD_PATH` (create it if you are section 1) so the next section
 ```markdown
 # Running notes — {FILENAME}
 
+Domain skill: <resolved skill path, e.g. records/corporate-filings.md — section 1 writes this; later sections omit>
+
 ## Entities so far
 - <id> | <name> | <type> | <aliases, comma-separated>
 
 ## Observations
 - p.<N>: <something that stuck out — a figure, a relationship, an anomaly, a "see Note X" cross-reference>
 ```
+
+**Section 1 only:** include the `Domain skill:` line (the path you resolved in Step 4) immediately after the heading, before `## Entities so far`. Later sections append only new entities and observations — do not add another `Domain skill:` line.
 
 Add any entities new to this section to **Entities so far**, and your salient notes to **Observations**. The Observations become the document's briefing notes, so keep them high-signal — what a reporter would jot down, not a summary.
 


### PR DESCRIPTION
## Summary

- Section 1 of a large-document extraction classifies the document type from its pages (same logic as before: descriptive filenames + `_index.md`, fallback to `general-records.md`) and records the chosen path as a `Domain skill:` line at the top of the running scratchpad.
- Sections 2..N read that line in Step 2 and load the same skill in Step 4, instead of re-classifying independently from their own page ranges. Fallback to self-classifying if the line is somehow absent.
- Updates `ARCHITECTURE.md` §6 ("Sections too" bullet) to reflect carry-forward rather than per-section self-classification.

No orchestrator change needed — skill selection stays inside the section subagent.

## Test plan

- [x] All 404 existing tests pass (`~/.local/pipx/venvs/watchdog-intel/bin/pytest`)
- [ ] Manually verify a large document: confirm all sections load the same domain skill (check scratchpad `Domain skill:` line after section 1 runs)

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)