### PR TITLE
Model-backend auth: subscription vs API key (#118)

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,11 @@ For a full end-to-end walkthrough of a first investigation, see [GETTING_STARTED
 | `watchdog search <name> "<query>"` | Semantic search across ingested documents |
 | `watchdog doctor` | Check all registered investigations for missing or broken vaults; suggests `watchdog move` or `watchdog delete` for each issue |
 | `watchdog configure` | View or change configuration |
+| `watchdog auth` | Show the auth mode and API-key status (masked) |
+| `watchdog auth use <mode>` | Set auth mode: `auto` (default), `subscription` (Claude Code login, not metered), or `api-key` (metered) |
+| `watchdog auth set [provider]` | Store an API key (prompted, hidden); `provider` defaults to `anthropic` |
+| `watchdog auth get [provider]` | Show one provider's key status and source (env var or stored) |
+| `watchdog auth remove [provider]` | Delete a stored API key |
 | `watchdog unlock <name>` | Release a stale chew or ingest lock; `--force` to remove even if recent |
 | `watchdog setup` | Set up Watchdog after installation; `--force` to re-run |
 | `watchdog refresh-skills [name]` | Update vault skill files after a watchdog upgrade; omit name when inside the project directory |

--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ For a full end-to-end walkthrough of a first investigation, see [GETTING_STARTED
 | `watchdog doctor` | Check all registered investigations for missing or broken vaults; suggests `watchdog move` or `watchdog delete` for each issue |
 | `watchdog configure` | View or change configuration |
 | `watchdog auth` | Show the auth mode and API-key status (masked) |
-| `watchdog auth use <mode>` | Set auth mode: `auto` (default), `subscription` (Claude Code login, not metered), or `api-key` (metered) |
+| `watchdog auth use <mode>` | Switch auth mode: `subscription` (Claude Code login, not metered) or `api-key` (metered). Normally chosen during `watchdog setup` |
 | `watchdog auth set [provider]` | Store an API key (prompted, hidden); `provider` defaults to `anthropic` |
 | `watchdog auth get [provider]` | Show one provider's key status and source (env var or stored) |
 | `watchdog auth remove [provider]` | Delete a stored API key |

--- a/src/watchdog/cli.py
+++ b/src/watchdog/cli.py
@@ -83,6 +83,7 @@ from watchdog.cmd.setup import (
     cmd_setup,
     cmd_unlock,
 )
+from watchdog.cmd.auth import cmd_auth
 
 
 def _cmd_rebuild_timeline(args) -> None:
@@ -294,6 +295,13 @@ def main() -> None:
     p_context.add_argument("--model", choices=_model_choices, default="sonnet",
                            help="Model to use (default: sonnet)")
     p_context.set_defaults(func=cmd_context)
+
+    p_auth = sub.add_parser("auth", help="Choose auth mode and manage API keys for model backends")
+    p_auth.add_argument("action", nargs="?", choices=["status", "use", "set", "get", "remove"],
+                        help="status (default) | use <mode> | set/get/remove [provider]")
+    p_auth.add_argument("target", nargs="?",
+                        help="mode for `use` (auto/subscription/api-key); provider for set/get/remove (default: anthropic)")
+    p_auth.set_defaults(func=cmd_auth)
 
     try:
         import argcomplete

--- a/src/watchdog/cli.py
+++ b/src/watchdog/cli.py
@@ -300,7 +300,7 @@ def main() -> None:
     p_auth.add_argument("action", nargs="?", choices=["status", "use", "set", "get", "remove"],
                         help="status (default) | use <mode> | set/get/remove [provider]")
     p_auth.add_argument("target", nargs="?",
-                        help="mode for `use` (auto/subscription/api-key); provider for set/get/remove (default: anthropic)")
+                        help="mode for `use` (subscription/api-key); provider for set/get/remove (default: anthropic)")
     p_auth.set_defaults(func=cmd_auth)
 
     try:

--- a/src/watchdog/cmd/auth.py
+++ b/src/watchdog/cmd/auth.py
@@ -18,6 +18,7 @@ The environment variable always takes precedence over a stored key.
 import json
 import os
 import stat
+import subprocess
 import sys
 from getpass import getpass
 from pathlib import Path
@@ -25,7 +26,7 @@ from pathlib import Path
 from watchdog.cmd import base
 from watchdog.cmd.base import _BOLD, _CYAN, _DIM, _GREEN, _RESET, _YELLOW
 
-_MODES = ("auto", "subscription", "api-key")
+_MODES = ("subscription", "api-key")
 
 # Providers whose keys watchdog manages. `anthropic` covers both the Claude
 # Agent SDK and the Claude API backends — they share ANTHROPIC_API_KEY.
@@ -46,25 +47,47 @@ def _claude_code_creds_path() -> Path:
     return Path.home() / ".claude" / ".credentials.json"
 
 
+# macOS Claude Code stores its OAuth login as a Keychain generic-password item
+# under this service (account = the macOS username), not in the credentials file.
+_KEYCHAIN_SERVICE = "Claude Code-credentials"
+
+
+def _keychain_has_claude_creds() -> bool:
+    """macOS: is the Claude Code login present in the Keychain?
+
+    Queries attributes only (no `-w`/`-g`), so it does not read the secret or
+    trigger an access prompt.
+    """
+    if sys.platform != "darwin":
+        return False
+    try:
+        return subprocess.run(
+            ["security", "find-generic-password", "-s", _KEYCHAIN_SERVICE],
+            capture_output=True, timeout=5,
+        ).returncode == 0
+    except (OSError, subprocess.SubprocessError):
+        return False
+
+
 def claude_code_logged_in() -> bool:
     """Best-effort check that the `claude` CLI is logged in.
 
-    The credentials file exists after an OAuth login. On macOS the CLI may instead
-    store credentials in the Keychain, so a False here does not prove logged-out —
-    the definitive test is an Agent SDK call succeeding without an API key.
+    Checks the credentials file (Linux / older setups) and the macOS Keychain item
+    the Agent SDK reads. The definitive test is still an SDK call succeeding.
     """
-    return _claude_code_creds_path().exists()
+    return _claude_code_creds_path().exists() or _keychain_has_claude_creds()
 
 
 def _load_state() -> dict:
+    """Return {"mode", "keys"}. `mode` is None until set by setup or `auth use`."""
     path = _credentials_path()
     if not path.exists():
-        return {"mode": "auto", "keys": {}}
+        return {"mode": None, "keys": {}}
     try:
         data = json.loads(path.read_text())
     except json.JSONDecodeError:
         sys.exit("Error: credentials file is corrupt; remove it and re-add your keys.")
-    data.setdefault("mode", "auto")
+    data.setdefault("mode", None)
     data.setdefault("keys", {})
     return data
 
@@ -98,59 +121,118 @@ def resolve_auth(provider: str = "anthropic") -> dict:
       {"mode": "subscription"}              → pass no key; the SDK uses Claude Code's login
       {"mode": "none", "reason": "<why>"}   → nothing configured; caller errors with guidance
     """
-    mode = _load_state().get("mode", "auto")
-    key = get_api_key(provider)
+    mode = _load_state().get("mode")
 
-    if mode == "api-key":
-        return {"mode": "api-key", "key": key} if key else {
-            "mode": "none", "reason": "api-key mode is set but no key is configured"}
+    if mode is None:
+        return {"mode": "none", "reason": "auth not configured — run `watchdog setup`"}
     if mode == "subscription":
         return {"mode": "subscription"}
-    # auto — mirror the SDK's own order: key wins, else Claude Code login.
-    if key:
-        return {"mode": "api-key", "key": key}
-    if claude_code_logged_in():
-        return {"mode": "subscription"}
-    return {"mode": "none", "reason": "no API key set and Claude Code is not logged in"}
+    # api-key
+    key = get_api_key(provider)
+    return {"mode": "api-key", "key": key} if key else {
+        "mode": "none", "reason": "api-key mode is set but no key is configured — run `watchdog auth set`"}
 
 
 # ── command surface ───────────────────────────────────────────────────────────
 
 def _status() -> None:
     state = _load_state()
-    mode = state.get("mode", "auto")
-    resolved = resolve_auth()
+    mode = state.get("mode")
+    meta = _PROVIDERS["anthropic"]
 
     print()
     print(f"  {_BOLD}Authentication{_RESET}  {_DIM}{_credentials_path()}{_RESET}")
     print()
-    print(f"  {_DIM}Mode{_RESET}           {_CYAN}{mode}{_RESET}"
-          + (f" {_DIM}→ {resolved['mode']}{_RESET}" if mode == "auto" else ""))
 
-    key, source = (get_api_key(), None)
+    if mode is None:
+        print(f"  {_YELLOW}Not configured.{_RESET}")
+        print(f"  {_DIM}Run{_RESET} {_CYAN}watchdog setup{_RESET} {_DIM}to choose how to authenticate "
+              f"(or{_RESET} {_CYAN}watchdog auth use <mode>{_RESET}{_DIM}).{_RESET}")
+        print()
+        return
+
+    print(f"  {_DIM}Mode{_RESET}           {_CYAN}{mode}{_RESET}")
+
+    if mode == "subscription":
+        cc = claude_code_logged_in()
+        cc_str = f"{_GREEN}detected{_RESET}" if cc else f"{_YELLOW}not detected{_RESET}"
+        print(f"  {_DIM}Claude Code{_RESET}    {cc_str}")
+        print()
+        if os.environ.get(meta["env"]):
+            print(f"  {_YELLOW}Warning:{_RESET} ${meta['env']} is set — the Agent SDK uses it before the")
+            print(f"  {_DIM}subscription login, so runs would be metered. Unset it to use the subscription.{_RESET}")
+        else:
+            print(f"  {_DIM}Runs use your{_RESET} {_BOLD}Claude Code subscription{_RESET} {_DIM}(not metered).{_RESET}")
+    else:  # api-key
+        key = get_api_key()
+        if key:
+            where = f"${meta['env']}" if os.environ.get(meta["env"]) else "stored"
+            print(f"  {_DIM}API key{_RESET}        {_CYAN}{_mask(key)}{_RESET} {_DIM}({where}){_RESET}")
+            print()
+            print(f"  {_DIM}Runs use a{_RESET} {_BOLD}metered API key{_RESET}{_DIM}.{_RESET}")
+        else:
+            print(f"  {_DIM}API key{_RESET}        {_YELLOW}(not set){_RESET}")
+            print()
+            print(f"  {_YELLOW}No key set.{_RESET} {_DIM}Add one with{_RESET} {_CYAN}watchdog auth set{_RESET}{_DIM}.{_RESET}")
+    print()
+
+
+def setup_auth_interactive(interactive: bool | None = None) -> None:
+    """Interactive auth picker for `watchdog setup`: choose subscription or API key.
+
+    Persists the chosen mode (and key, for api-key). Skips cleanly when not run on
+    a terminal. `interactive` is overridable for testing.
+    """
+    if interactive is None:
+        interactive = sys.stdin.isatty()
+
+    print()
+    print(f"  {_BOLD}How should Watchdog authenticate to Claude?{_RESET}")
+    print(f"    1. Claude Code subscription {_DIM}— use your existing `claude` login; not metered{_RESET}")
+    print(f"    2. API key {_DIM}— metered billing{_RESET}")
+    print()
+
+    if not interactive:
+        print(f"  {_DIM}Non-interactive — set this later with{_RESET} {_CYAN}watchdog auth use <mode>{_RESET}{_DIM}.{_RESET}")
+        return
+
+    try:
+        choice = input("  Choice [1]: ").strip() or "1"
+        while choice not in ("1", "2"):
+            choice = input("  Enter 1 or 2: ").strip()
+    except (EOFError, KeyboardInterrupt):
+        print()
+        return
+
+    state = _load_state()
     meta = _PROVIDERS["anthropic"]
-    if os.environ.get(meta["env"]):
-        source = f"from ${meta['env']}"
-    elif _load_state()["keys"].get("anthropic"):
-        source = "stored"
-    key_str = f"{_CYAN}{_mask(key)}{_RESET} {_DIM}({source}){_RESET}" if key else f"{_YELLOW}(not set){_RESET}"
-    print(f"  {_DIM}API key{_RESET}        {key_str}")
 
-    cc = claude_code_logged_in()
-    cc_str = f"{_GREEN}detected{_RESET}" if cc else f"{_YELLOW}not detected{_RESET} {_DIM}(or stored in the macOS Keychain){_RESET}"
-    print(f"  {_DIM}Claude Code{_RESET}    {cc_str}")
-    print()
+    if choice == "1":
+        state["mode"] = "subscription"
+        _save_state(state)
+        if claude_code_logged_in():
+            print(f"\n  {_GREEN}✓{_RESET}  Claude Code login detected.")
+        else:
+            print(f"\n  {_YELLOW}!{_RESET}  Claude Code login not detected — run {_CYAN}claude{_RESET} to log in.")
+        if os.environ.get(meta["env"]):
+            print(f"  {_YELLOW}!{_RESET}  ${meta['env']} is set and the SDK uses it first — unset it to avoid metering.")
+        return
 
-    if resolved["mode"] == "none":
-        print(f"  {_YELLOW}No usable auth:{_RESET} {resolved['reason']}.")
-        print(f"  {_DIM}Run{_RESET} {_CYAN}watchdog auth set{_RESET} {_DIM}(API key) or{_RESET} {_CYAN}claude{_RESET} {_DIM}(subscription login).{_RESET}")
-    elif mode == "subscription" and os.environ.get(meta["env"]):
-        print(f"  {_YELLOW}Warning:{_RESET} ${meta['env']} is set — the Agent SDK uses it before the")
-        print(f"  {_DIM}subscription login, so runs would be metered despite subscription mode.{_RESET}")
+    print(f"\n  {_DIM}Create a key at{_RESET} {_CYAN}https://platform.claude.com/{_RESET} {_DIM}→ API keys.{_RESET}")
+    try:
+        key = getpass("  Paste your Anthropic API key (hidden): ").strip()
+    except (EOFError, KeyboardInterrupt):
+        key = ""
+    state["mode"] = "api-key"
+    if key:
+        if not key.startswith(meta["prefix"]):
+            print(f"  {_YELLOW}!{_RESET}  Key doesn't start with '{meta['prefix']}' — storing it anyway.")
+        state["keys"]["anthropic"] = key
+        _save_state(state)
+        print(f"\n  {_GREEN}✓{_RESET}  API key stored ({_mask(key)}).")
     else:
-        billed = "metered API key" if resolved["mode"] == "api-key" else "Claude Code subscription (not metered)"
-        print(f"  {_DIM}Runs will authenticate with:{_RESET} {_BOLD}{billed}{_RESET}")
-    print()
+        _save_state(state)
+        print(f"\n  {_YELLOW}!{_RESET}  No key entered — add one later with {_CYAN}watchdog auth set{_RESET}.")
 
 
 def _use(mode: str | None) -> None:
@@ -164,8 +246,7 @@ def _use(mode: str | None) -> None:
     meta = _PROVIDERS["anthropic"]
     if mode == "subscription":
         if not claude_code_logged_in():
-            print(f"  {_YELLOW}Note:{_RESET} Claude Code login not detected — run {_CYAN}claude{_RESET} to log in")
-            print(f"  {_DIM}(or it may be in the macOS Keychain, which can't be checked here).{_RESET}")
+            print(f"  {_YELLOW}Note:{_RESET} Claude Code login not detected — run {_CYAN}claude{_RESET} to log in.")
         if os.environ.get(meta["env"]):
             print(f"  {_YELLOW}Warning:{_RESET} ${meta['env']} is set and the SDK uses it first — unset it to avoid metering.")
         print(f"  {_DIM}Subscription mode runs watchdog under your own Claude login. Anthropic's terms")

--- a/src/watchdog/cmd/auth.py
+++ b/src/watchdog/cmd/auth.py
@@ -1,0 +1,241 @@
+"""`watchdog auth` — choose how model backends authenticate, and manage API keys.
+
+Two auth modes (#118):
+  - **subscription** — rely on Claude Code's own login (`~/.claude/.credentials.json`,
+    the same credentials the `claude` CLI uses). No metered API billing. Intended for
+    running watchdog locally under your own Claude subscription. Anthropic's terms
+    restrict *distributing* SDK products that depend on claude.ai login — see `_use`.
+  - **api-key** — use a metered Anthropic API key (`ANTHROPIC_API_KEY`, or one stored
+    here).
+
+Default mode is **auto**: use an API key if one is available, otherwise fall back to
+Claude Code's login — mirroring the Agent SDK's own resolution order.
+
+State lives in `~/.watchdog/credentials.json` (mode 0600): `{"mode", "keys": {...}}`.
+The environment variable always takes precedence over a stored key.
+"""
+
+import json
+import os
+import stat
+import sys
+from getpass import getpass
+from pathlib import Path
+
+from watchdog.cmd import base
+from watchdog.cmd.base import _BOLD, _CYAN, _DIM, _GREEN, _RESET, _YELLOW
+
+_MODES = ("auto", "subscription", "api-key")
+
+# Providers whose keys watchdog manages. `anthropic` covers both the Claude
+# Agent SDK and the Claude API backends — they share ANTHROPIC_API_KEY.
+_PROVIDERS: dict[str, dict] = {
+    "anthropic": {
+        "label":  "Anthropic — Claude API / Agent SDK",
+        "env":    "ANTHROPIC_API_KEY",
+        "prefix": "sk-ant-",
+    },
+}
+
+
+def _credentials_path() -> Path:
+    return base.WATCHDOG_HOME / "credentials.json"
+
+
+def _claude_code_creds_path() -> Path:
+    return Path.home() / ".claude" / ".credentials.json"
+
+
+def claude_code_logged_in() -> bool:
+    """Best-effort check that the `claude` CLI is logged in.
+
+    The credentials file exists after an OAuth login. On macOS the CLI may instead
+    store credentials in the Keychain, so a False here does not prove logged-out —
+    the definitive test is an Agent SDK call succeeding without an API key.
+    """
+    return _claude_code_creds_path().exists()
+
+
+def _load_state() -> dict:
+    path = _credentials_path()
+    if not path.exists():
+        return {"mode": "auto", "keys": {}}
+    try:
+        data = json.loads(path.read_text())
+    except json.JSONDecodeError:
+        sys.exit("Error: credentials file is corrupt; remove it and re-add your keys.")
+    data.setdefault("mode", "auto")
+    data.setdefault("keys", {})
+    return data
+
+
+def _save_state(state: dict) -> None:
+    base.WATCHDOG_HOME.mkdir(parents=True, exist_ok=True)
+    path = _credentials_path()
+    path.write_text(json.dumps(state, indent=2) + "\n")
+    os.chmod(path, stat.S_IRUSR | stat.S_IWUSR)  # 0600 — owner read/write only
+
+
+def _mask(key: str) -> str:
+    if len(key) <= 8:
+        return "…" + key[-2:] if len(key) > 2 else "(set)"
+    return f"{key[:10]}…{key[-4:]}"
+
+
+def get_api_key(provider: str = "anthropic") -> str | None:
+    """Resolve a provider's API key: environment variable first, then stored."""
+    meta = _PROVIDERS.get(provider)
+    if meta and os.environ.get(meta["env"]):
+        return os.environ[meta["env"]]
+    return _load_state()["keys"].get(provider)
+
+
+def resolve_auth(provider: str = "anthropic") -> dict:
+    """How a model backend should authenticate for this run — the resolver #118 calls.
+
+    Returns one of:
+      {"mode": "api-key", "key": "<key>"}   → pass the key (metered)
+      {"mode": "subscription"}              → pass no key; the SDK uses Claude Code's login
+      {"mode": "none", "reason": "<why>"}   → nothing configured; caller errors with guidance
+    """
+    mode = _load_state().get("mode", "auto")
+    key = get_api_key(provider)
+
+    if mode == "api-key":
+        return {"mode": "api-key", "key": key} if key else {
+            "mode": "none", "reason": "api-key mode is set but no key is configured"}
+    if mode == "subscription":
+        return {"mode": "subscription"}
+    # auto — mirror the SDK's own order: key wins, else Claude Code login.
+    if key:
+        return {"mode": "api-key", "key": key}
+    if claude_code_logged_in():
+        return {"mode": "subscription"}
+    return {"mode": "none", "reason": "no API key set and Claude Code is not logged in"}
+
+
+# ── command surface ───────────────────────────────────────────────────────────
+
+def _status() -> None:
+    state = _load_state()
+    mode = state.get("mode", "auto")
+    resolved = resolve_auth()
+
+    print()
+    print(f"  {_BOLD}Authentication{_RESET}  {_DIM}{_credentials_path()}{_RESET}")
+    print()
+    print(f"  {_DIM}Mode{_RESET}           {_CYAN}{mode}{_RESET}"
+          + (f" {_DIM}→ {resolved['mode']}{_RESET}" if mode == "auto" else ""))
+
+    key, source = (get_api_key(), None)
+    meta = _PROVIDERS["anthropic"]
+    if os.environ.get(meta["env"]):
+        source = f"from ${meta['env']}"
+    elif _load_state()["keys"].get("anthropic"):
+        source = "stored"
+    key_str = f"{_CYAN}{_mask(key)}{_RESET} {_DIM}({source}){_RESET}" if key else f"{_YELLOW}(not set){_RESET}"
+    print(f"  {_DIM}API key{_RESET}        {key_str}")
+
+    cc = claude_code_logged_in()
+    cc_str = f"{_GREEN}detected{_RESET}" if cc else f"{_YELLOW}not detected{_RESET} {_DIM}(or stored in the macOS Keychain){_RESET}"
+    print(f"  {_DIM}Claude Code{_RESET}    {cc_str}")
+    print()
+
+    if resolved["mode"] == "none":
+        print(f"  {_YELLOW}No usable auth:{_RESET} {resolved['reason']}.")
+        print(f"  {_DIM}Run{_RESET} {_CYAN}watchdog auth set{_RESET} {_DIM}(API key) or{_RESET} {_CYAN}claude{_RESET} {_DIM}(subscription login).{_RESET}")
+    elif mode == "subscription" and os.environ.get(meta["env"]):
+        print(f"  {_YELLOW}Warning:{_RESET} ${meta['env']} is set — the Agent SDK uses it before the")
+        print(f"  {_DIM}subscription login, so runs would be metered despite subscription mode.{_RESET}")
+    else:
+        billed = "metered API key" if resolved["mode"] == "api-key" else "Claude Code subscription (not metered)"
+        print(f"  {_DIM}Runs will authenticate with:{_RESET} {_BOLD}{billed}{_RESET}")
+    print()
+
+
+def _use(mode: str | None) -> None:
+    if mode not in _MODES:
+        sys.exit(f"Error: mode must be one of: {', '.join(_MODES)}")
+    state = _load_state()
+    state["mode"] = mode
+    _save_state(state)
+    print(f"\n  {_GREEN}Auth mode:{_RESET} {_BOLD}{mode}{_RESET}\n")
+
+    meta = _PROVIDERS["anthropic"]
+    if mode == "subscription":
+        if not claude_code_logged_in():
+            print(f"  {_YELLOW}Note:{_RESET} Claude Code login not detected — run {_CYAN}claude{_RESET} to log in")
+            print(f"  {_DIM}(or it may be in the macOS Keychain, which can't be checked here).{_RESET}")
+        if os.environ.get(meta["env"]):
+            print(f"  {_YELLOW}Warning:{_RESET} ${meta['env']} is set and the SDK uses it first — unset it to avoid metering.")
+        print(f"  {_DIM}Subscription mode runs watchdog under your own Claude login. Anthropic's terms")
+        print(f"  restrict distributing SDK products that rely on claude.ai login — for a shared/")
+        print(f"  deployed tool, use api-key mode (metered) or seek Anthropic approval.{_RESET}\n")
+    elif mode == "api-key" and not get_api_key():
+        print(f"  {_DIM}No key set yet —{_RESET} {_CYAN}watchdog auth set{_RESET}{_DIM}.{_RESET}\n")
+
+
+def _set(provider: str) -> None:
+    meta = _PROVIDERS[provider]
+    if os.environ.get(meta["env"]):
+        print(f"\n  {_YELLOW}Note:{_RESET} ${meta['env']} is set in your environment and "
+              f"will take precedence over a stored key.")
+    try:
+        key = getpass(f"\n  Paste {meta['label']} API key (hidden): ").strip()
+    except (EOFError, KeyboardInterrupt):
+        print()
+        return
+    if not key:
+        print(f"\n  {_DIM}No key entered — nothing changed.{_RESET}\n")
+        return
+    if not key.startswith(meta["prefix"]):
+        print(f"\n  {_YELLOW}Warning:{_RESET} key doesn't start with '{meta['prefix']}' — storing it anyway.")
+    state = _load_state()
+    state["keys"][provider] = key
+    _save_state(state)
+    print(f"\n  {_GREEN}Stored:{_RESET} {_BOLD}{provider}{_RESET} {_CYAN}{_mask(key)}{_RESET}")
+    if state.get("mode") == "subscription":
+        print(f"  {_DIM}Auth mode is 'subscription', so this key won't be used. Switch with{_RESET} {_CYAN}watchdog auth use api-key{_RESET}{_DIM}.{_RESET}")
+    print()
+
+
+def _get(provider: str) -> None:
+    meta = _PROVIDERS[provider]
+    key = get_api_key(provider)
+    print()
+    if not key:
+        print(f"  {_BOLD}{provider}{_RESET}  {_YELLOW}(not set){_RESET}")
+        print(f"  {_DIM}Set it with:{_RESET} {_CYAN}watchdog auth set {provider}{_RESET}")
+    else:
+        where = f"${meta['env']}" if os.environ.get(meta["env"]) else "stored credential"
+        print(f"  {_BOLD}{provider}{_RESET}  {_CYAN}{_mask(key)}{_RESET}  {_DIM}({where}){_RESET}")
+    print()
+
+
+def _remove(provider: str) -> None:
+    state = _load_state()
+    if provider not in state["keys"]:
+        print(f"\n  {_DIM}No stored key for '{provider}'.{_RESET}\n")
+        return
+    del state["keys"][provider]
+    _save_state(state)
+    print(f"\n  {_GREEN}Removed:{_RESET} stored key for {_BOLD}{provider}{_RESET}\n")
+    if os.environ.get(_PROVIDERS[provider]["env"]):
+        print(f"  {_YELLOW}Note:{_RESET} ${_PROVIDERS[provider]['env']} is still set in your environment.\n")
+
+
+def cmd_auth(args) -> None:
+    action = getattr(args, "action", None)
+    target = getattr(args, "target", None)
+
+    if action in (None, "status"):
+        _status()
+        return
+    if action == "use":
+        _use(target)
+        return
+
+    provider = target or "anthropic"
+    if provider not in _PROVIDERS:
+        sys.exit(f"Error: unknown provider '{provider}'. Known: {', '.join(_PROVIDERS)}")
+    {"set": _set, "get": _get, "remove": _remove}[action](provider)

--- a/src/watchdog/cmd/base.py
+++ b/src/watchdog/cmd/base.py
@@ -453,6 +453,7 @@ def _print_banner() -> None:
         ("Settings", [
             ("setup",      "Set up Watchdog after installation"),
             ("configure",  "View or change configuration"),
+            ("auth",       "Manage API keys for model backends"),
             ("about",      "Show version and project links"),
         ]),
     ]

--- a/src/watchdog/setup_cmd.py
+++ b/src/watchdog/setup_cmd.py
@@ -297,7 +297,11 @@ def run(force: bool = False) -> None:
         ) + "\n"
     )
 
