### PR TITLE
Fall back to sectioned extraction when whole-doc output overruns

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -144,8 +144,17 @@ carry-forward block (entities-so-far + observations) in each section's prompt, t
 combined by `merge.merge_extractions` into a single extraction JSON that goes through the
 same post-flight / `write_vault` path.
 
+**Output-overrun fallback.** Sectioning is gated on *input* size, but a moderate-input,
+entity-dense document can overrun the model's *output* ceiling — the agent-SDK backend
+can't cap output tokens, so the JSON truncates and post-flight rejects it. When
+whole-document extraction fails on a **multi-page** document, the orchestrator
+force-sections it (`section.run(force_budget=…)`, capped at half the doc so it yields ≥2
+sections) and retries on the sectioned path — which bounds per-call output — before giving
+up. See D19.
+
 **Failure handling.** The model adapter raises if it can't get schema-valid JSON; a doc
-whose extraction or post-flight fails is logged to `.watchdog/Registry/ingest.log` and
+whose extraction or post-flight fails (after the output-overrun fallback, for multi-page
+docs) is logged to `.watchdog/Registry/ingest.log` and
 cleaned via `abort.run` (`pipeline/abort.py`) — staging/section temp removed, queue file
 moved to `.watchdog/queue/_failed/`, registry untouched. One bad document never sinks the
 batch; move the queue file back from `_failed/` to retry.
@@ -401,4 +410,5 @@ registry for every document would be wasteful. The manifest is the cheap index.
 | D15 | Runaway guard + `ingest-abort` (§5) | A stuck subagent bails (`STATUS: failed`) instead of wedging the batch; clean bail leaves no partial vault writes, so the doc re-ingests cleanly | A failed doc must be manually moved back from `queue/_failed/` to retry |
 | D16 | ~~Entity synthesis (§8) and finalize (§9) kept as separate subagents, not merged~~ **Superseded by D17.** | Original rationale: synthesis was a per-entity parallel fan-out, finalize a single whole-batch agent; merging would serialize entity work and re-concentrate fragments + scratchpads + timeline into one context. This held while synthesis was a fan-out — but the fan-out itself proved to be the cost problem (see D17) | — |
 | D17 | Merge synthesis + finalize into one post-ingest subagent fed a Python-built bundle (§8, §9) | The per-entity fan-out launched one subagent per `count ≥ 2` entity (36 in a representative run), each paying startup + preamble cache-write to do a few hundred tokens of judgement — ~$5 of a $19 run. D16 feared merging would re-bloat context, but fragments are *compact digests* (D8), so one agent reading the whole bundle stays small; the cost win (one agent, one cached preamble) dominates the serialization cost. The bundle's `build_bundle`/`apply_bundle` survive into D18; only the surrounding subagent is gone | A very large batch could need bundle splitting by token budget (not yet implemented) |
