### PR TITLE
Model selection: configurable classifier model, no auto-escalation

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -101,7 +101,8 @@ unconfigured), acquires a run lock (`.watchdog/Registry/.ingest-lock`, stale aft
 minutes), scans the queue, and clears the previous run's entity-fragment staging (§8).
 It then runs the Python orchestrator in-process (`asyncio.run(orchestrate.run(...))`) and
 releases the lock in a `finally`. Models and concurrency come from `watchdog configure`
-(`extractor_model`, `finalizer_model`, `extract_concurrency`) or per-run flags.
+(`classifier_model`, `extractor_model`, `finalizer_model`, `extract_concurrency`,
+`classify_pages`) or per-run flags.
 
 A second, finer lock (`.watchdog/Registry/.write-lock`, `flock`) serializes the actual
 registry/note writes so the concurrent document workers write safely.
@@ -120,14 +121,15 @@ registry/note writes so the concurrent document workers write safely.
 1. **Pre-flight** (`preflight.run`, a function call) — packages the page text and the
    candidate existing entities matched by substring against the manifest (no ML), each
    carrying its current note summary + timeline/roles/contradictions digest (§8).
-2. **Classify** — one cheap model call (`model_client.acomplete_json`, haiku) over a text
-   excerpt + the generated `records/_index.md`, returning the closest domain-skill
-   filename (§6). Python reads that one skill and injects it into the extraction prompt.
+2. **Classify** — one cheap model call (`model_client.acomplete_json`, `classifier_model`,
+   default haiku) over the document's first `classify_pages` pages + the generated
+   `records/_index.md`, returning the closest domain-skill filename (§6). Python reads that
+   one skill and injects it into the extraction prompt.
 3. **Extract** — one model call against the `EXTRACTION` schema: title, date, entities
    (deduped against the pre-flight candidates), roles, timeline events, key facts,
    per-entity summary/analysis, contradictions, morgue fields, and a briefing scratchpad.
-   Schema validation + a tier-escalating retry live in `model_client`; the orchestrator
-   adds one post-flight repair retry.
+   Schema validation + a same-model retry live in `model_client` (no automatic tier
+   escalation — see D20); the orchestrator adds one post-flight repair retry.
 4. **Post-flight** (`postflight.run`, a function call) — validates the JSON, applies
    `match_id` merges, and calls `write_vault.run()`.
 