-    # 8. Done
+    # 8. Authentication
+    from watchdog.cmd.auth import setup_auth_interactive
+    setup_auth_interactive()
+
+    # 9. Done
     reload_hint = f"{_CYAN}source {profile}{_RESET}" if profile else "reload your shell"
     print()
     print(f"{_GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━{_RESET}")

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,4 +1,4 @@
-"""Tests for `watchdog auth` — modes, API key storage, env precedence, masking, perms."""
+"""Tests for `watchdog auth` — modes, setup picker, API key storage, env precedence."""
 
 import os
 import stat
@@ -41,7 +41,7 @@ def test_credentials_file_is_0600(home, monkeypatch):
 
 
 def test_env_var_takes_precedence(home, monkeypatch):
-    auth._save_state({"mode": "auto", "keys": {"anthropic": "sk-ant-stored"}})
+    auth._save_state({"mode": "api-key", "keys": {"anthropic": "sk-ant-stored"}})
     monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-fromenv")
     assert auth.get_api_key("anthropic") == "sk-ant-fromenv"
 
@@ -53,7 +53,7 @@ def test_empty_key_not_stored(home, monkeypatch):
 
 
 def test_remove_deletes_stored_key(home):
-    auth._save_state({"mode": "auto", "keys": {"anthropic": "sk-ant-stored"}})
+    auth._save_state({"mode": "api-key", "keys": {"anthropic": "sk-ant-stored"}})
     auth.cmd_auth(_ns("remove"))
     assert auth.get_api_key("anthropic") is None
 