+| D19 | Force-section on whole-doc output overrun (§5) | Sectioning triggers on *input* size (`section_token_threshold`), but truncation is *output*-driven — a moderate-input, entity-dense doc overruns the model's output ceiling on the agent-SDK backend (which can't cap output), truncating the JSON and escalating the retry toward a pricier tier. On a multi-page doc whose whole-doc extraction is rejected, the orchestrator re-runs it through the sectioned path with a small forced budget (≥2 sections) to bound per-call output | Adds one (failed) whole-doc attempt before the fallback; single-page docs can't be split, so they still just fail |
 | D18 | Python orchestrator; the model is called only for reasoning (#118 W3) | A Claude Code skill session *is* a model loop, so the orchestrator (and per-turn coordination) cost model tokens even for pure dispatch — the orchestrator alone ran $1–3+ of a representative batch, ~38–86% of pipeline spend was per-turn context re-send. Moving the loop to Python (`orchestrate.py`) calling the model only for classify/extract/synthesis/timeline-dedup/briefing removes that floor and lets each task route to a backend + tier (`model_client`, D-auth #119). Supersedes the subagent split (D3) and the off-orchestrator finalize (D14) | Extraction now runs the Claude Agent SDK in-process and parallel concurrency is bounded by subscription/API rate limits (`extract_concurrency` knob); the `claude-api` backend is unproven until a metered key is used |

--- a/src/watchdog/pipeline/orchestrate.py
+++ b/src/watchdog/pipeline/orchestrate.py
@@ -31,6 +31,10 @@ def _say(msg: str) -> None:
     """Print a styled progress line to the terminal (indented per the CLI style guide)."""
     print(f"  {msg}", flush=True)
 DEFAULT_CLASSIFY_PAGES = 5
+# Per-section input budget when falling back to sectioning after a whole-doc extraction
+# overruns the output ceiling. Small, so each section's output stays well under the cap;
+# section.run caps it at half the document so a splittable doc yields ≥2 sections.
+_FALLBACK_SECTION_TOKENS = 15_000
 # Safety cap on classifier input: bounds a pathological single huge page; the page
 # count (classify_pages) is the primary limiter, so keep this generous.
 _CLASSIFY_EXCERPT_CHARS = 24000
@@ -145,7 +149,12 @@ async def _simple_extract(vault, sha, pf, skill_text, brief, model):
     for _ in range(2):
         p = base if not errors else (base + "\n\nThe previous extraction was rejected:\n"
                                      + "\n".join(errors) + "\nReturn a corrected JSON object.")
-        r = await model_client.acomplete_json(task="extract", model=model, prompt=p, schema=schemas.EXTRACTION)
+        try:
+            r = await model_client.acomplete_json(task="extract", model=model, prompt=p, schema=schemas.EXTRACTION)
+        except model_client.ModelError as e:
+            # No valid JSON after the client's own retries — often output truncated on a
+            # dense doc. Report failure so the caller can fall back to sectioning.
+            return extraction, scratchpad, cost, False, [f"extraction returned no valid JSON ({e})"]
         cost += r.cost_usd or 0.0
         extraction = r.parsed
         scratchpad = extraction.pop("scratchpad", "")
@@ -228,6 +237,19 @@ async def _extract_document(vault: Path, sha: str, brief: str | None,
         _say(f"{_DIM}→  {filename}  extracting · {skill_label}…{_RESET}")
         extraction, scratchpad, cost, ok, errors = await _simple_extract(
             vault, sha, pf, skill_text, brief, extract_model)
+        # Whole-document extraction can overrun the model's output ceiling on entity-dense
+        # docs (the agent-SDK backend can't cap output) — the JSON truncates and is rejected.
+        # Fall back to the sectioned path, which bounds per-call output, before giving up.
+        if not ok and page_count > 1:
+            fb = section.run(vault, sha, force_budget=_FALLBACK_SECTION_TOKENS)
+            if fb.get("sectioned"):
+                n_sections = len(fb.get("sections", []))
+                _say(f"{_DIM}↻  {filename}  whole-doc extraction rejected — "
+                     f"re-extracting in {n_sections} sections…{_RESET}")
+                whole_cost = cost
+                extraction, scratchpad, cost, ok, errors = await _extract_sectioned(
+                    vault, sha, pf, skill_text, fb, extract_model)
+                cost += whole_cost   # account for the failed whole-doc attempt
 
     if not ok:
         return _fail(vault, sha, filename, "post-flight rejected: " + "; ".join(errors[:3]))

--- a/src/watchdog/pipeline/section.py
+++ b/src/watchdog/pipeline/section.py
@@ -96,7 +96,14 @@ def char_windows(total: int, size: int, overlap: int) -> list[tuple[int, int]]:
     return windows
 
 
-def run(vault: Path, sha256: str) -> dict:
+def run(vault: Path, sha256: str, *, force_budget: int | None = None) -> dict:
+    """Plan sections for a document.
+
+    Normally threshold-gated: documents at/under `section_token_threshold` are not
+    sectioned. Pass `force_budget` to always section (used as a fallback when
+    whole-document extraction overruns the model's output ceiling) — the per-section
+    budget is capped at half the document so a splittable document yields ≥2 sections.
+    """
     queue_file = vault / ".watchdog" / "queue" / f"{sha256}.json"
     if not queue_file.exists():
         return {"error": f"queue file not found for sha256 {sha256}"}
@@ -110,7 +117,10 @@ def run(vault: Path, sha256: str) -> dict:
     budget = _config_get("section_token_budget", DEFAULT_TOKEN_BUDGET)
     overlap_tokens = _config_get("section_overlap_tokens", DEFAULT_OVERLAP_TOKENS)
 
-    if total_tokens <= threshold:
+    if force_budget is not None:
+        budget = min(force_budget, max(1, total_tokens // 2))   # guarantee ≥2 sections
+        overlap_tokens = min(overlap_tokens, max(0, budget // 4))
+    elif total_tokens <= threshold:
         return {"sectioned": False, "page_count": page_count, "est_tokens": total_tokens}
 
     tmp = vault / ".watchdog" / "tmp"

--- a/tests/test_orchestrate.py
+++ b/tests/test_orchestrate.py
@@ -180,6 +180,66 @@ def test_classifier_sees_only_first_n_pages(tmp_path, monkeypatch):
     assert "distinctword3" not in seen["prompt"]   # page 3 excluded
 
 
+def test_whole_doc_failure_falls_back_to_sectioning(tmp_path, monkeypatch):
+    """A multi-page doc whose whole-doc extraction is rejected is re-extracted in sections."""
+    vault = make_vault(tmp_path)
+    monkeypatch.setattr(orchestrate.section, "_config_get", lambda k, d: d)   # deterministic defaults
+    qdir = vault / ".watchdog" / "queue"
+    qdir.mkdir(parents=True, exist_ok=True)
+    pages = [{"page": 1, "markdown": "Acme part one " * 50},
+             {"page": 2, "markdown": "Acme part two " * 50}]
+    (qdir / "abc123.json").write_text(json.dumps({
+        "sha256": "abc123", "filename": "test-doc.pdf", "source_path": "_INCOMING/test-doc.pdf",
+        "page_count": 2, "pages": pages,
+        "near_dup": {"near_duplicates": [], "top_similarity": 0.0},
+    }))
+    (vault / "_INCOMING" / "test-doc.pdf").write_text("dummy")
+
+    calls = {"extract": 0, "section": 0}
+    sec_first = {
+        "document": {"sha256": "abc123", "filename": "test-doc.pdf", "title": "Acme AR",
+                     "document_type": "Annual Report", "summary": "Acme report.",
+                     "key_facts": [{"fact": "x", "confidence": "high"}]},
+        "entities": [{"id": "acme-corp", "name": "Acme Corp", "type": "Company",
+                      "timeline_events": [], "roles": []}],
+        "morgue_entity_id": "acme-corp", "morgue_document_type": "annual-report",
+        "observations": "sec1",
+    }
+    sec_later = {"entities": [{"id": "acme-corp", "name": "Acme Corp", "type": "Company",
+                              "timeline_events": [], "roles": []}], "observations": "sec2"}
+
+    async def fake(*, task, prompt, schema, model=None, backend=None, max_retries=1):
+        if task == "classify":
+            parsed = {"skill": "general-records.md"}
+        elif task == "extract":
+            calls["extract"] += 1
+            parsed = _extraction(valid=False)                 # whole-doc → postflight rejects
+        elif task == "extract-section":
+            calls["section"] += 1
+            parsed = sec_first if "This is SECTION 1" in prompt else sec_later
+        elif task == "briefing":
+            parsed = {"investigation_status": "x", "what_was_ingested": []}
+        else:
+            parsed = {"entity_syntheses": []} if task == "entity-synthesis" else {"events": []}
+        return model_client.ModelResult(parsed=parsed, text="", model="m",
+                                        backend="b", auth_mode="subscription", cost_usd=0.01)
+    monkeypatch.setattr(orchestrate.model_client, "acomplete_json", fake)
+
+    summary = asyncio.run(orchestrate.run(vault))
+    assert calls["extract"] >= 1 and calls["section"] >= 2     # whole-doc tried, then sectioned
+    assert summary["extracted"] == 1 and summary["failed"] == 0
+    assert (vault / "entities" / "company" / "acme-corp.md").exists()
+
+
+def test_single_page_failure_does_not_section(tmp_path, monkeypatch):
+    """A 1-page doc can't be split, so a rejection just fails (no fallback loop)."""
+    vault = make_vault(tmp_path)
+    _queue_doc(vault)                                          # single page
+    _mock(monkeypatch, extraction=_extraction(valid=False))
+    summary = asyncio.run(orchestrate.run(vault))
+    assert summary["failed"] == 1 and summary["extracted"] == 0
+
+
 def test_orchestrator_cancels_gracefully_on_sigint(tmp_path, monkeypatch):
     """Ctrl+C during extraction → cancelled summary, no traceback, unfinished docs keep
     their queue file, and post-ingest is skipped."""

--- a/tests/test_section.py
+++ b/tests/test_section.py
@@ -113,6 +113,17 @@ def test_run_non_paginated_splits_on_chars(tmp_path, monkeypatch):
     assert len(body) == 800                 # budget 200 tokens * 4 chars
 
 
+def test_run_force_budget_sections_below_threshold(tmp_path, monkeypatch):
+    monkeypatch.setattr(section, "_config_get", _config(threshold=100, budget=200, overlap=0))
+    vault = _vault(tmp_path)
+    _write_queue(vault, "doc1", [{"page": 1, "markdown": "x" * 40},
+                                 {"page": 2, "markdown": "x" * 40}], 2)  # 20 est tokens, under threshold
+    # force_budget sections it anyway, capped at half the doc → ≥2 sections
+    result = section.run(vault, "doc1", force_budget=1000)
+    assert result["sectioned"] is True
+    assert len(result["sections"]) >= 2
+
+
 def test_run_missing_queue_file_errors(tmp_path):
     vault = tmp_path / "vault"
     (vault / ".watchdog").mkdir(parents=True)


### PR DESCRIPTION
Fixes the most expensive failure mode in extraction: entity-dense documents that overrun the model's **output**-token ceiling.

## The problem

On the agent-SDK (subscription) backend we can't cap output tokens, so a dense document's extraction JSON runs to the model's 32k ceiling, **truncates** into invalid JSON, post-flight rejects it, and the retry **escalates toward a pricier tier** — re-emitting another huge JSON. In a measured 5-doc batch, the 2 documents that hit this were the most expensive sessions.

Sectioning already bounds per-call output, but `section.run` only triggers on **input** size (`section_token_threshold`, 120k). The offending docs are *modest input, dense output* (~35k input → 32k+ output), so they slip past the gate and get extracted whole.

## The fix

When whole-document extraction fails on a **multi-page** document, force-section it and retry instead of giving up or re-running the whole thing:

- **`section.run(force_budget=…)`** — section regardless of the input threshold, with the per-section budget capped at half the document so a splittable doc always yields ≥2 sections (smaller sections → smaller per-call output).
- **`_simple_extract`** now returns `ok=False` on a `ModelError` (no valid JSON — usually truncation) instead of raising, so the orchestrator can catch it and fall back.
- **`_extract_document`** re-runs a rejected multi-page doc through the existing sectioned path with a 15k-token forced budget. Single-page docs can't be split, so they still just fail. The failed whole-doc attempt's cost is carried into the total.

No schema change, no quality tradeoff — it only changes what happens *after* a whole-doc extraction is already rejected.

## Notes

- This is finding 3 from the cost analysis. Finding 2 (slimming extractor prose) was measured to be a smaller lever than expected — entity `roles` dominate output, not prose — so it's deliberately **not** here.
- `ARCHITECTURE.md`: new decision-log entry **D19** + a §5 paragraph.
- Tests: forced-section planning, the orchestrator fallback (whole-doc rejected → sectioned → success), and single-page-doesn't-section. 467 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
