### PR TITLE
Pin a record skill to skip classification; group `configure` output

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -100,9 +100,9 @@ Chew is fully local and writes no model-derived fields — `document_type` is le
 unconfigured), acquires a run lock (`.watchdog/Registry/.ingest-lock`, stale after 30
 minutes), scans the queue, and clears the previous run's entity-fragment staging (§8).
 It then runs the Python orchestrator in-process (`asyncio.run(orchestrate.run(...))`) and
-releases the lock in a `finally`. Models and concurrency come from `watchdog configure`
-(`classifier_model`, `extractor_model`, `finalizer_model`, `extract_concurrency`,
-`classify_pages`) or per-run flags.
+releases the lock in a `finally`. Models, concurrency, and classification come from
+`watchdog configure` (`classifier_model`, `extractor_model`, `finalizer_model`,
+`extract_concurrency`, `classify_pages`, `default_skill`) or per-run flags.
 
 A second, finer lock (`.watchdog/Registry/.write-lock`, `flock`) serializes the actual
 registry/note writes so the concurrent document workers write safely.
@@ -124,7 +124,9 @@ registry/note writes so the concurrent document workers write safely.
 2. **Classify** — one cheap model call (`model_client.acomplete_json`, `classifier_model`,
    default haiku) over the document's first `classify_pages` pages + the generated
    `records/_index.md`, returning the closest domain-skill filename (§6). Python reads that
-   one skill and injects it into the extraction prompt.
+   one skill and injects it into the extraction prompt. **Skipped entirely when a skill is
+   pinned** for the run (`--skill` / `default_skill`) — that one skill is used for every
+   document, saving a model call per doc on known-homogeneous batches.
 3. **Extract** — one model call against the `EXTRACTION` schema: title, date, entities
    (deduped against the pre-flight candidates), roles, timeline events, key facts,
    per-entity summary/analysis, contradictions, morgue fields, and a briefing scratchpad.

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -170,13 +170,17 @@ watchdog ingest --finalizer-model opus     # stronger synthesis + briefing
 watchdog ingest --classifier-model sonnet  # stronger document classification
 watchdog ingest --concurrency 2            # fewer docs in parallel (if you hit rate limits)
 watchdog ingest --classify-pages 10        # show the classifier more pages of each document
+watchdog ingest --skill corporate-filings  # pin one record skill, skip classification
 ```
+
+`--skill` with no value lists the installed record skills and lets you pick one interactively. For a vault that's always one document type, set it once:
 
 ```bash
 watchdog configure extractor_model haiku
 watchdog configure classifier_model sonnet
 watchdog configure extract_concurrency 2
 watchdog configure classify_pages 10