@@ -73,7 +73,7 @@ def test_set_does_not_clobber_mode(home, monkeypatch):
 # ── masking ───────────────────────────────────────────────────────────────────
 
 def test_get_masks_and_reports_source(home, capsys):
-    auth._save_state({"mode": "auto", "keys": {"anthropic": "sk-ant-api03-abcdefghij1234"}})
+    auth._save_state({"mode": "api-key", "keys": {"anthropic": "sk-ant-api03-abcdefghij1234"}})
     auth.cmd_auth(_ns("get"))
     out = capsys.readouterr().out
     assert "stored credential" in out
@@ -88,8 +88,15 @@ def test_unknown_provider_errors(home):
 
 # ── modes ─────────────────────────────────────────────────────────────────────
 
-def test_default_mode_is_auto(home):
-    assert auth._load_state()["mode"] == "auto"
+def test_default_mode_is_unconfigured(home):
+    assert auth._load_state()["mode"] is None
+
+
+def test_status_unconfigured_points_to_setup(home, capsys):
+    auth.cmd_auth(_ns())
+    out = capsys.readouterr().out
+    assert "Not configured" in out
+    assert "watchdog setup" in out
 
 
 def test_use_persists_mode(home):
@@ -99,30 +106,71 @@ def test_use_persists_mode(home):
 
 def test_use_rejects_unknown_mode(home):
     with pytest.raises(SystemExit):