@@ -412,3 +414,4 @@ registry for every document would be wasteful. The manifest is the cheap index.
 | D17 | Merge synthesis + finalize into one post-ingest subagent fed a Python-built bundle (§8, §9) | The per-entity fan-out launched one subagent per `count ≥ 2` entity (36 in a representative run), each paying startup + preamble cache-write to do a few hundred tokens of judgement — ~$5 of a $19 run. D16 feared merging would re-bloat context, but fragments are *compact digests* (D8), so one agent reading the whole bundle stays small; the cost win (one agent, one cached preamble) dominates the serialization cost. The bundle's `build_bundle`/`apply_bundle` survive into D18; only the surrounding subagent is gone | A very large batch could need bundle splitting by token budget (not yet implemented) |
 | D19 | Force-section on whole-doc output overrun (§5) | Sectioning triggers on *input* size (`section_token_threshold`), but truncation is *output*-driven — a moderate-input, entity-dense doc overruns the model's output ceiling on the agent-SDK backend (which can't cap output), truncating the JSON and escalating the retry toward a pricier tier. On a multi-page doc whose whole-doc extraction is rejected, the orchestrator re-runs it through the sectioned path with a small forced budget (≥2 sections) to bound per-call output | Adds one (failed) whole-doc attempt before the fallback; single-page docs can't be split, so they still just fail |
 | D18 | Python orchestrator; the model is called only for reasoning (#118 W3) | A Claude Code skill session *is* a model loop, so the orchestrator (and per-turn coordination) cost model tokens even for pure dispatch — the orchestrator alone ran $1–3+ of a representative batch, ~38–86% of pipeline spend was per-turn context re-send. Moving the loop to Python (`orchestrate.py`) calling the model only for classify/extract/synthesis/timeline-dedup/briefing removes that floor and lets each task route to a backend + tier (`model_client`, D-auth #119). Supersedes the subagent split (D3) and the off-orchestrator finalize (D14) | Extraction now runs the Claude Agent SDK in-process and parallel concurrency is bounded by subscription/API rate limits (`extract_concurrency` knob); the `claude-api` backend is unproven until a metered key is used |
+| D20 | Configured model only — no automatic escalation; classifier model is its own knob | `model_client` originally bumped the tier up (haiku→sonnet→opus) on a JSON-validation failure. That makes ingest cost unpredictable and can silently spend opus money — the opposite of a budgeted pipeline. Now a failed call retries on the **same** configured model (the orchestrator's post-flight repair + D19 sectioning handle genuine failures), and the classify step gets its own `classifier_model` knob (default haiku) alongside `extractor_model`/`finalizer_model`, so each stage's model is explicit and stable | A doc that a stronger model would have salvaged now fails instead of auto-upgrading — the user opts into a stronger model deliberately via config |

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -167,12 +167,14 @@ By default Watchdog uses Sonnet for extraction and for the post-ingest step (syn
 ```bash
 watchdog ingest --extractor-model haiku   # faster, cheaper extraction
 watchdog ingest --finalizer-model opus     # stronger synthesis + briefing
+watchdog ingest --classifier-model sonnet  # stronger document classification
 watchdog ingest --concurrency 2            # fewer docs in parallel (if you hit rate limits)
 watchdog ingest --classify-pages 10        # show the classifier more pages of each document
 ```
 
 ```bash
 watchdog configure extractor_model haiku
+watchdog configure classifier_model sonnet
 watchdog configure extract_concurrency 2
 watchdog configure classify_pages 10
 ```

--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ For a full end-to-end walkthrough of a first investigation, see [GETTING_STARTED
 | `watchdog ingest` | Extract all queued documents — runs the Python pipeline in your terminal |
 | `watchdog ingest --extractor-model M` | Override the extraction model for this run (`sonnet`/`opus`/`haiku`; default from `watchdog configure`) |
 | `watchdog ingest --finalizer-model M` | Override the post-ingest model for this run — synthesis + timeline + briefing (`sonnet`/`opus`/`haiku`; default from `watchdog configure`) |
+| `watchdog ingest --classifier-model M` | Override the document-classification model for this run (`sonnet`/`opus`/`haiku`; default from `watchdog configure`: `haiku`) |
 | `watchdog ingest --concurrency N` | Documents extracted in parallel for this run (default from `watchdog configure`: 5) |
 | `watchdog ingest --classify-pages N` | Pages shown to the document classifier for this run (default from `watchdog configure`: 5) |
 | `watchdog context [name]` | Open Claude Code with the context seeding skill; omit name when inside the vault |
@@ -446,6 +447,7 @@ watchdog configure <key> <value>
 | `embed_images` | `false` | Embed figures as base64 in the extracted markdown so Claude can read charts and image-based tables. Significantly increases token usage. |
 | `dup_threshold` | `0.85` | Jaccard similarity score at which two documents are flagged as near-duplicates. Range: 0.0–1.0. |
 | `shingle_size` | `3` | Word n-gram size for near-duplicate fingerprinting. Changing this invalidates existing MinHash signatures — re-ingest to rebuild. |
+| `classifier_model` | `haiku` | Claude model that reads a document's first pages and picks its record skill. Haiku is plenty; raise it only if classification goes wrong on ambiguous documents. Options: `haiku`, `sonnet`, `opus`. Per-run override: `--classifier-model`. |
 | `extractor_model` | `sonnet` | Claude model for document extraction. Options: `haiku`, `sonnet`, `opus`. Per-run override: `--extractor-model`. |
 | `finalizer_model` | `sonnet` | Claude model for post-ingest — entity synthesis (Summary + Analysis for entities in ≥2 documents) + timeline reconciliation + briefing. Options: `haiku`, `sonnet`, `opus`. Per-run override: `--finalizer-model`. |
 | `extract_concurrency` | `5` | Documents extracted in parallel during `watchdog ingest`. Lower it if you hit model rate limits; raise it for throughput. Per-run override: `--concurrency`. |

--- a/src/watchdog/cli.py
+++ b/src/watchdog/cli.py
@@ -285,6 +285,9 @@ def main() -> None:
     p_ingest.add_argument("--finalizer-model", choices=_model_choices, default=None,
                           dest="finalizer_model",
                           help="Model for synthesis + timeline + briefing — overrides watchdog configure (default: sonnet)")
+    p_ingest.add_argument("--classifier-model", choices=_model_choices, default=None,
+                          dest="classifier_model",
+                          help="Model for document classification — overrides watchdog configure (default: haiku)")
     p_ingest.add_argument("--concurrency", type=int, default=None,
                           help="Documents extracted in parallel — overrides watchdog configure (default: 5)")
     p_ingest.add_argument("--classify-pages", type=int, default=None, dest="classify_pages",

--- a/src/watchdog/cmd/base.py
+++ b/src/watchdog/cmd/base.py
@@ -111,6 +111,7 @@ _CMD_HELP: dict[str, dict] = {
         "opts": [
             ("--extractor-model M",  "Override the extraction model for this run (sonnet/opus/haiku; default from watchdog configure)"),
             ("--finalizer-model M",  "Override the synthesis + timeline + briefing model for this run (sonnet/opus/haiku; default from watchdog configure)"),
+            ("--classifier-model M", "Override the document-classification model for this run (sonnet/opus/haiku; default from watchdog configure)"),
             ("--concurrency N",      "Documents extracted in parallel for this run (default from watchdog configure: 5)"),
             ("--classify-pages N",   "Pages shown to the document classifier for this run (default from watchdog configure: 5)"),
         ],

--- a/src/watchdog/cmd/ingest.py
+++ b/src/watchdog/cmd/ingest.py
@@ -110,14 +110,15 @@ def cmd_ingest(args, *, confirm: bool = True) -> None:
         except Exception:
             pass
 
-    def _model(flag_val, config_key) -> str:
-        m = flag_val or config.get(config_key) or "sonnet"
+    def _model(flag_val, config_key, default="sonnet") -> str:
+        m = flag_val or config.get(config_key) or default
         if m not in _MODEL_IDS:
             sys.exit(f"Error: unknown model '{m}' — choose sonnet, opus, or haiku")
         return m
 
-    extract_model = _model(getattr(args, "extractor_model", None), "extractor_model")
-    post_model    = _model(getattr(args, "finalizer_model", None), "finalizer_model")
+    extract_model  = _model(getattr(args, "extractor_model", None), "extractor_model")
+    post_model     = _model(getattr(args, "finalizer_model", None), "finalizer_model")
+    classify_model = _model(getattr(args, "classifier_model", None), "classifier_model", default="haiku")
     try:
         concurrency = int(getattr(args, "concurrency", None) or config.get("extract_concurrency") or 5)
     except (TypeError, ValueError):
@@ -170,7 +171,7 @@ def cmd_ingest(args, *, confirm: bool = True) -> None:
     try:
         summary = asyncio.run(orchestrate.run(
             vault, concurrency=concurrency, extract_model=extract_model, post_model=post_model,
-            classify_pages=classify_pages))
+            classify_model=classify_model, classify_pages=classify_pages))
     except KeyboardInterrupt:
         # Fallback only — orchestrate.run normally traps SIGINT itself and returns a
         # cancelled summary. This catches a Ctrl+C in the brief window before/after that.

--- a/src/watchdog/cmd/setup.py
+++ b/src/watchdog/cmd/setup.py
@@ -168,6 +168,19 @@ _CONFIGURE_KEYS = {
         "default": False,
     },
     # ── Models ───────────────────────────────────────────────────────────────
+    "classifier_model": {
+        "short": "Claude model that picks each document's record skill (default: haiku)",
+        "help": (
+            "Model used for the cheap classification step that reads a document's first pages\n"
+            "  and picks the matching record skill. Haiku is plenty for this; raise it only if\n"
+            "  classification is going wrong on ambiguous documents.\n"
+            "  Valid values: haiku, sonnet, opus. Default: haiku.\n"
+            "  Override for a single run with: watchdog ingest --classifier-model M"
+        ),
+        "type": "enum",
+        "default": "haiku",
+        "choices": ["haiku", "sonnet", "opus"],
+    },
     "extractor_model": {
         "short": "Claude model for document extraction (default: sonnet)",
         "help": (

--- a/src/watchdog/model_client.py
+++ b/src/watchdog/model_client.py
@@ -12,7 +12,7 @@ Backends:
 Routing: subscription auth can only use claude-agent-sdk; api-key auth defaults to
 claude-api (cheaper) and may use either. A per-task policy or an explicit `backend=`
 overrides the default. Every call validates the returned JSON against the schema,
-escalates the model tier on failure, and reports usage/cost/latency.
+retries on the same model on failure, and reports usage/cost/latency.
 
 The model is invoked for *reasoning only* — callers pass a fully-formed prompt and a
 schema and get validated structured output back. Deterministic work stays in Python.
@@ -28,8 +28,7 @@ from dataclasses import dataclass
 
 from watchdog.cmd import auth
 
-# Model tiers, cheapest → strongest. Retries escalate up this ladder.
-_TIERS = ("haiku", "sonnet", "opus")
+# Tier name → model id. The configured model is used as-is — no automatic escalation.
 _MODEL_IDS = {
     "haiku":  "claude-haiku-4-5",
     "sonnet": "claude-sonnet-4-6",
@@ -199,8 +198,8 @@ async def acomplete_json(*, task: str, prompt: str, schema: dict, model: str | N
 
     `model` may be a tier name (haiku/sonnet/opus) or a raw model id; omit it for the
     per-task default. `backend` forces 'claude-api' or 'claude-agent-sdk'; omit it to
-    route by auth mode. On invalid/unparseable output the call retries, escalating to
-    the next-stronger tier each time (up to `max_retries` extra attempts).
+    route by auth mode. On invalid/unparseable output the call retries on the **same**
+    model (up to `max_retries` extra attempts) — never escalating — then raises.
     """
     resolved = auth.resolve_auth()
     if resolved["mode"] == "none":
@@ -213,10 +212,7 @@ async def acomplete_json(*, task: str, prompt: str, schema: dict, model: str | N
     max_tokens = _TASK_MAX_TOKENS.get(task, _API_MAX_TOKENS)
 
     requested = model or _TASK_TIERS.get(task, DEFAULT_TIER)
-    if requested in _MODEL_IDS:
-        tier_idx, model_id = _TIERS.index(requested), _MODEL_IDS[requested]
-    else:
-        tier_idx, model_id = None, requested   # raw id — no escalation
+    model_id = _MODEL_IDS.get(requested, requested)   # tier name → id, or a raw id as-is
 
     start = time.monotonic()
     total_cost = 0.0
@@ -241,10 +237,6 @@ async def acomplete_json(*, task: str, prompt: str, schema: dict, model: str | N
                     latency_s=round(time.monotonic() - start, 3), attempts=attempts,
                 )
             last_err = "; ".join(errors[:3])
-
-        if tier_idx is not None and tier_idx < len(_TIERS) - 1:
-            tier_idx += 1
-            model_id = _MODEL_IDS[_TIERS[tier_idx]]
 
     raise ModelError(
         f"task '{task}' failed JSON validation after {attempts} attempt(s) "

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1388,6 +1388,15 @@ def test_offer_ingest_eof_prints_hint(configured, monkeypatch, capsys):
     assert "watchdog ingest" in capsys.readouterr().out
 
 
+# ── classifier_model config ───────────────────────────────────────────────────
+
+def test_classifier_model_is_a_configurable_key():
+    from watchdog.cmd.setup import _CONFIGURE_KEYS
+    entry = _CONFIGURE_KEYS["classifier_model"]
+    assert entry["default"] == "haiku"
+    assert set(entry["choices"]) == {"haiku", "sonnet", "opus"}
+
+
 # ── _notify ───────────────────────────────────────────────────────────────────
 
 def test_notify_no_op_on_non_darwin(monkeypatch):

--- a/tests/test_model_client.py
+++ b/tests/test_model_client.py
@@ -80,15 +80,14 @@ def test_no_auth_errors(monkeypatch):
 
 # ── validation, retry, escalation ─────────────────────────────────────────────
 
-def test_invalid_then_valid_retries_and_escalates(api_key_auth, monkeypatch):
-    # haiker tier requested; first output bad JSON, second valid
+def test_invalid_then_valid_retries_same_model(api_key_auth, monkeypatch):
+    # haiku requested; first output bad JSON, second valid — retry stays on haiku (no escalation)
     api = FakeBackend(_out("not json"), _out('{"name": "Acme"}'))
     monkeypatch.setitem(mc._ABACKENDS, "claude-api", api)
     r = mc.complete_json(task="t", prompt="p", schema=SCHEMA, model="haiku")
     assert r.parsed == {"name": "Acme"}
     assert r.attempts == 2
-    assert api.calls[0]["model_id"] == mc._MODEL_IDS["haiku"]    # first attempt
-    assert api.calls[1]["model_id"] == mc._MODEL_IDS["sonnet"]   # escalated
+    assert api.calls[0]["model_id"] == api.calls[1]["model_id"] == mc._MODEL_IDS["haiku"]
 
 
 def test_schema_violation_then_valid(api_key_auth, monkeypatch):


### PR DESCRIPTION
Two related model-selection changes so every ingest stage uses exactly the model you configured — predictably and visibly.

## 1. No automatic tier escalation

`model_client` used to bump the tier up the ladder (haiku→sonnet→opus) whenever a call returned invalid/unschematic JSON. That makes ingest cost unpredictable and can **silently spend opus money** — the opposite of a budgeted pipeline.

Now a failed call **retries on the same configured model**. Genuine failures are already handled downstream: the orchestrator's post-flight repair retry, and the #122 sectioning fallback for output overruns. Removes the now-unused `_TIERS` ladder.

(If you want opus, set it explicitly in config — it's never auto-selected.)

## 2. Tunable classifier model

The classification step (which reads a document's first pages and picks a record skill) was hardcoded to haiku — the `classify_model` param existed on `orchestrate.run` but was never exposed. Now:

- **`classifier_model`** config key (default `haiku`) + **`--classifier-model`** per-run flag, alongside `extractor_model` / `finalizer_model`.

Haiku is plenty for classification; the knob is there for the rare ambiguous-document case.

## Notes

- `ARCHITECTURE.md`: decision-log **D20** + §4/§5 updates.
- README (commands + config tables), GETTING_STARTED, and `watchdog ingest` help updated.
- Tests: same-model retry (no escalation) and the new config key. 468 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