+watchdog configure default_skill corporate-filings
 ```
 
 For each document, the pipeline:

--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ For a full end-to-end walkthrough of a first investigation, see [GETTING_STARTED
 | `watchdog ingest --classifier-model M` | Override the document-classification model for this run (`sonnet`/`opus`/`haiku`; default from `watchdog configure`: `haiku`) |
 | `watchdog ingest --concurrency N` | Documents extracted in parallel for this run (default from `watchdog configure`: 5) |
 | `watchdog ingest --classify-pages N` | Pages shown to the document classifier for this run (default from `watchdog configure`: 5) |
+| `watchdog ingest --skill [NAME]` | Pin a record skill for every document, skipping classification. Pass a name, or `--skill` with no value to pick interactively |
 | `watchdog context [name]` | Open Claude Code with the context seeding skill; omit name when inside the vault |
 | `watchdog context --model M` | Override the model for context seeding (`sonnet`/`opus`/`haiku`, default: `sonnet`) |
 | `watchdog watch [name]` | Watch `_INCOMING/` and chew files automatically as they arrive; omit name when inside the project directory |
@@ -452,6 +453,7 @@ watchdog configure <key> <value>
 | `finalizer_model` | `sonnet` | Claude model for post-ingest — entity synthesis (Summary + Analysis for entities in ≥2 documents) + timeline reconciliation + briefing. Options: `haiku`, `sonnet`, `opus`. Per-run override: `--finalizer-model`. |
 | `extract_concurrency` | `5` | Documents extracted in parallel during `watchdog ingest`. Lower it if you hit model rate limits; raise it for throughput. Per-run override: `--concurrency`. |
 | `classify_pages` | `5` | Leading pages of each document shown to the classifier (`min(page_count, this)`). More pages classify ambiguous documents better at a small extra cost on the cheap classifier model. Per-run override: `--classify-pages`. |
+| `default_skill` | _(unset)_ | Pin a record skill (a name from the vault's records dir) for every ingested document, skipping classification — for vaults that are always one document type. Per-run override: `--skill`. |
 
 **Examples:**
 

--- a/src/watchdog/cli.py
+++ b/src/watchdog/cli.py
@@ -292,6 +292,11 @@ def main() -> None:
                           help="Documents extracted in parallel — overrides watchdog configure (default: 5)")
     p_ingest.add_argument("--classify-pages", type=int, default=None, dest="classify_pages",
                           help="Pages shown to the document classifier — overrides watchdog configure (default: 5)")
+    from watchdog.cmd.ingest import _PICK_SKILL
+    p_ingest.add_argument("--skill", nargs="?", const=_PICK_SKILL, default=None, dest="skill",
+                          metavar="NAME",
+                          help="Pin a record skill for every document, skipping classification. "
+                               "Pass a skill name, or use --skill with no value to pick interactively.")
     p_ingest.set_defaults(func=cmd_ingest)
 
     p_context = sub.add_parser("context", help="Open Claude Code to seed investigation context from _CONTEXT/")

--- a/src/watchdog/cmd/base.py
+++ b/src/watchdog/cmd/base.py
@@ -114,6 +114,7 @@ _CMD_HELP: dict[str, dict] = {
             ("--classifier-model M", "Override the document-classification model for this run (sonnet/opus/haiku; default from watchdog configure)"),
             ("--concurrency N",      "Documents extracted in parallel for this run (default from watchdog configure: 5)"),
             ("--classify-pages N",   "Pages shown to the document classifier for this run (default from watchdog configure: 5)"),
+            ("--skill [NAME]",       "Pin a record skill for every document, skipping classification (no value = pick interactively)"),
         ],
     },
     "context": {

--- a/src/watchdog/cmd/ingest.py
+++ b/src/watchdog/cmd/ingest.py
@@ -15,6 +15,55 @@ from watchdog.cmd.base import (
     load_projects,
 )
 
+# Sentinel for `--skill` with no value: trigger the interactive record-skill picker.
+_PICK_SKILL = "\x00pick"
+
+
+def _available_skills(vault: Path) -> list[str]:
+    """Installed record-skill names (filenames minus .md), excluding internal `_` files."""
+    records = vault / ".claude" / "commands" / "records"
+    if not records.is_dir():
+        return []
+    return sorted(p.stem for p in records.glob("*.md") if not p.name.startswith("_"))
+
+
+def _pick_skill_interactive(vault: Path) -> str | None:
+    """Numbered picker for `watchdog ingest --skill` (no value). Enter → classify per doc."""
+    skills = _available_skills(vault)
+    if not skills:
+        print(f"\n  {_DIM}No record skills installed — classifying each document.{_RESET}")
+        return None
+    print(f"\n  {_BOLD}Pin a record skill{_RESET} {_DIM}for all documents (skips per-document classification):{_RESET}\n")
+    for i, s in enumerate(skills, 1):
+        print(f"    {_CYAN}{i:>2}{_RESET}  {s}")
+    try:
+        ans = input("\n  Number, or Enter to classify each: ").strip()
+    except (EOFError, KeyboardInterrupt):
+        print()
+        return None
+    if ans.isdigit() and 1 <= int(ans) <= len(skills):
+        return skills[int(ans) - 1]
+    if ans:
+        print(f"  {_DIM}Not a valid choice — classifying each document.{_RESET}")
+    return None
+
+
+def _resolve_pinned_skill(args, vault: Path, config: dict) -> str | None:
+    """Resolve the pinned record skill — `--skill` flag → interactive picker → `default_skill`
+    config. Exits with the available list if an explicitly named skill doesn't exist."""
+    raw = getattr(args, "skill", None)
+    if raw == _PICK_SKILL:
+        return _pick_skill_interactive(vault)          # the picker only offers valid skills
+    skill = raw or config.get("default_skill")
+    if not skill:
+        return None
+    canon = skill.removesuffix(".md")
+    if canon not in _available_skills(vault):
+        avail = ", ".join(_available_skills(vault)) or "(none installed)"
+        sys.exit(f"\n  {_YELLOW}Error:{_RESET} unknown record skill {_BOLD}{canon}{_RESET}.\n"
+                 f"  Available: {_CYAN}{avail}{_RESET}\n")
+    return canon
+
 
 def _run_preprocess(
     vault: Path,
@@ -141,6 +190,10 @@ def cmd_ingest(args, *, confirm: bool = True) -> None:
     q = len(result["queue_files"])
     print(f"\n  {_BOLD}{q} document{'s' if q != 1 else ''}{_RESET} ready for extraction")
 
+    pinned_skill = _resolve_pinned_skill(args, vault, config)
+    if pinned_skill:
+        print(f"  {_DIM}Skill pinned:{_RESET} {_CYAN}{pinned_skill}{_RESET}{_DIM} — classification skipped.{_RESET}")
+
     def _release_lock() -> None:
         (vault / ".watchdog" / "Registry" / ".ingest-lock").unlink(missing_ok=True)
         (vault / ".watchdog" / "ingest-state.json").unlink(missing_ok=True)
@@ -171,7 +224,7 @@ def cmd_ingest(args, *, confirm: bool = True) -> None:
     try:
         summary = asyncio.run(orchestrate.run(
             vault, concurrency=concurrency, extract_model=extract_model, post_model=post_model,
-            classify_model=classify_model, classify_pages=classify_pages))
+            classify_model=classify_model, classify_pages=classify_pages, pinned_skill=pinned_skill))
     except KeyboardInterrupt:
         # Fallback only — orchestrate.run normally traps SIGINT itself and returns a
         # cancelled summary. This catches a Ctrl+C in the brief window before/after that.

--- a/src/watchdog/cmd/setup.py
+++ b/src/watchdog/cmd/setup.py
@@ -106,6 +106,17 @@ _CONFIGURE_KEYS = {
         "default": 5,
         "min": 1,
     },
+    "default_skill": {
+        "short": "Pin a record skill for every ingested document, skipping classification (default: unset)",
+        "help": (
+            "When every document in a vault is the same type, set this to a record-skill name\n"
+            "  (a file in the vault's records dir, minus .md) to skip per-document classification\n"
+            "  and use that one skill for all of them. Leave unset to classify each document.\n"
+            "  Override for one run with: watchdog ingest --skill NAME (or --skill to pick one)."
+        ),
+        "type": "string",
+        "default": None,
+    },
     "chunk_size": {
         "short": "Pages per chunk when splitting large PDFs for parallel processing (default: 40)",
         "help": (
@@ -236,6 +247,24 @@ _CONFIGURE_KEYS = {
         "min": 1,
     },
 }
+
+# Display grouping for the `watchdog configure` listing (presentation only — set/get is
+# unaffected). Each section owns an ordered list of keys; any key missing from every
+# section is still shown, under "Other", so a newly added key never silently disappears.
+_CONFIGURE_SECTIONS = [
+    ("Vaults", "Where investigations are created.",
+     ["projects_dir"]),
+    ("OCR", "Text recognition for scanned documents.",
+     ["ocr_engine", "ocr_languages", "garbled_threshold"]),
+    ("Chew", "Local preprocessing — parallelism and large-PDF handling.",
+     ["chew_workers", "chunk_size", "chunk_workers", "chunk_timeout", "table_structure", "embed_images"]),
+    ("Ingest", "Extraction run — parallelism, classification, skill pinning.",
+     ["extract_concurrency", "classify_pages", "default_skill"]),
+    ("Models", "Which Claude model runs each step.",
+     ["classifier_model", "extractor_model", "finalizer_model"]),
+    ("Deduplication", "Near-duplicate detection.",
+     ["dup_threshold", "shingle_size"]),
+]
 
 _OCR_ENGINE_PACKAGES = {
     # engine → (import_name, pip_package) or None if bundled with docling
@@ -376,11 +405,29 @@ def cmd_configure(args) -> None:
     if key is None:
         print()
         print(f"  {_BOLD}Configuration{_RESET}  {_DIM}{CONFIG_FILE}{_RESET}")
-        print()
-        for k, meta in _CONFIGURE_KEYS.items():
+
+        def _print_key(k):
+            meta = _CONFIGURE_KEYS[k]
             print(f"  {_DIM}{k:<26}{_RESET} {_display_value(k, config.get(k))}")
             print(f"  {' ' * 26} {_DIM}{meta['short']}{_RESET}")
             print()
+
+        shown = set()
+        for title, blurb, keys in _CONFIGURE_SECTIONS:
+            print()
+            print(f"  {_BOLD}{title}{_RESET}  {_DIM}{blurb}{_RESET}")
+            print()
+            for k in keys:
+                if k in _CONFIGURE_KEYS:
+                    _print_key(k)
+                    shown.add(k)
+        leftovers = [k for k in _CONFIGURE_KEYS if k not in shown]
+        if leftovers:
+            print()
+            print(f"  {_BOLD}Other{_RESET}")
+            print()
+            for k in leftovers:
+                _print_key(k)
         return
 
     if key not in _CONFIGURE_KEYS:

--- a/src/watchdog/pipeline/orchestrate.py
+++ b/src/watchdog/pipeline/orchestrate.py
@@ -209,7 +209,8 @@ def _fail(vault: Path, sha: str, filename: str, reason: str) -> dict:
 
 async def _extract_document(vault: Path, sha: str, brief: str | None,
                             extract_model: str, classify_model: str,
-                            classify_pages: int = DEFAULT_CLASSIFY_PAGES) -> dict:
+                            classify_pages: int = DEFAULT_CLASSIFY_PAGES,
+                            pinned_skill: str | None = None) -> dict:
     pf = preflight.run(vault, sha)
     if pf.get("error"):
         return _fail(vault, sha, "", pf["error"])
@@ -220,10 +221,14 @@ async def _extract_document(vault: Path, sha: str, brief: str | None,
     filename = pf["filename"]
     pages = pf.get("pages", [])
     page_count = pf.get("page_count") or len(pages)
-    _say(f"{_DIM}→  {filename}  classifying ({page_count} page{'s' if page_count != 1 else ''})…{_RESET}")
-    # Classify on the first N pages (page-aware, not a mid-page char cut); the char cap is a guard.
-    excerpt = _pages_text(pages[:max(1, classify_pages)])[:_CLASSIFY_EXCERPT_CHARS]
-    skill = await _classify(vault, excerpt, classify_model)
+    if pinned_skill:
+        # Skill pinned for the whole run — skip per-document classification entirely.
+        skill = pinned_skill if pinned_skill.endswith(".md") else f"{pinned_skill}.md"
+    else:
+        _say(f"{_DIM}→  {filename}  classifying ({page_count} page{'s' if page_count != 1 else ''})…{_RESET}")
+        # Classify on the first N pages (page-aware, not a mid-page char cut); the char cap is a guard.
+        excerpt = _pages_text(pages[:max(1, classify_pages)])[:_CLASSIFY_EXCERPT_CHARS]
+        skill = await _classify(vault, excerpt, classify_model)
     skill_text = _read_skill(vault, skill)
     skill_label = skill.removesuffix(".md")
 
@@ -381,12 +386,14 @@ async def _post_ingest(vault: Path, results: list, brief: str | None, post_model
 async def run(vault: Path, *, concurrency: int = DEFAULT_CONCURRENCY,
               extract_model: str = "sonnet", post_model: str = "sonnet",
               classify_model: str = "haiku",
-              classify_pages: int = DEFAULT_CLASSIFY_PAGES) -> dict:
+              classify_pages: int = DEFAULT_CLASSIFY_PAGES,
+              pinned_skill: str | None = None) -> dict:
     """Extract every queued document (bounded by `concurrency`), then post-ingest.
 
     `extract_model` drives extraction (whole-doc + section); `post_model` drives
     synthesis/timeline/briefing; `classify_model` the cheap document classifier,
-    which sees the first `classify_pages` pages of each document.
+    which sees the first `classify_pages` pages of each document. `pinned_skill`
+    (a record-skill name) skips classification and uses that skill for every document.
     """
     queue_dir = vault / ".watchdog" / "queue"
     shas = [f.stem for f in sorted(queue_dir.glob("*.json"))] if queue_dir.exists() else []
@@ -405,7 +412,7 @@ async def run(vault: Path, *, concurrency: int = DEFAULT_CONCURRENCY,
                 return {"sha256": sha, "filename": "", "status": "cancelled"}
             try:
                 return await _extract_document(vault, sha, brief, extract_model, classify_model,
-                                               classify_pages)
+                                               classify_pages, pinned_skill)
             except asyncio.CancelledError:           # ctrl+c mid-document — queue file stays
                 return {"sha256": sha, "filename": "", "status": "cancelled"}
             except Exception as e:                   # one bad doc must not sink the batch

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1397,6 +1397,72 @@ def test_classifier_model_is_a_configurable_key():
     assert set(entry["choices"]) == {"haiku", "sonnet", "opus"}
 
 
+# ── configure sections + default_skill ────────────────────────────────────────
+
+def test_configure_sections_cover_every_key_exactly_once():
+    from watchdog.cmd.setup import _CONFIGURE_KEYS, _CONFIGURE_SECTIONS
+    grouped = [k for _, _, ks in _CONFIGURE_SECTIONS for k in ks]
+    assert set(grouped) == set(_CONFIGURE_KEYS)     # nothing falls into "Other"
+    assert len(grouped) == len(set(grouped))        # no key in two sections
+
+
+def test_default_skill_is_a_configurable_key():
+    from watchdog.cmd.setup import _CONFIGURE_KEYS
+    assert "default_skill" in _CONFIGURE_KEYS
+
+
+# ── _resolve_pinned_skill ─────────────────────────────────────────────────────
+
+def _vault_with_skills(tmp_path, names=("general-records", "corporate-filings")):
+    records = tmp_path / "v" / ".claude" / "commands" / "records"
+    records.mkdir(parents=True)
+    for n in names:
+        (records / f"{n}.md").write_text("skill")
+    (records / "_index.md").write_text("internal")     # excluded from choices
+    return tmp_path / "v"
+
+
+def test_resolve_pinned_skill_from_flag(tmp_path):
+    from watchdog.cmd import ingest as ing
+    assert ing._resolve_pinned_skill(args(skill="corporate-filings"), _vault_with_skills(tmp_path), {}) == "corporate-filings"
+
+
+def test_resolve_pinned_skill_strips_md_suffix(tmp_path):
+    from watchdog.cmd import ingest as ing
+    assert ing._resolve_pinned_skill(args(skill="corporate-filings.md"), _vault_with_skills(tmp_path), {}) == "corporate-filings"
+
+
+def test_resolve_pinned_skill_unknown_exits(tmp_path):
+    from watchdog.cmd import ingest as ing
+    with pytest.raises(SystemExit, match="unknown record skill"):
+        ing._resolve_pinned_skill(args(skill="nope"), _vault_with_skills(tmp_path), {})
+
+
+def test_resolve_pinned_skill_from_config(tmp_path):
+    from watchdog.cmd import ingest as ing
+    vault = _vault_with_skills(tmp_path)
+    assert ing._resolve_pinned_skill(args(), vault, {"default_skill": "general-records"}) == "general-records"
+
+
+def test_resolve_pinned_skill_none_classifies(tmp_path):
+    from watchdog.cmd import ingest as ing
+    assert ing._resolve_pinned_skill(args(), _vault_with_skills(tmp_path), {}) is None
+
+
+def test_resolve_pinned_skill_interactive_pick(tmp_path, monkeypatch):
+    from watchdog.cmd import ingest as ing
+    vault = _vault_with_skills(tmp_path, names=("alpha", "beta"))   # sorted: alpha=1, beta=2
+    monkeypatch.setattr("builtins.input", lambda *a: "2")
+    assert ing._resolve_pinned_skill(args(skill=ing._PICK_SKILL), vault, {}) == "beta"
+
+
+def test_resolve_pinned_skill_interactive_enter_classifies(tmp_path, monkeypatch):
+    from watchdog.cmd import ingest as ing
+    vault = _vault_with_skills(tmp_path, names=("alpha", "beta"))
+    monkeypatch.setattr("builtins.input", lambda *a: "")
+    assert ing._resolve_pinned_skill(args(skill=ing._PICK_SKILL), vault, {}) is None
+
+
 # ── _notify ───────────────────────────────────────────────────────────────────
 
 def test_notify_no_op_on_non_darwin(monkeypatch):

--- a/tests/test_orchestrate.py
+++ b/tests/test_orchestrate.py
@@ -240,6 +240,49 @@ def test_single_page_failure_does_not_section(tmp_path, monkeypatch):
     assert summary["failed"] == 1 and summary["extracted"] == 0
 
 
+def test_pinned_skill_skips_classification(tmp_path, monkeypatch):
+    vault = make_vault(tmp_path)
+    _queue_doc(vault)
+    tasks = []
+    async def fake(*, task, prompt, schema, model=None, backend=None, max_retries=1):
+        tasks.append(task)
+        parsed = {
+            "extract": _extraction(),
+            "entity-synthesis": {"entity_syntheses": []},
+            "briefing": {"investigation_status": "x", "what_was_ingested": []},
+        }.get(task, {"events": []})
+        return model_client.ModelResult(parsed=parsed, text="", model="m", backend="b",
+                                        auth_mode="subscription", cost_usd=0.0)
+    monkeypatch.setattr(orchestrate.model_client, "acomplete_json", fake)
+
+    summary = asyncio.run(orchestrate.run(vault, pinned_skill="general-records"))
+    assert summary["extracted"] == 1
+    assert "classify" not in tasks          # classification skipped entirely
+
+
+def test_pinned_skill_is_injected_into_extraction(tmp_path, monkeypatch):
+    vault = make_vault(tmp_path)
+    _queue_doc(vault)
+    records = vault / ".claude" / "commands" / "records"
+    records.mkdir(parents=True, exist_ok=True)
+    (records / "corporate-filings.md").write_text("CORPORATE FILINGS SKILL BODY")
+    seen = {}
+    async def fake(*, task, prompt, schema, model=None, backend=None, max_retries=1):
+        if task == "extract":
+            seen["prompt"] = prompt
+        parsed = {
+            "extract": _extraction(),
+            "entity-synthesis": {"entity_syntheses": []},
+            "briefing": {"investigation_status": "x", "what_was_ingested": []},
+        }.get(task, {"events": []})
+        return model_client.ModelResult(parsed=parsed, text="", model="m", backend="b",
+                                        auth_mode="subscription", cost_usd=0.0)
+    monkeypatch.setattr(orchestrate.model_client, "acomplete_json", fake)
+
+    asyncio.run(orchestrate.run(vault, pinned_skill="corporate-filings"))
+    assert "CORPORATE FILINGS SKILL BODY" in seen["prompt"]
+
+
 def test_orchestrator_cancels_gracefully_on_sigint(tmp_path, monkeypatch):
     """Ctrl+C during extraction → cancelled summary, no traceback, unfinished docs keep
     their queue file, and post-ingest is skipped."""


### PR DESCRIPTION
Two related config/UX changes — closes #124 and #126.

## #124 — Pin a record skill for an ingest (skip classification)

When you already know a batch is all one document type (e.g. 50 corporate filings), classification per document is wasted work and can occasionally misroute a doc.

- **`watchdog ingest --skill corporate-filings`** — use that record skill for every document and skip the per-doc classification call entirely.
- **`watchdog ingest --skill`** (no value) — lists installed record skills and lets you pick one interactively.
- **`default_skill`** config key — for a vault that's always one type, set it once.

Resolution order: `--skill` flag → interactive picker → `default_skill` config. An explicitly named skill that doesn't exist errors with the available list. Under the hood `orchestrate.run` gains `pinned_skill`, which short-circuits `_classify` and injects the named skill into every extraction prompt.

## #126 — Group `watchdog configure` output into labeled sections

The flat key list had grown hard to scan. The listing now renders under headings — **Vaults / OCR / Chew / Ingest / Models / Deduplication** — each with a one-line blurb (CLI style guide: bold heading, dim blurb). Presentation only; set/get is unchanged. Any key not assigned to a section still shows under "Other", and a test enforces that every key is grouped exactly once, so a newly added key can't silently disappear.

`default_skill` lands in the new **Ingest** section — which is the thread connecting the two issues.

## Notes

- Interpretation choice on the interactive picker: it's **opt-in** via bare `--skill` rather than an unconditional prompt on every ingest, to avoid prompt fatigue. Easy to switch to an always-offered prompt if you'd prefer.
- Docs: README (commands + config tables), GETTING_STARTED, ARCHITECTURE §4/§5.
- Tests: pinned-skill skipping + injection, skill resolution/validation/picker, and configure-section coverage. 479 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