-        auth.cmd_auth(_ns("use", "bogus"))
+        auth.cmd_auth(_ns("use", "auto"))   # 'auto' is no longer a mode
 
 
-def test_resolve_auto_prefers_key(home, monkeypatch):
-    monkeypatch.setattr(auth, "claude_code_logged_in", lambda: True)
-    auth._save_state({"mode": "auto", "keys": {"anthropic": "sk-ant-k"}})
-    assert auth.resolve_auth() == {"mode": "api-key", "key": "sk-ant-k"}
-
-
-def test_resolve_auto_falls_back_to_subscription(home, monkeypatch):
-    monkeypatch.setattr(auth, "claude_code_logged_in", lambda: True)
-    assert auth.resolve_auth() == {"mode": "subscription"}
-
-
-def test_resolve_auto_none_when_nothing_available(home):
-    # home fixture already stubs claude_code_logged_in → False, env key cleared
+def test_resolve_unconfigured_is_none(home):
     assert auth.resolve_auth()["mode"] == "none"
 
 
-def test_resolve_subscription_mode_ignores_key(home):
+def test_resolve_subscription_ignores_key(home):
     auth._save_state({"mode": "subscription", "keys": {"anthropic": "sk-ant-k"}})
     assert auth.resolve_auth() == {"mode": "subscription"}
 
 
