### PR TITLE
Add model settings to watchdog configure; add --entity-synthesizer-model flag

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -105,7 +105,7 @@ actual registry/note writes so parallel subagents can write safely.
 `skills/watchdog-ingest-subagent.md` (per-document extractor).
 **Code:** `pipeline/preflight.py`, `pipeline/postflight.py`, `pipeline/write_vault.py`.
 
-The orchestrator (default model: sonnet, configurable) partitions the queue by
+The orchestrator (model: `ORCHESTRATOR_MODEL`, configurable via `watchdog configure orchestrator_model` or `--orchestrator-model`) partitions the queue by
 estimated size. **Normal** documents are processed in **batches of up to 5**, all
 extractor subagents in a batch launched in parallel. **Large** documents (over
 `section_token_threshold`) are extracted in sections instead (see "Large documents"
@@ -242,7 +242,7 @@ solution is **two complementary mechanisms covering disjoint cases:**
   count in `_queue.json`. This is a *free byproduct* of data the extractor already
   produced — no extra extractor tokens. After extraction, the orchestrator (§3 of the
   ingest skill) reads `_queue.json`, selects entities with **count ≥ 2**, and fans out
-  entity-synthesis subagents (batches of 5) that reconcile the fragments + current
+  entity-synthesis subagents (batches of 5, model `ENTITY_SYNTHESIZER_MODEL`) that reconcile the fragments + current
   prose into a synthesized Summary and Analysis via `watchdog write-entity-synthesis`
   (`pipeline/finalize_entity.py`).
 - **The gate is the cost control.** Most entities in a batch are single-mention and
@@ -348,9 +348,11 @@ registry for every document would be wasteful. The manifest is the cheap index.
 
 ## 13. Models & skills
 
-- **Models** (all configurable, default sonnet): the orchestrator, the extractor
-  model (used by the per-document, section, and entity-synthesis subagents), and the
-  finalize subagent's `--finalizer-model` (timeline + briefing).
+- **Models** (all configurable via `watchdog configure`, default sonnet): four separate
+  model settings — `orchestrator_model` (ingest orchestrator), `extractor_model`
+  (per-document, section, and large-document subagents), `entity_synthesizer_model`
+  (entity synthesis subagents, §8), and `finalizer_model` (timeline + briefing, §9).
+  Each can also be overridden for a single run via the matching `watchdog ingest` flag.
 - **Subagent skills**: `watchdog-ingest-subagent.md` (per-document extraction),
   `watchdog-ingest-section-subagent.md` (one page-range section of a large document),
   `watchdog-entity-synthesis-subagent.md` (prose synthesis, §8), and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,10 @@
 
 [ARCHITECTURE.md](ARCHITECTURE.md) records how the preprocessing and ingestion pipeline is built and the rationale behind each architectural decision. **When a change alters the pipeline's structure, the split between deterministic code and the model, the vault/registry layout, or any decision logged there, update `ARCHITECTURE.md` in the same change** — including its decision-log table. Treat it as part of the definition of done, like tests.
 
+## Documentation
+
+**When a change adds, removes, or modifies anything user-facing — CLI flags, `watchdog configure` keys, CLI commands, default values, or ingest workflow steps — update `README.md`, `GETTING_STARTED.md`, and `INSTALL.md` in the same change.** The configuration table in README, the processing section in GETTING_STARTED, and the ingest walkthrough in INSTALL are the three most likely to need updating. Treat doc updates as part of the definition of done, like tests.
+
 ## Testing
 
 Write tests for new features and any non-trivial function. The suite lives in `tests/`.

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -162,13 +162,21 @@ watchdog ingest
 
 Watchdog scans the queue and prompts you to open Claude Code. When you confirm, it opens Claude Code with the extraction skill pre-loaded — extraction begins automatically.
 
-By default, Watchdog uses Claude Sonnet for all three components: the orchestrator, the extraction subagents (one per document), and the finalizer subagent (timeline reconciliation + briefing). You can override any of them at the command line:
+By default, Watchdog uses Claude Sonnet for all four components: the orchestrator, the extraction subagents (one per document), the entity synthesis subagents (run after extraction for entities mentioned in two or more documents), and the finalizer subagent (timeline reconciliation + briefing). You can set persistent defaults with `watchdog configure`, or override for a single run at the command line:
 
 ```bash
-watchdog ingest --extractor-model haiku      # faster, cheaper subagents
-watchdog ingest --orchestrator-model opus    # more capable orchestrator
-watchdog ingest --finalizer-model opus       # stronger model for timeline + briefing
+watchdog ingest --extractor-model haiku           # faster, cheaper subagents
+watchdog ingest --orchestrator-model opus         # more capable orchestrator
+watchdog ingest --finalizer-model opus            # stronger model for timeline + briefing
+watchdog ingest --entity-synthesizer-model haiku  # cheaper model for entity synthesis
 watchdog ingest --orchestrator-model opus --extractor-model haiku
+```
+
+To set a persistent default so you don't have to pass the flag every time:
+
+```bash
+watchdog configure extractor_model haiku
+watchdog configure orchestrator_model sonnet
 ```
 
 Claude works through each chewed file in the queue, processing up to 5 documents in parallel. For each document, it:

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -188,7 +188,7 @@ watchdog ingest
 
 Watchdog scans the queue, then opens Claude Code with the extraction skill pre-loaded — extraction begins automatically.
 
-By default, Watchdog uses Claude Sonnet for all stages. You can pass `--extractor-model haiku` for faster, cheaper extraction, `--orchestrator-model opus` for a more capable orchestrator, or `--finalizer-model opus` for a stronger model on the post-ingest timeline reconciliation and briefing step. See the [Commands](README.md#processing) section of the README for details.
+By default, Watchdog uses Claude Sonnet for all stages. You can configure persistent model defaults with `watchdog configure` (e.g. `watchdog configure extractor_model haiku`), or override for a single run with flags like `--extractor-model haiku`, `--orchestrator-model opus`, `--finalizer-model opus`, or `--entity-synthesizer-model haiku`. See the [Commands](README.md#processing) and [Configuration](README.md#configuration) sections of the README for details.
 
 Claude will work through each chewed file, extract entities, relationships, and key facts, and write everything to your vault. At the end it produces a briefing showing:
 - What documents were processed

--- a/README.md
+++ b/README.md
@@ -209,9 +209,10 @@ For a full end-to-end walkthrough of a first investigation, see [GETTING_STARTED
 | `watchdog chew --chew-workers N` | Override parallel file workers for this run |
 | `watchdog chew --chunk-workers N` | Override parallel chunk workers per file for this run |
 | `watchdog ingest` | Acquire the ingest lock, scan the queue, and open Claude Code — `/watchdog-ingest` fires automatically |
-| `watchdog ingest --orchestrator-model M` | Override the orchestrator model (`sonnet`/`opus`/`haiku`, default: `sonnet`) |
-| `watchdog ingest --extractor-model M` | Override the extraction subagent model (`sonnet`/`haiku`, default: `sonnet`) |
-| `watchdog ingest --finalizer-model M` | Override the finalizer subagent model — timeline reconciliation + briefing (`sonnet`/`opus`/`haiku`, default: `sonnet`) |
+| `watchdog ingest --orchestrator-model M` | Override the orchestrator model for this run (`sonnet`/`opus`/`haiku`; default from `watchdog configure`) |
+| `watchdog ingest --extractor-model M` | Override the extraction subagent model for this run (`sonnet`/`opus`/`haiku`; default from `watchdog configure`) |
+| `watchdog ingest --finalizer-model M` | Override the finalizer subagent model for this run — timeline reconciliation + briefing (`sonnet`/`opus`/`haiku`; default from `watchdog configure`) |
+| `watchdog ingest --entity-synthesizer-model M` | Override the entity synthesis subagent model for this run (`sonnet`/`opus`/`haiku`; default from `watchdog configure`) |
 | `watchdog context [name]` | Open Claude Code with the context seeding skill; omit name when inside the vault |
 | `watchdog context --model M` | Override the model for context seeding (`sonnet`/`opus`/`haiku`, default: `sonnet`) |
 | `watchdog watch [name]` | Watch `_INCOMING/` and chew files automatically as they arrive; omit name when inside the project directory |
@@ -445,6 +446,10 @@ watchdog configure <key> <value>
 | `embed_images` | `false` | Embed figures as base64 in the extracted markdown so Claude can read charts and image-based tables. Significantly increases token usage. |
 | `dup_threshold` | `0.85` | Jaccard similarity score at which two documents are flagged as near-duplicates. Range: 0.0–1.0. |
 | `shingle_size` | `3` | Word n-gram size for near-duplicate fingerprinting. Changing this invalidates existing MinHash signatures — re-ingest to rebuild. |
+| `orchestrator_model` | `sonnet` | Claude model for the ingest orchestrator. Options: `haiku`, `sonnet`, `opus`. Can be overridden per-run with `--orchestrator-model`. |
+| `extractor_model` | `sonnet` | Claude model for per-document extraction subagents. Options: `haiku`, `sonnet`, `opus`. Can be overridden per-run with `--extractor-model`. |
+| `finalizer_model` | `sonnet` | Claude model for the post-ingest finalizer subagent (timeline reconciliation + briefing). Options: `haiku`, `sonnet`, `opus`. Can be overridden per-run with `--finalizer-model`. |
+| `entity_synthesizer_model` | `sonnet` | Claude model for entity synthesis subagents (Summary + Analysis reconciliation for entities appearing in ≥2 documents). Options: `haiku`, `sonnet`, `opus`. Can be overridden per-run with `--entity-synthesizer-model`. |
 
 **Examples:**
 
@@ -460,6 +465,12 @@ watchdog configure ocr_languages "fr-FR,ar-SA"
 
 # Move investigation storage to an external drive
 watchdog configure projects_dir /Volumes/SecureDrive/Investigations
+
+# Use Haiku for extraction subagents by default (faster and cheaper)
+watchdog configure extractor_model haiku
+
+# Use Opus for the orchestrator on high-stakes investigations
+watchdog configure orchestrator_model opus
 ```
 
 ---

--- a/src/watchdog/cli.py
+++ b/src/watchdog/cli.py
@@ -278,15 +278,18 @@ def main() -> None:
 
     _model_choices = ["sonnet", "opus", "haiku"]
     p_ingest = sub.add_parser("ingest", help="Set up extraction session and open in Claude Code")
-    p_ingest.add_argument("--orchestrator-model", choices=_model_choices, default="sonnet",
+    p_ingest.add_argument("--orchestrator-model", choices=_model_choices, default=None,
                           dest="orchestrator_model",
-                          help="Model for the orchestrator session (default: sonnet)")
-    p_ingest.add_argument("--extractor-model", choices=_model_choices, default="sonnet",
+                          help="Model for the orchestrator session — overrides watchdog configure (default: sonnet)")
+    p_ingest.add_argument("--extractor-model", choices=_model_choices, default=None,
                           dest="extractor_model",
-                          help="Model for extraction subagents (default: sonnet)")
-    p_ingest.add_argument("--finalizer-model", choices=_model_choices, default="sonnet",
+                          help="Model for extraction subagents — overrides watchdog configure (default: sonnet)")
+    p_ingest.add_argument("--finalizer-model", choices=_model_choices, default=None,
                           dest="finalizer_model",
-                          help="Model for the finalize subagent — timeline reconciliation + briefing (default: sonnet)")
+                          help="Model for the finalizer subagent — timeline reconciliation + briefing — overrides watchdog configure (default: sonnet)")
+    p_ingest.add_argument("--entity-synthesizer-model", choices=_model_choices, default=None,
+                          dest="entity_synthesizer_model",
+                          help="Model for entity synthesis subagents — overrides watchdog configure (default: sonnet)")
     p_ingest.set_defaults(func=cmd_ingest)
 
     p_context = sub.add_parser("context", help="Open Claude Code to seed investigation context from _CONTEXT/")

--- a/src/watchdog/cmd/base.py
+++ b/src/watchdog/cmd/base.py
@@ -117,9 +117,10 @@ _CMD_HELP: dict[str, dict] = {
     "ingest": {
         "desc": "Set up extraction session and open in Claude Code",
         "opts": [
-            ("--orchestrator-model M", "Model for the orchestrator session (sonnet/opus/haiku, default: sonnet)"),
-            ("--extractor-model M",    "Model for extraction subagents (sonnet/haiku, default: sonnet)"),
-            ("--finalizer-model M",    "Model for the finalize subagent — timeline + briefing (sonnet/opus/haiku, default: sonnet)"),
+            ("--orchestrator-model M",       "Override orchestrator model for this run (sonnet/opus/haiku; default from watchdog configure)"),
+            ("--extractor-model M",          "Override extraction subagent model for this run (sonnet/opus/haiku; default from watchdog configure)"),
+            ("--finalizer-model M",          "Override finalizer subagent model for this run — timeline + briefing (sonnet/opus/haiku; default from watchdog configure)"),
+            ("--entity-synthesizer-model M", "Override entity synthesizer model for this run (sonnet/opus/haiku; default from watchdog configure)"),
         ],
     },
     "context": {

--- a/src/watchdog/cmd/ingest.py
+++ b/src/watchdog/cmd/ingest.py
@@ -75,16 +75,39 @@ def cmd_ingest(args) -> None:
     vault = Path(".").resolve()
     if not (vault / ".watchdog").is_dir():
         sys.exit("Error: must be run from inside a Watchdog vault directory")
-    orchestrator_model = getattr(args, "orchestrator_model", None) or "sonnet"
-    extractor_model    = getattr(args, "extractor_model",    None) or "sonnet"
-    finalizer_model    = getattr(args, "finalizer_model",    None) or "sonnet"
-    for label, model in (("orchestrator", orchestrator_model),
-                         ("extractor", extractor_model),
-                         ("finalizer", finalizer_model)):
+
+    from watchdog.cmd.base import CONFIG_FILE
+    config: dict = {}
+    if CONFIG_FILE.exists():
+        import json as _json
+        try:
+            config = _json.loads(CONFIG_FILE.read_text())
+        except Exception:
+            pass
+
+    def _model(flag_val: str | None, config_key: str) -> str:
+        return flag_val or config.get(config_key) or "sonnet"
+
+    orchestrator_model      = _model(getattr(args, "orchestrator_model",      None), "orchestrator_model")
+    extractor_model         = _model(getattr(args, "extractor_model",         None), "extractor_model")
+    finalizer_model         = _model(getattr(args, "finalizer_model",         None), "finalizer_model")
+    entity_synthesizer_model = _model(getattr(args, "entity_synthesizer_model", None), "entity_synthesizer_model")
+
+    for label, model in (
+        ("orchestrator",       orchestrator_model),
+        ("extractor",          extractor_model),
+        ("finalizer",          finalizer_model),
+        ("entity-synthesizer", entity_synthesizer_model),
+    ):
         if model not in _MODEL_IDS:
             sys.exit(f"Error: unknown {label} model '{model}' — choose sonnet, opus, or haiku")
     from watchdog.pipeline.ingest_setup import run as is_run
-    result = is_run(vault, extractor_model=extractor_model, finalizer_model=finalizer_model)
+    result = is_run(
+        vault,
+        extractor_model=extractor_model,
+        finalizer_model=finalizer_model,
+        entity_synthesizer_model=entity_synthesizer_model,
+    )
     if "error" in result:
         sys.exit(f"\n  {_YELLOW}Error:{_RESET} {result['error']}\n")
     if result["total"] == 0:

--- a/src/watchdog/cmd/setup.py
+++ b/src/watchdog/cmd/setup.py
@@ -143,6 +143,57 @@ _CONFIGURE_KEYS = {
         "type": "bool",
         "default": False,
     },
+    # ── Models ───────────────────────────────────────────────────────────────
+    "orchestrator_model": {
+        "short": "Claude model for the ingest orchestrator (default: sonnet)",
+        "help": (
+            "Model used for the orchestrator session launched by `watchdog ingest`.\n"
+            "  The orchestrator manages the extraction loop and kicks off subagents.\n"
+            "  Valid values: haiku, sonnet, opus. Default: sonnet.\n"
+            "  Override for a single run with: watchdog ingest --orchestrator-model M"
+        ),
+        "type": "enum",
+        "default": "sonnet",
+        "choices": ["haiku", "sonnet", "opus"],
+    },
+    "extractor_model": {
+        "short": "Claude model for per-document extraction subagents (default: sonnet)",
+        "help": (
+            "Model used for each per-document extraction subagent during ingest.\n"
+            "  Haiku is significantly cheaper and faster; use it for large batches of\n"
+            "  straightforward documents. Sonnet handles complex or ambiguous documents better.\n"
+            "  Valid values: haiku, sonnet, opus. Default: sonnet.\n"
+            "  Override for a single run with: watchdog ingest --extractor-model M"
+        ),
+        "type": "enum",
+        "default": "sonnet",
+        "choices": ["haiku", "sonnet", "opus"],
+    },
+    "finalizer_model": {
+        "short": "Claude model for the post-ingest finalizer subagent (default: sonnet)",
+        "help": (
+            "Model used for the finalizer subagent that reconciles the timeline and\n"
+            "  produces the post-ingest briefing after extraction is complete.\n"
+            "  Valid values: haiku, sonnet, opus. Default: sonnet.\n"
+            "  Override for a single run with: watchdog ingest --finalizer-model M"
+        ),
+        "type": "enum",
+        "default": "sonnet",
+        "choices": ["haiku", "sonnet", "opus"],
+    },
+    "entity_synthesizer_model": {
+        "short": "Claude model for entity synthesis subagents (default: sonnet)",
+        "help": (
+            "Model used for entity synthesis subagents — the pass that reconciles an\n"
+            "  entity's Summary and Analysis when it appears in two or more documents\n"
+            "  in a single ingest run.\n"
+            "  Valid values: haiku, sonnet, opus. Default: sonnet.\n"
+            "  Override for a single run with: watchdog ingest --entity-synthesizer-model M"
+        ),
+        "type": "enum",
+        "default": "sonnet",
+        "choices": ["haiku", "sonnet", "opus"],
+    },
     # ── Deduplication ─────────────────────────────────────────────────────────
     "dup_threshold": {
         "short": "Near-duplicate Jaccard similarity threshold — score at which documents are flagged (default: 0.85)",

--- a/src/watchdog/pipeline/ingest_setup.py
+++ b/src/watchdog/pipeline/ingest_setup.py
@@ -30,7 +30,7 @@ def _iso_now() -> str:
     return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
-def run(vault: Path, extractor_model: str = "sonnet", finalizer_model: str = "sonnet") -> dict:
+def run(vault: Path, extractor_model: str = "sonnet", finalizer_model: str = "sonnet", entity_synthesizer_model: str = "sonnet") -> dict:
     """Acquire lock, scan queue, write state file. Returns the state dict."""
     lock_file = vault / ".watchdog" / "Registry" / ".ingest-lock"
     state_file = vault / ".watchdog" / "ingest-state.json"
@@ -98,6 +98,7 @@ def run(vault: Path, extractor_model: str = "sonnet", finalizer_model: str = "so
         "queue_files": queue_files,
         "extractor_model": extractor_model,
         "finalizer_model": finalizer_model,
+        "entity_synthesizer_model": entity_synthesizer_model,
         "section_token_threshold": _section_token_threshold(),
     }
     state_file.write_text(json.dumps(state, ensure_ascii=False, indent=2), encoding="utf-8")

--- a/src/watchdog/skills/watchdog-ingest.md
+++ b/src/watchdog/skills/watchdog-ingest.md
@@ -40,6 +40,8 @@ Set `EXTRACTOR_MODEL = INGEST.extractor_model` if present, else `"sonnet"`.
 
 Set `FINALIZER_MODEL = INGEST.finalizer_model` if present, else `"sonnet"`.
 
+Set `ENTITY_SYNTHESIZER_MODEL = INGEST.entity_synthesizer_model` if present, else `"sonnet"`.
+
 Set `SECTION_TOKEN_THRESHOLD = INGEST.section_token_threshold` if present, else `120000`.
 
 Set `QUEUE_FILES = INGEST.queue_files`.
@@ -164,7 +166,7 @@ Read `.watchdog/tmp/entity-fragments/_queue.json` with the Read tool. If it does
 
 Set `SYNTHESIZE` = every entry with `count >= 2`. If `SYNTHESIZE` is empty, skip.
 
-Process `SYNTHESIZE` in **batches of up to 5** — launch all synthesis subagents in a batch simultaneously (a single message with parallel Agent calls). Set each Agent's `description` to `Watchdog entity synthesis: <ENTITY_NAME clamped to 50 chars>` and `model` to `EXTRACTOR_MODEL`. Substitute `{placeholder}` values before sending:
+Process `SYNTHESIZE` in **batches of up to 5** — launch all synthesis subagents in a batch simultaneously (a single message with parallel Agent calls). Set each Agent's `description` to `Watchdog entity synthesis: <ENTITY_NAME clamped to 50 chars>` and `model` to `ENTITY_SYNTHESIZER_MODEL`. Substitute `{placeholder}` values before sending:
 
 ```
 Read `.claude/commands/watchdog-entity-synthesis-subagent.md` for full instructions. Then synthesize this entity:

--- a/tests/test_ingest_setup.py
+++ b/tests/test_ingest_setup.py
@@ -172,6 +172,26 @@ def test_finalizer_model_defaults_to_sonnet(tmp_path):
     assert result["finalizer_model"] == "sonnet"
 
 
+def test_entity_synthesizer_model_written_to_state(tmp_path):
+    vault = _make_vault(tmp_path)
+    _write_queue_file(vault, "abc123")
+
+    result = run(vault, entity_synthesizer_model="opus")
+
+    assert result["entity_synthesizer_model"] == "opus"
+    state = json.loads((vault / ".watchdog" / "ingest-state.json").read_text())
+    assert state["entity_synthesizer_model"] == "opus"
+
+
+def test_entity_synthesizer_model_defaults_to_sonnet(tmp_path):
+    vault = _make_vault(tmp_path)
+    _write_queue_file(vault, "abc123")
+
+    result = run(vault)
+
+    assert result["entity_synthesizer_model"] == "sonnet"
+
+
 def test_queue_files_include_page_count(tmp_path):
     vault = _make_vault(tmp_path)
     qf = vault / ".watchdog" / "queue" / "abc123.json"


### PR DESCRIPTION
Closes #115.

## Summary

- Four new `watchdog configure` keys: `orchestrator_model`, `extractor_model`, `finalizer_model`, `entity_synthesizer_model` — all enum (haiku/sonnet/opus, default sonnet). Per-run `--*-model` flags on `watchdog ingest` now override the configured default rather than always falling back to sonnet.
- New `--entity-synthesizer-model` flag for `watchdog ingest`; entity synthesis subagents now use `ENTITY_SYNTHESIZER_MODEL` from the ingest state (previously they inherited `EXTRACTOR_MODEL`).
- Docs updated: README commands table + configuration table, GETTING_STARTED ingest section, INSTALL ingest walkthrough, ARCHITECTURE §13 models description.
- CLAUDE.md: added Documentation guideline requiring README/GETTING_STARTED/INSTALL updates alongside any user-facing change.

## Test plan

- [ ] `watchdog configure` — verify the four new model keys appear with correct defaults
- [ ] `watchdog configure extractor_model haiku` — verify it persists to config.json and `watchdog ingest` picks it up without passing a flag
- [ ] `watchdog ingest --extractor-model opus` — verify the flag overrides the configured value
- [ ] `watchdog ingest --entity-synthesizer-model haiku` — verify it flows through to the ingest state file
- [ ] All 406 tests pass (`~/.local/pipx/venvs/watchdog-intel/bin/pytest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)