### PR TITLE
Classify on the first N pages, configurable (default 5)

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -168,11 +168,13 @@ By default Watchdog uses Sonnet for extraction and for the post-ingest step (syn
 watchdog ingest --extractor-model haiku   # faster, cheaper extraction
 watchdog ingest --finalizer-model opus     # stronger synthesis + briefing
 watchdog ingest --concurrency 2            # fewer docs in parallel (if you hit rate limits)
+watchdog ingest --classify-pages 10        # show the classifier more pages of each document
 ```
 
 ```bash
 watchdog configure extractor_model haiku
 watchdog configure extract_concurrency 2
+watchdog configure classify_pages 10
 ```
 
 For each document, the pipeline:

--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ For a full end-to-end walkthrough of a first investigation, see [GETTING_STARTED
 | `watchdog ingest --extractor-model M` | Override the extraction model for this run (`sonnet`/`opus`/`haiku`; default from `watchdog configure`) |
 | `watchdog ingest --finalizer-model M` | Override the post-ingest model for this run — synthesis + timeline + briefing (`sonnet`/`opus`/`haiku`; default from `watchdog configure`) |
 | `watchdog ingest --concurrency N` | Documents extracted in parallel for this run (default from `watchdog configure`: 5) |
+| `watchdog ingest --classify-pages N` | Pages shown to the document classifier for this run (default from `watchdog configure`: 5) |
 | `watchdog context [name]` | Open Claude Code with the context seeding skill; omit name when inside the vault |
 | `watchdog context --model M` | Override the model for context seeding (`sonnet`/`opus`/`haiku`, default: `sonnet`) |
 | `watchdog watch [name]` | Watch `_INCOMING/` and chew files automatically as they arrive; omit name when inside the project directory |
@@ -448,6 +449,7 @@ watchdog configure <key> <value>
 | `extractor_model` | `sonnet` | Claude model for document extraction. Options: `haiku`, `sonnet`, `opus`. Per-run override: `--extractor-model`. |
 | `finalizer_model` | `sonnet` | Claude model for post-ingest — entity synthesis (Summary + Analysis for entities in ≥2 documents) + timeline reconciliation + briefing. Options: `haiku`, `sonnet`, `opus`. Per-run override: `--finalizer-model`. |
 | `extract_concurrency` | `5` | Documents extracted in parallel during `watchdog ingest`. Lower it if you hit model rate limits; raise it for throughput. Per-run override: `--concurrency`. |
+| `classify_pages` | `5` | Leading pages of each document shown to the classifier (`min(page_count, this)`). More pages classify ambiguous documents better at a small extra cost on the cheap classifier model. Per-run override: `--classify-pages`. |
 
 **Examples:**
 

--- a/src/watchdog/cli.py
+++ b/src/watchdog/cli.py
@@ -287,6 +287,8 @@ def main() -> None:
                           help="Model for synthesis + timeline + briefing — overrides watchdog configure (default: sonnet)")
     p_ingest.add_argument("--concurrency", type=int, default=None,
                           help="Documents extracted in parallel — overrides watchdog configure (default: 5)")
+    p_ingest.add_argument("--classify-pages", type=int, default=None, dest="classify_pages",
+                          help="Pages shown to the document classifier — overrides watchdog configure (default: 5)")
     p_ingest.set_defaults(func=cmd_ingest)
 
     p_context = sub.add_parser("context", help="Open Claude Code to seed investigation context from _CONTEXT/")

--- a/src/watchdog/cmd/base.py
+++ b/src/watchdog/cmd/base.py
@@ -112,6 +112,7 @@ _CMD_HELP: dict[str, dict] = {
             ("--extractor-model M",  "Override the extraction model for this run (sonnet/opus/haiku; default from watchdog configure)"),
             ("--finalizer-model M",  "Override the synthesis + timeline + briefing model for this run (sonnet/opus/haiku; default from watchdog configure)"),
             ("--concurrency N",      "Documents extracted in parallel for this run (default from watchdog configure: 5)"),
+            ("--classify-pages N",   "Pages shown to the document classifier for this run (default from watchdog configure: 5)"),
         ],
     },
     "context": {

--- a/src/watchdog/cmd/ingest.py
+++ b/src/watchdog/cmd/ingest.py
@@ -122,6 +122,11 @@ def cmd_ingest(args, *, confirm: bool = True) -> None:
         concurrency = int(getattr(args, "concurrency", None) or config.get("extract_concurrency") or 5)
     except (TypeError, ValueError):
         concurrency = 5
+    try:
+        classify_pages = int(getattr(args, "classify_pages", None) or config.get("classify_pages") or 5)
+    except (TypeError, ValueError):
+        classify_pages = 5
+    classify_pages = max(1, classify_pages)
 
     from watchdog.pipeline.ingest_setup import run as is_run
     result = is_run(vault)
@@ -164,7 +169,8 @@ def cmd_ingest(args, *, confirm: bool = True) -> None:
     print(f"  {_DIM}Press {_RESET}{_CYAN}Ctrl+C{_RESET}{_DIM} to stop; finished documents are kept.{_RESET}\n")
     try:
         summary = asyncio.run(orchestrate.run(
-            vault, concurrency=concurrency, extract_model=extract_model, post_model=post_model))
+            vault, concurrency=concurrency, extract_model=extract_model, post_model=post_model,
+            classify_pages=classify_pages))
     except KeyboardInterrupt:
         # Fallback only — orchestrate.run normally traps SIGINT itself and returns a
         # cancelled summary. This catches a Ctrl+C in the brief window before/after that.

--- a/src/watchdog/cmd/setup.py
+++ b/src/watchdog/cmd/setup.py
@@ -94,6 +94,18 @@ _CONFIGURE_KEYS = {
         "default": 5,
         "min": 1,
     },
+    "classify_pages": {
+        "short": "Pages shown to the document classifier during `watchdog ingest` (default: 5)",
+        "help": (
+            "How many leading pages of each document the classifier reads to pick a record skill.\n"
+            "  Uses min(page_count, this). More pages classify ambiguous documents better (e.g. a\n"
+            "  cover letter before the real filing) at a small extra cost on the cheap classifier model.\n"
+            "  Override for one run with `watchdog ingest --classify-pages N`. Default: 5. Minimum: 1."
+        ),
+        "type": "int",
+        "default": 5,
+        "min": 1,
+    },
     "chunk_size": {
         "short": "Pages per chunk when splitting large PDFs for parallel processing (default: 40)",
         "help": (

--- a/src/watchdog/pipeline/orchestrate.py
+++ b/src/watchdog/pipeline/orchestrate.py
@@ -30,7 +30,10 @@ DEFAULT_CONCURRENCY = 5
 def _say(msg: str) -> None:
     """Print a styled progress line to the terminal (indented per the CLI style guide)."""
     print(f"  {msg}", flush=True)
-_CLASSIFY_EXCERPT_CHARS = 6000
+DEFAULT_CLASSIFY_PAGES = 5
+# Safety cap on classifier input: bounds a pathological single huge page; the page
+# count (classify_pages) is the primary limiter, so keep this generous.
+_CLASSIFY_EXCERPT_CHARS = 24000
 # 24-bit RGB ints for Obsidian graph entity-type colour groups.
 _GRAPH_PALETTE = [0x4C9A2A, 0xC0392B, 0x2980B9, 0x8E44AD, 0xD35400,
                   0x16A085, 0xF39C12, 0x7F8C8D, 0x2C3E50, 0xC2185B]
@@ -196,7 +199,8 @@ def _fail(vault: Path, sha: str, filename: str, reason: str) -> dict:
 
 
 async def _extract_document(vault: Path, sha: str, brief: str | None,
-                            extract_model: str, classify_model: str) -> dict:
+                            extract_model: str, classify_model: str,
+                            classify_pages: int = DEFAULT_CLASSIFY_PAGES) -> dict:
     pf = preflight.run(vault, sha)
     if pf.get("error"):
         return _fail(vault, sha, "", pf["error"])
@@ -205,9 +209,12 @@ async def _extract_document(vault: Path, sha: str, brief: str | None,
         return {"sha256": sha, "filename": pf.get("filename"), "status": "skipped"}
 
     filename = pf["filename"]
-    page_count = pf.get("page_count") or len(pf.get("pages", []))
+    pages = pf.get("pages", [])
+    page_count = pf.get("page_count") or len(pages)
     _say(f"{_DIM}→  {filename}  classifying ({page_count} page{'s' if page_count != 1 else ''})…{_RESET}")
-    skill = await _classify(vault, _pages_text(pf.get("pages", []))[:_CLASSIFY_EXCERPT_CHARS], classify_model)
+    # Classify on the first N pages (page-aware, not a mid-page char cut); the char cap is a guard.
+    excerpt = _pages_text(pages[:max(1, classify_pages)])[:_CLASSIFY_EXCERPT_CHARS]
+    skill = await _classify(vault, excerpt, classify_model)
     skill_text = _read_skill(vault, skill)
     skill_label = skill.removesuffix(".md")
 
@@ -351,11 +358,13 @@ async def _post_ingest(vault: Path, results: list, brief: str | None, post_model
 
 async def run(vault: Path, *, concurrency: int = DEFAULT_CONCURRENCY,
               extract_model: str = "sonnet", post_model: str = "sonnet",
-              classify_model: str = "haiku") -> dict:
+              classify_model: str = "haiku",
+              classify_pages: int = DEFAULT_CLASSIFY_PAGES) -> dict:
     """Extract every queued document (bounded by `concurrency`), then post-ingest.
 
     `extract_model` drives extraction (whole-doc + section); `post_model` drives
-    synthesis/timeline/briefing; `classify_model` the cheap document classifier.
+    synthesis/timeline/briefing; `classify_model` the cheap document classifier,
+    which sees the first `classify_pages` pages of each document.
     """
     queue_dir = vault / ".watchdog" / "queue"
     shas = [f.stem for f in sorted(queue_dir.glob("*.json"))] if queue_dir.exists() else []
@@ -373,7 +382,8 @@ async def run(vault: Path, *, concurrency: int = DEFAULT_CONCURRENCY,
             if cancelled.is_set():
                 return {"sha256": sha, "filename": "", "status": "cancelled"}
             try:
-                return await _extract_document(vault, sha, brief, extract_model, classify_model)
+                return await _extract_document(vault, sha, brief, extract_model, classify_model,
+                                               classify_pages)
             except asyncio.CancelledError:           # ctrl+c mid-document — queue file stays
                 return {"sha256": sha, "filename": "", "status": "cancelled"}
             except Exception as e:                   # one bad doc must not sink the batch

--- a/tests/test_orchestrate.py
+++ b/tests/test_orchestrate.py
@@ -148,6 +148,38 @@ def test_orchestrator_updates_graph_colours(tmp_path, monkeypatch):
     assert "path:entities/company" in queries     # Acme Corp → entities/company/
 
 
+def test_classifier_sees_only_first_n_pages(tmp_path, monkeypatch):
+    """classify_pages bounds the classifier excerpt to the first N pages (page-aware)."""
+    vault = make_vault(tmp_path)
+    qdir = vault / ".watchdog" / "queue"
+    qdir.mkdir(parents=True, exist_ok=True)
+    pages = [{"page": i, "markdown": f"distinctword{i}"} for i in (1, 2, 3)]
+    (qdir / "abc123.json").write_text(json.dumps({
+        "sha256": "abc123", "filename": "test-doc.pdf", "source_path": "_INCOMING/test-doc.pdf",
+        "page_count": 3, "pages": pages,
+        "near_dup": {"near_duplicates": [], "top_similarity": 0.0},
+    }))
+    (vault / "_INCOMING" / "test-doc.pdf").write_text("dummy")
+
+    seen = {}
+    async def fake(*, task, prompt, schema, model=None, backend=None, max_retries=1):
+        if task == "classify":
+            seen["prompt"] = prompt
+        parsed = {
+            "classify": {"skill": "general-records.md"},
+            "extract": _extraction(),
+            "entity-synthesis": {"entity_syntheses": []},
+            "briefing": {"investigation_status": "x", "what_was_ingested": []},
+        }.get(task, {"events": []})
+        return model_client.ModelResult(parsed=parsed, text="", model="m",
+                                        backend="b", auth_mode="subscription", cost_usd=0.0)
+    monkeypatch.setattr(orchestrate.model_client, "acomplete_json", fake)
+
+    asyncio.run(orchestrate.run(vault, classify_pages=2))
+    assert "distinctword1" in seen["prompt"] and "distinctword2" in seen["prompt"]
+    assert "distinctword3" not in seen["prompt"]   # page 3 excluded
+
+
 def test_orchestrator_cancels_gracefully_on_sigint(tmp_path, monkeypatch):
     """Ctrl+C during extraction → cancelled summary, no traceback, unfinished docs keep
     their queue file, and post-ingest is skipped."""


### PR DESCRIPTION
Limits the document classifier to the **first N pages** of each document, configurable, defaulting to 5.

## Why

The classifier previously saw `_pages_text(all_pages)[:6000 chars]` — roughly the first ~1.5 pages, truncated mid-page. That misclassifies documents whose type only becomes clear after a cover page (e.g. a cover letter in front of the actual filing). Reading the first `min(page_count, classify_pages)` whole pages is page-aware and gives the classifier a fuller view of the opening.

This is a **classification-quality/robustness** change, not a cost reduction — at `n=5` it usually feeds the classifier a bit *more* than the old 6000-char cap. The classifier runs on the cheap model (haiku), so the extra input is negligible.

## What's here

- `orchestrate.py`: classify excerpt is now the first `min(page_count, classify_pages)` pages; the internal char cap is raised to 24k purely as a safety guard against a pathological single huge page (so it doesn't pre-empt 5 normal pages).
- New `classify_pages` config key (default 5) + `--classify-pages N` per-run flag, threaded `cmd_ingest → orchestrate.run → _extract_document`.
- Docs: README commands + configuration tables, GETTING_STARTED examples, `base.py` ingest help.
- Test: asserts pages beyond the limit are excluded from the classifier excerpt.

464 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