-def test_resolve_api_key_mode_without_key_is_none(home):
+def test_resolve_api_key_with_key(home):
+    auth._save_state({"mode": "api-key", "keys": {"anthropic": "sk-ant-k"}})
+    assert auth.resolve_auth() == {"mode": "api-key", "key": "sk-ant-k"}
+
+
+def test_resolve_api_key_without_key_is_none(home):
     auth._save_state({"mode": "api-key", "keys": {}})
     assert auth.resolve_auth()["mode"] == "none"
+
+
+# ── Claude Code login detection ───────────────────────────────────────────────
+
+def test_keychain_check_skipped_off_darwin(monkeypatch):
+    monkeypatch.setattr(auth.sys, "platform", "linux")
+    assert auth._keychain_has_claude_creds() is False
+
+
+def test_keychain_check_handles_missing_security_binary(monkeypatch):
+    monkeypatch.setattr(auth.sys, "platform", "darwin")
+    monkeypatch.setattr(auth.subprocess, "run",
+                        lambda *a, **k: (_ for _ in ()).throw(FileNotFoundError()))
+    assert auth._keychain_has_claude_creds() is False
+
+
+def test_logged_in_true_via_keychain_when_file_absent(tmp_path, monkeypatch):
+    monkeypatch.setattr(auth, "_claude_code_creds_path", lambda: tmp_path / "nope")
+    monkeypatch.setattr(auth, "_keychain_has_claude_creds", lambda: True)
+    assert auth.claude_code_logged_in() is True
+
+
+def test_logged_in_false_when_neither_present(tmp_path, monkeypatch):
+    monkeypatch.setattr(auth, "_claude_code_creds_path", lambda: tmp_path / "nope")
+    monkeypatch.setattr(auth, "_keychain_has_claude_creds", lambda: False)
+    assert auth.claude_code_logged_in() is False
+
+
+# ── setup picker ──────────────────────────────────────────────────────────────
+
+def test_setup_picks_subscription(home, monkeypatch):
+    monkeypatch.setattr("builtins.input", lambda *a: "1")
+    auth.setup_auth_interactive(interactive=True)
+    assert auth._load_state()["mode"] == "subscription"
+
+
+def test_setup_picks_api_key_and_stores(home, monkeypatch):
+    monkeypatch.setattr("builtins.input", lambda *a: "2")
+    monkeypatch.setattr(auth, "getpass", lambda *a, **k: "sk-ant-setupkey-123456")
+    auth.setup_auth_interactive(interactive=True)
+    state = auth._load_state()
+    assert state["mode"] == "api-key"
+    assert state["keys"]["anthropic"] == "sk-ant-setupkey-123456"
+
+
+def test_setup_noninteractive_leaves_unconfigured(home):
+    auth.setup_auth_interactive(interactive=False)
+    assert auth._load_state()["mode"] is None

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,128 @@
+"""Tests for `watchdog auth` — modes, API key storage, env precedence, masking, perms."""
+
+import os
+import stat
+import types
+
+import pytest
+
+from watchdog.cmd import auth, base
+
+
+@pytest.fixture
+def home(tmp_path, monkeypatch):
+    """Redirect WATCHDOG_HOME, clear the real env key, assume Claude Code logged out."""
+    monkeypatch.setattr(base, "WATCHDOG_HOME", tmp_path)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.setattr(auth, "claude_code_logged_in", lambda: False)
+    return tmp_path
+
+
+def _ns(action=None, target=None):
+    return types.SimpleNamespace(action=action, target=target)
+
+
+# ── key storage ───────────────────────────────────────────────────────────────
+
+def test_get_api_key_unset(home):
+    assert auth.get_api_key("anthropic") is None
+
+
+def test_set_then_resolve_stored(home, monkeypatch):
+    monkeypatch.setattr(auth, "getpass", lambda *a, **k: "sk-ant-test-1234567890")
+    auth.cmd_auth(_ns("set"))
+    assert auth.get_api_key("anthropic") == "sk-ant-test-1234567890"
+
+
+def test_credentials_file_is_0600(home, monkeypatch):
+    monkeypatch.setattr(auth, "getpass", lambda *a, **k: "sk-ant-test-1234567890")
+    auth.cmd_auth(_ns("set"))
+    assert stat.S_IMODE(os.stat(auth._credentials_path()).st_mode) == 0o600
+
+
+def test_env_var_takes_precedence(home, monkeypatch):
+    auth._save_state({"mode": "auto", "keys": {"anthropic": "sk-ant-stored"}})
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-fromenv")
+    assert auth.get_api_key("anthropic") == "sk-ant-fromenv"
+
+
+def test_empty_key_not_stored(home, monkeypatch):
+    monkeypatch.setattr(auth, "getpass", lambda *a, **k: "   ")
+    auth.cmd_auth(_ns("set"))
+    assert auth.get_api_key("anthropic") is None
+
+
+def test_remove_deletes_stored_key(home):
+    auth._save_state({"mode": "auto", "keys": {"anthropic": "sk-ant-stored"}})
+    auth.cmd_auth(_ns("remove"))
+    assert auth.get_api_key("anthropic") is None
+
+
+def test_remove_when_absent_is_noop(home, capsys):
+    auth.cmd_auth(_ns("remove"))
+    assert "No stored key" in capsys.readouterr().out
+
+
+def test_set_does_not_clobber_mode(home, monkeypatch):
+    auth._save_state({"mode": "subscription", "keys": {}})
+    monkeypatch.setattr(auth, "getpass", lambda *a, **k: "sk-ant-test-1234567890")
+    auth.cmd_auth(_ns("set"))
+    assert auth._load_state()["mode"] == "subscription"
+
+
+# ── masking ───────────────────────────────────────────────────────────────────
+
+def test_get_masks_and_reports_source(home, capsys):
+    auth._save_state({"mode": "auto", "keys": {"anthropic": "sk-ant-api03-abcdefghij1234"}})
+    auth.cmd_auth(_ns("get"))
+    out = capsys.readouterr().out
+    assert "stored credential" in out
+    assert "abcdefghij" not in out       # middle hidden
+    assert "sk-ant-api" in out and "1234" in out
+
+
+def test_unknown_provider_errors(home):
+    with pytest.raises(SystemExit):
+        auth.cmd_auth(_ns("get", target="bogus"))
+
+
+# ── modes ─────────────────────────────────────────────────────────────────────
+
+def test_default_mode_is_auto(home):
+    assert auth._load_state()["mode"] == "auto"
+
+
+def test_use_persists_mode(home):
+    auth.cmd_auth(_ns("use", "subscription"))
+    assert auth._load_state()["mode"] == "subscription"
+
+
+def test_use_rejects_unknown_mode(home):
+    with pytest.raises(SystemExit):
+        auth.cmd_auth(_ns("use", "bogus"))
+
+
+def test_resolve_auto_prefers_key(home, monkeypatch):
+    monkeypatch.setattr(auth, "claude_code_logged_in", lambda: True)
+    auth._save_state({"mode": "auto", "keys": {"anthropic": "sk-ant-k"}})
+    assert auth.resolve_auth() == {"mode": "api-key", "key": "sk-ant-k"}
+
+
+def test_resolve_auto_falls_back_to_subscription(home, monkeypatch):
+    monkeypatch.setattr(auth, "claude_code_logged_in", lambda: True)
+    assert auth.resolve_auth() == {"mode": "subscription"}
+
+
+def test_resolve_auto_none_when_nothing_available(home):
+    # home fixture already stubs claude_code_logged_in → False, env key cleared
+    assert auth.resolve_auth()["mode"] == "none"
+
+
+def test_resolve_subscription_mode_ignores_key(home):
+    auth._save_state({"mode": "subscription", "keys": {"anthropic": "sk-ant-k"}})
+    assert auth.resolve_auth() == {"mode": "subscription"}
+
+
+def test_resolve_api_key_mode_without_key_is_none(home):
+    auth._save_state({"mode": "api-key", "keys": {}})
+    assert auth.resolve_auth()["mode"] == "none"


### PR DESCRIPTION
First piece of the Python-orchestration epic (#118): the model-backend **auth layer** the `ModelClient` will sit on. No pipeline behavior changes yet — this is the auth plumbing plus its CLI/setup UX.

## What

A `watchdog auth` surface and a `resolve_auth()` resolver that the model backends will call, supporting two auth modes:

- **subscription** — rely on Claude Code's own login (the same credentials the `claude` CLI uses); **not metered**. For running watchdog locally under your own Claude subscription.
- **api-key** — a metered `ANTHROPIC_API_KEY` (env var, or stored here).

The mode is an **explicit choice made during `watchdog setup`** (a subscription-vs-key picker), with a real *unconfigured* state — `watchdog auth` and `resolve_auth()` point an unconfigured user to `watchdog setup`.

## Pieces

- **`watchdog auth`** — `status` (default) · `use <mode>` · `set`/`get`/`remove [provider]`. Keys stored in `~/.watchdog/credentials.json` (**0600**), separate from `config.json` so secrets never appear in `watchdog configure` output. `set` prompts hidden (getpass); display is always masked.
- **Env precedence** — `ANTHROPIC_API_KEY` wins over a stored key, matching the SDK's own resolution. `auth.get_api_key()` / `auth.resolve_auth()` are the entry points #118's backend calls.
- **`watchdog setup`** now asks how to authenticate and persists the choice (storing a pasted key for api-key mode).
- **macOS Keychain detection** — on macOS the Agent SDK reads the Claude Code login from the Keychain (`Claude Code-credentials`), not the credentials file; `claude_code_logged_in()` queries it (attributes only — no secret read, no prompt).
- **Subscription-mode guardrails** — surfaces the gotcha that a stray `ANTHROPIC_API_KEY` overrides subscription mode (the SDK checks it first), and notes Anthropic's terms restrict *distributing* SDK products that rely on claude.ai login.

## Auth/cost note (corrects #118's earlier premise)

The Agent SDK authenticates with either a metered API key **or** Claude Code's login (subscription) — the latter is auto-detected when no key is set. Subscription auth is not metered but is governed by the consumer/Max terms (interactive use); distributing an SDK product on subscription login needs Anthropic approval. Both modes are supported here; the choice is the user's.

## Verification

- 25 tests in `tests/test_auth.py` (modes, setup picker, env precedence, 0600 perms, masking, Keychain detection incl. platform guard + missing-binary handling); full suite **435 green**.
- Spike-0 confirmed out of band: the Agent SDK runs a hello-world via the subscription login with no API key.

## Docs

README command reference updated. Fuller setup-flow docs are deferred to when a backend actually consumes the key (the rest of #118).

🤖 Generated with [Claude Code](https://claude.com/claude-code)