### PR TITLE
Make record skills global (show-skills, frontmatter, skill provenance)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -123,7 +123,7 @@ registry/note writes so the concurrent document workers write safely.
    carrying its current note summary + timeline/roles/contradictions digest (§8).
 2. **Classify** — one cheap model call (`model_client.acomplete_json`, `classifier_model`,
    default haiku) over the document's first `classify_pages` pages + the generated
-   `records/_index.md`, returning the closest domain-skill filename (§6). Python reads that
+   in-memory skill index, returning the closest domain-skill filename (§6). Python reads that
    one skill and injects it into the extraction prompt. **Skipped entirely when a skill is
    pinned** for the run (`--skill` / `default_skill`) — that one skill is used for every
    document, saving a model call per doc on known-homogeneous batches.
@@ -178,12 +178,15 @@ longer folded into the extractor.
   document's text vs. *meta-text describing how to read that document type* — and
   with ~35 adjacent skills the cosine similarity was noisy. Worse, a confident-wrong
   classification was the *most* harmful outcome: it loaded the wrong domain skill.
-- **Why a dedicated model call wins.** The orchestrator sends a text excerpt + the
-  generated `records/_index.md` to a cheap haiku call that returns the skill filename;
-  Python then reads that one skill and injects it into the extraction prompt. Accurate,
-  cheap, and it keeps the extraction prompt lean (only the relevant skill, not the
-  index). When the skill-based extractor self-classified, that work was turns inside the
-  expensive extraction call (the #87 tax); a separate haiku call is cheaper.
+- **Why a dedicated model call wins.** The orchestrator sends a text excerpt + the skill
+  index (built in memory from the global catalog, `skills_catalog.build_index()`) to a
+  cheap haiku call that returns the skill filename; Python then reads that one skill (from
+  the global catalog) and injects it into the extraction prompt. Accurate, cheap, and it
+  keeps the extraction prompt lean (only the relevant skill, not the index). When the
+  skill-based extractor self-classified, that work was turns inside the expensive
+  extraction call (the #87 tax); a separate haiku call is cheaper.
+- **Pinning.** `--skill` / `default_skill` skips this call entirely and uses one skill
+  for the whole run (see §5, D21).
 - **Tradeoff.** `document_type` is `null` in the queue between chew and ingest; it is
   populated at ingest. Accepted — nothing downstream needs it earlier.
 - **Sections.** A sectioned document (§5) is classified once, on its full-text excerpt,
@@ -379,17 +382,16 @@ registry for every document would be wasteful. The manifest is the cheap index.
   `watchdog-context`, `watchdog-entity`, `watchdog-query`, `watchdog-surface`,
   `watchdog-wiki`, `watchdog-health`. Ingest is the Python orchestrator (§5); it uses no
   Claude Code skill.
-- **Domain skills** live in `src/watchdog/skills/records/` and are installed into a
-  vault's `.claude/commands/records/` by `setup_cmd.install_skills`, which also
-  generates `records/_index.md` (one-line description per skill, derived from each
-  skill's intro). New skills are added by dropping a file in that directory — no code
-  changes. The index is **generated, not checked in**, so it has a single source of
-  truth and cannot drift from the skills (see D12). It is rebuilt by *scanning the
-  records directory* — so skills a user adds directly to their vault are indexed too —
-  on install, on `watchdog refresh-skills`, and at the start of every ingest
-  (`ingest_setup.run` → `regenerate_records_index`). Regeneration is unconditional
-  rather than mtime-gated: it's cheap and that way it self-heals on add, edit, and
-  delete alike.
+- **Domain (record) skills are global** (`watchdog.skills_catalog`, see D21): the
+  package's `src/watchdog/skills/records/` plus the user's `~/.watchdog/skills/records/`
+  (a user skill overrides a package skill of the same name). The ingest orchestrator
+  reads them directly from there — nothing is copied into a vault — so they're always
+  current with no refresh step. New skills are added by dropping a file (in the package,
+  or the user dir). The classification index is **built in memory** from the catalog
+  (`build_index()`), so it never drifts (supersedes D12); each skill's index line comes
+  from its `description:` frontmatter, falling back to the first intro sentence.
+  `watchdog show-skills` lists them / opens the GitHub folder; `--skill` / `default_skill`
+  pin one (a catalog name or a file path).
 
 ---
 
@@ -408,7 +410,7 @@ registry for every document would be wasteful. The manifest is the cheap index.
 | D9 | Raw-then-canonical timeline files (§9) | Subagents write lock-free; merge deferred to one post-batch step | Two file generations on disk |
 | D10 | MinHash near-dup, detect-only (§10) | Cheap local dedup signal; journalist decides | Approximate similarity |
 | D11 | Separate lightweight manifest (§12) | Cheap candidate lookup in pre-flight | A second index to keep in sync (done in `write_vault`) |
-| D12 | Generate `records/_index.md` by scanning the records dir (§13), don't check in a static index; rebuild unconditionally on install/refresh/ingest | Single source of truth — the skill's own intro; a static file silently drifts and breaks the "just drop a skill file" workflow. Scanning the dir (not the package) indexes user-added skills; unconditional rebuild is cheap and self-heals on add/edit/delete (no mtime edge cases) | Descriptor quality depends on parsing the intro prose; a dedicated frontmatter descriptor field is the upgrade path if that heuristic gets fragile |
+| D12 | ~~Generate `records/_index.md` by scanning the per-vault records dir~~ **Superseded by D21.** Index is now built in memory from the global catalog at classify time, so there's no file to scan or keep fresh. | Single source of truth — the skill's own intro; a static file silently drifts and breaks the "just drop a skill file" workflow. Scanning the dir (not the package) indexes user-added skills; unconditional rebuild is cheap and self-heals on add/edit/delete (no mtime edge cases) | Descriptor quality depends on parsing the intro prose; a dedicated frontmatter descriptor field is the upgrade path if that heuristic gets fragile |
 | D13 | Sectioned extraction for large documents (§5) | Documents over the token threshold don't fit one context; sequential page-range sections with a carried scratchpad + deterministic `merge-sections` preserve cross-section consistency | Large docs are extracted serially (slower); needs overlap + merge-dedup |
 | D14 | ~~Timeline reconciliation + briefing in one finalize subagent~~ **Superseded by D18.** | Kept scratchpad prose and timeline NDJSON out of the model orchestrator's context. Moot under Python orchestration — `_post_ingest` reads them directly | — |
 | D15 | Runaway guard + `ingest-abort` (§5) | A stuck subagent bails (`STATUS: failed`) instead of wedging the batch; clean bail leaves no partial vault writes, so the doc re-ingests cleanly | A failed doc must be manually moved back from `queue/_failed/` to retry |
@@ -416,4 +418,5 @@ registry for every document would be wasteful. The manifest is the cheap index.
 | D17 | Merge synthesis + finalize into one post-ingest subagent fed a Python-built bundle (§8, §9) | The per-entity fan-out launched one subagent per `count ≥ 2` entity (36 in a representative run), each paying startup + preamble cache-write to do a few hundred tokens of judgement — ~$5 of a $19 run. D16 feared merging would re-bloat context, but fragments are *compact digests* (D8), so one agent reading the whole bundle stays small; the cost win (one agent, one cached preamble) dominates the serialization cost. The bundle's `build_bundle`/`apply_bundle` survive into D18; only the surrounding subagent is gone | A very large batch could need bundle splitting by token budget (not yet implemented) |
 | D19 | Force-section on whole-doc output overrun (§5) | Sectioning triggers on *input* size (`section_token_threshold`), but truncation is *output*-driven — a moderate-input, entity-dense doc overruns the model's output ceiling on the agent-SDK backend (which can't cap output), truncating the JSON and escalating the retry toward a pricier tier. On a multi-page doc whose whole-doc extraction is rejected, the orchestrator re-runs it through the sectioned path with a small forced budget (≥2 sections) to bound per-call output | Adds one (failed) whole-doc attempt before the fallback; single-page docs can't be split, so they still just fail |
 | D18 | Python orchestrator; the model is called only for reasoning (#118 W3) | A Claude Code skill session *is* a model loop, so the orchestrator (and per-turn coordination) cost model tokens even for pure dispatch — the orchestrator alone ran $1–3+ of a representative batch, ~38–86% of pipeline spend was per-turn context re-send. Moving the loop to Python (`orchestrate.py`) calling the model only for classify/extract/synthesis/timeline-dedup/briefing removes that floor and lets each task route to a backend + tier (`model_client`, D-auth #119). Supersedes the subagent split (D3) and the off-orchestrator finalize (D14) | Extraction now runs the Claude Agent SDK in-process and parallel concurrency is bounded by subscription/API rate limits (`extract_concurrency` knob); the `claude-api` backend is unproven until a metered key is used |
+| D21 | Record skills are global, not per-vault (`skills_catalog`) | Copying skills into every vault was a holdover from the Claude-Code-skill ingest, which needed them under `.claude/commands/` for discovery. The Python orchestrator (D18) just reads the file, so the copy was vestigial and created drift (each vault stale until `refresh-skills`). Skills now live in the package + `~/.watchdog/skills/records/` (user overrides) and are read directly; the classify index is built in memory (supersedes D12); per-skill `description:` frontmatter lets a user-added skill set its own index line. Pinning (`--skill`/`default_skill`, a name or path) and `watchdog show-skills` round it out. Pre-production, so vault-local copies are simply ignored (strictly global) rather than migrated | Loses per-vault skill freezing/customization; mitigated by `--skill PATH` for one-offs and by stamping the skill used into each document's note + registry (`record_skill`) for provenance. Custom skills in `~/.watchdog` aren't carried with a shared vault |
 | D20 | Configured model only — no automatic escalation; classifier model is its own knob | `model_client` originally bumped the tier up (haiku→sonnet→opus) on a JSON-validation failure. That makes ingest cost unpredictable and can silently spend opus money — the opposite of a budgeted pipeline. Now a failed call retries on the **same** configured model (the orchestrator's post-flight repair + D19 sectioning handle genuine failures), and the classify step gets its own `classifier_model` knob (default haiku) alongside `extractor_model`/`finalizer_model`, so each stage's model is explicit and stable | A doc that a stronger model would have salvaged now fails instead of auto-upgrading — the user opts into a stronger model deliberately via config |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,14 +51,15 @@ The `pypi` GitHub environment and PyPI trusted-publisher entry for `watchdog-int
 
 ### Where skills live
 
-Skill files live in `src/watchdog/skills/records/`. They are plain markdown. No code changes are needed — skills are automatically picked up by the setup process when a new file is added to that directory.
+Record (domain) skill files live in `src/watchdog/skills/records/`. They are plain markdown and **global** — the ingest orchestrator reads them directly from the package via `watchdog.skills_catalog` (they are no longer copied into each vault). No code changes are needed when adding one. A user can add their own skills in `~/.watchdog/skills/records/`, which the catalog merges in (a user skill overrides a package skill of the same name). See ARCHITECTURE D21.
 
 ### Standard structure
 
-A blank template is at `src/watchdog/skills/records/_template.md` — copy it as the starting point for any new skill. Files starting with `_` are excluded from installation and will not be loaded by Claude.
+A blank template is at `src/watchdog/skills/records/_template.md` — copy it as the starting point for any new skill. Files starting with `_` are excluded from the catalog.
 
 Every skill file should follow this structure in order:
 
+0. **Frontmatter** — a YAML block with a `description:` line. This one line is the skill's entry in the classifier index, so make it a precise summary of the document types covered. (If omitted, the index falls back to the first sentence of the intro.)
 1. **Intro paragraph** — one or two sentences explaining when this skill is loaded by `/ingest`. Name the document types that trigger it.
 2. **Document types covered** — a bulleted list of the specific document types the skill applies to. This is the one section where it is acceptable to list jurisdiction-specific document names (since those are the literal names of the documents). Group by jurisdiction if there are many.
 3. **Always-present fields table** — a two-column table (`Field` | `What to look for`) listing the fields that appear in virtually every document of this type. Extract these even when not prominently displayed.

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -173,7 +173,7 @@ watchdog ingest --classify-pages 10        # show the classifier more pages of e
 watchdog ingest --skill corporate-filings  # pin one record skill, skip classification
 ```
 
-`--skill` with no value lists the installed record skills and lets you pick one interactively. For a vault that's always one document type, set it once:
+`--skill` with no value lists the available record skills and lets you pick one interactively; `--skill path/to/skill.md` pins an ad-hoc skill file. Run `watchdog show-skills` to see what the built-in skills cover (it also opens the skills folder on GitHub), and add your own in `~/.watchdog/skills/records/`. For a vault that's always one document type, set it once:
 
 ```bash
 watchdog configure extractor_model haiku

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ For a full end-to-end walkthrough of a first investigation, see [GETTING_STARTED
 | `watchdog ingest --classifier-model M` | Override the document-classification model for this run (`sonnet`/`opus`/`haiku`; default from `watchdog configure`: `haiku`) |
 | `watchdog ingest --concurrency N` | Documents extracted in parallel for this run (default from `watchdog configure`: 5) |
 | `watchdog ingest --classify-pages N` | Pages shown to the document classifier for this run (default from `watchdog configure`: 5) |
-| `watchdog ingest --skill [NAME]` | Pin a record skill for every document, skipping classification. Pass a name, or `--skill` with no value to pick interactively |
+| `watchdog ingest --skill [NAME\|PATH]` | Pin a record skill (a name or a path to a skill file) for every document, skipping classification. `--skill` with no value picks from the list |
 | `watchdog context [name]` | Open Claude Code with the context seeding skill; omit name when inside the vault |
 | `watchdog context --model M` | Override the model for context seeding (`sonnet`/`opus`/`haiku`, default: `sonnet`) |
 | `watchdog watch [name]` | Watch `_INCOMING/` and chew files automatically as they arrive; omit name when inside the project directory |
@@ -230,7 +230,8 @@ For a full end-to-end walkthrough of a first investigation, see [GETTING_STARTED
 | `watchdog auth remove [provider]` | Delete a stored API key |
 | `watchdog unlock <name>` | Release a stale chew or ingest lock; `--force` to remove even if recent |
 | `watchdog setup` | Set up Watchdog after installation; `--force` to re-run |
-| `watchdog refresh-skills [name]` | Update vault skill files after a watchdog upgrade; omit name when inside the project directory |
+| `watchdog refresh-skills [name]` | Update a vault's Claude Code command skills after a watchdog upgrade (record skills are global, so they never need refreshing); omit name when inside the project directory |
+| `watchdog show-skills [name]` | List the record skills (and open the skills folder on GitHub), or print one skill in full |
 | `watchdog about` | Show version and project links |
 
 ### Claude Code slash commands
@@ -388,7 +389,7 @@ Skills are jurisdiction-agnostic by default: universal principles come first, wi
 
 These skills encode real investigative knowledge — what fields are always present, what patterns are anomalous, what investigators typically miss. See [src/watchdog/skills/records/](src/watchdog/skills/records/) to read them or contribute new ones. A contributor template is at [`src/watchdog/skills/records/_template.md`](src/watchdog/skills/records/_template.md).
 
-Skills are installed into each vault's `.claude/commands/records/` folder when you run `watchdog new`, so they travel with the investigation and can be customized per-vault. After upgrading Watchdog, run `watchdog refresh-skills` from inside a vault to pull in updated skills.
+Record skills are **global** — the ingest pipeline reads them straight from the installed package, so they're always current with no per-vault copies to refresh. Add your own in `~/.watchdog/skills/records/` (a custom skill overrides a built-in one of the same name), point a single run at any file with `watchdog ingest --skill path/to/skill.md`, and read what a skill says with `watchdog show-skills`.
 
 ---
 
@@ -453,7 +454,7 @@ watchdog configure <key> <value>
 | `finalizer_model` | `sonnet` | Claude model for post-ingest — entity synthesis (Summary + Analysis for entities in ≥2 documents) + timeline reconciliation + briefing. Options: `haiku`, `sonnet`, `opus`. Per-run override: `--finalizer-model`. |
 | `extract_concurrency` | `5` | Documents extracted in parallel during `watchdog ingest`. Lower it if you hit model rate limits; raise it for throughput. Per-run override: `--concurrency`. |
 | `classify_pages` | `5` | Leading pages of each document shown to the classifier (`min(page_count, this)`). More pages classify ambiguous documents better at a small extra cost on the cheap classifier model. Per-run override: `--classify-pages`. |
-| `default_skill` | _(unset)_ | Pin a record skill (a name from the vault's records dir) for every ingested document, skipping classification — for vaults that are always one document type. Per-run override: `--skill`. |
+| `default_skill` | _(unset)_ | Pin a record skill (a name from the global catalog, or a path to a skill file) for every ingested document, skipping classification — for vaults that are always one document type. Per-run override: `--skill`. |
 
 **Examples:**
 
@@ -537,7 +538,7 @@ Please open an issue before starting significant work so we can discuss approach
 - **Registries** (`.watchdog/Registry/documents.json`, `entities.json`, `manifest.json`) are the source of truth. Obsidian notes are generated outputs — deleting a note doesn't lose data. `manifest.json` is a lightweight id/name/type/aliases index used for entity lookup without loading full registry data.
 - **Vault writes are file-locked** — `write_vault` acquires an exclusive lock on `.watchdog/Registry/.write-lock` before reading and writing registry files, so the concurrent document workers serialize safely without corruption.
 - **Ingest is a Python orchestrator** — `watchdog ingest` runs the pipeline in your terminal and calls the model only for reasoning (classify, extract, synthesize, dedup the timeline, brief). Documents are extracted in parallel (bounded by `extract_concurrency`); the slow mechanical work and all bookkeeping stay in Python.
-- **Skills are per-vault** — domain knowledge skill files live in `.claude/commands/records/` inside each vault, installed by `watchdog new` and refreshed by `watchdog refresh-skills`. This means skills travel with the investigation and can be customized per-vault.
+- **Record skills are global** — domain-knowledge skill files ship with the package and are read directly by the ingest pipeline (`watchdog.skills_catalog`); nothing is copied per vault, so they're always current. Users add custom skills in `~/.watchdog/skills/records/`. (Claude Code *command* skills like `/watchdog-query` are still installed per vault by `watchdog new` / `refresh-skills`.)
 - **Single CLI entry point** — `watchdog` is the only command installed on your PATH. All pipeline utilities are subcommands.
 
 ---

--- a/src/watchdog/cli.py
+++ b/src/watchdog/cli.py
@@ -81,6 +81,7 @@ from watchdog.cmd.setup import (
     cmd_configure,
     cmd_refresh_skills,
     cmd_setup,
+    cmd_show_skills,
     cmd_unlock,
 )
 from watchdog.cmd.auth import cmd_auth
@@ -194,6 +195,10 @@ def main() -> None:
     p_refresh = sub.add_parser("refresh-skills", help="Update skill files in a vault after a watchdog upgrade")
     p_refresh.add_argument("name", nargs="?", help="Investigation name or slug (default: current directory)").completer = _project_completer
     p_refresh.set_defaults(func=cmd_refresh_skills)
+
+    p_show_skills = sub.add_parser("show-skills", help="List the record skills, or print one (opens the skills folder on GitHub)")
+    p_show_skills.add_argument("name", nargs="?", help="Skill name to print in full (omit to list all)")
+    p_show_skills.set_defaults(func=cmd_show_skills)
 
     p_about = sub.add_parser("about", help="Show version and project links")
     p_about.set_defaults(func=cmd_about)

--- a/src/watchdog/cmd/base.py
+++ b/src/watchdog/cmd/base.py
@@ -114,7 +114,7 @@ _CMD_HELP: dict[str, dict] = {
             ("--classifier-model M", "Override the document-classification model for this run (sonnet/opus/haiku; default from watchdog configure)"),
             ("--concurrency N",      "Documents extracted in parallel for this run (default from watchdog configure: 5)"),
             ("--classify-pages N",   "Pages shown to the document classifier for this run (default from watchdog configure: 5)"),
-            ("--skill [NAME]",       "Pin a record skill for every document, skipping classification (no value = pick interactively)"),
+            ("--skill [NAME|PATH]",  "Pin a record skill (name or file path) for every document, skipping classification (no value = pick from the list)"),
         ],
     },
     "context": {

--- a/src/watchdog/cmd/ingest.py
+++ b/src/watchdog/cmd/ingest.py
@@ -19,50 +19,51 @@ from watchdog.cmd.base import (
 _PICK_SKILL = "\x00pick"
 
 
-def _available_skills(vault: Path) -> list[str]:
-    """Installed record-skill names (filenames minus .md), excluding internal `_` files."""
-    records = vault / ".claude" / "commands" / "records"
-    if not records.is_dir():
-        return []
-    return sorted(p.stem for p in records.glob("*.md") if not p.name.startswith("_"))
-
-
-def _pick_skill_interactive(vault: Path) -> str | None:
-    """Numbered picker for `watchdog ingest --skill` (no value). Enter → classify per doc."""
-    skills = _available_skills(vault)
-    if not skills:
-        print(f"\n  {_DIM}No record skills installed — classifying each document.{_RESET}")
+def _pick_skill_interactive() -> str | None:
+    """Numbered picker for `watchdog ingest --skill` (no value), drawn from the global
+    skill catalog. Returns the chosen skill's file path; Enter → classify per doc."""
+    from watchdog import skills_catalog
+    catalog = skills_catalog.catalog()
+    if not catalog:
+        print(f"\n  {_DIM}No record skills available — classifying each document.{_RESET}")
         return None
+    names = list(catalog)
     print(f"\n  {_BOLD}Pin a record skill{_RESET} {_DIM}for all documents (skips per-document classification):{_RESET}\n")
-    for i, s in enumerate(skills, 1):
-        print(f"    {_CYAN}{i:>2}{_RESET}  {s}")
+    for i, name in enumerate(names, 1):
+        print(f"    {_CYAN}{i:>2}{_RESET}  {name}")
     try:
         ans = input("\n  Number, or Enter to classify each: ").strip()
     except (EOFError, KeyboardInterrupt):
         print()
         return None
-    if ans.isdigit() and 1 <= int(ans) <= len(skills):
-        return skills[int(ans) - 1]
+    if ans.isdigit() and 1 <= int(ans) <= len(names):
+        return catalog[names[int(ans) - 1]]
     if ans:
         print(f"  {_DIM}Not a valid choice — classifying each document.{_RESET}")
     return None
 
 
-def _resolve_pinned_skill(args, vault: Path, config: dict) -> str | None:
-    """Resolve the pinned record skill — `--skill` flag → interactive picker → `default_skill`
-    config. Exits with the available list if an explicitly named skill doesn't exist."""
+def _resolve_pinned_skill(args, config: dict) -> str | None:
+    """Resolve the pinned record skill to a file path — `--skill` flag → interactive picker
+    → `default_skill` config. The value may be a **skill name** (from the global catalog) or
+    a **path to a skill file**. Exits if a named skill isn't found and isn't a file."""
+    from watchdog import skills_catalog
     raw = getattr(args, "skill", None)
     if raw == _PICK_SKILL:
-        return _pick_skill_interactive(vault)          # the picker only offers valid skills
-    skill = raw or config.get("default_skill")
-    if not skill:
+        return _pick_skill_interactive()                   # picker returns a path or None
+    value = raw or config.get("default_skill")
+    if not value:
         return None
-    canon = skill.removesuffix(".md")
-    if canon not in _available_skills(vault):
-        avail = ", ".join(_available_skills(vault)) or "(none installed)"
-        sys.exit(f"\n  {_YELLOW}Error:{_RESET} unknown record skill {_BOLD}{canon}{_RESET}.\n"
-                 f"  Available: {_CYAN}{avail}{_RESET}\n")
-    return canon
+    as_path = Path(value).expanduser()
+    if as_path.is_file():                                   # an explicit skill file
+        return str(as_path.resolve())
+    catalog = skills_catalog.catalog()                      # otherwise a catalog name
+    canon = value.removesuffix(".md")
+    if canon in catalog:
+        return catalog[canon]
+    avail = ", ".join(catalog) or "(none available)"
+    sys.exit(f"\n  {_YELLOW}Error:{_RESET} record skill {_BOLD}{canon}{_RESET} not found "
+             f"(not a known skill or a file path).\n  Available: {_CYAN}{avail}{_RESET}\n")
 
 
 def _run_preprocess(
@@ -190,9 +191,9 @@ def cmd_ingest(args, *, confirm: bool = True) -> None:
     q = len(result["queue_files"])
     print(f"\n  {_BOLD}{q} document{'s' if q != 1 else ''}{_RESET} ready for extraction")
 
-    pinned_skill = _resolve_pinned_skill(args, vault, config)
+    pinned_skill = _resolve_pinned_skill(args, config)
     if pinned_skill:
-        print(f"  {_DIM}Skill pinned:{_RESET} {_CYAN}{pinned_skill}{_RESET}{_DIM} — classification skipped.{_RESET}")
+        print(f"  {_DIM}Skill pinned:{_RESET} {_CYAN}{Path(pinned_skill).stem}{_RESET}{_DIM} — classification skipped.{_RESET}")
 
     def _release_lock() -> None:
         (vault / ".watchdog" / "Registry" / ".ingest-lock").unlink(missing_ok=True)

--- a/src/watchdog/cmd/setup.py
+++ b/src/watchdog/cmd/setup.py
@@ -375,6 +375,56 @@ def cmd_refresh_skills(args) -> None:
     print()
 
 
+def cmd_show_skills(args) -> None:
+    """List the global record skills, or print one. With no name, also opens the skills
+    folder on GitHub so the full text is easy to read."""
+    import webbrowser
+    from watchdog import skills_catalog
+
+    catalog = skills_catalog.catalog()
+    name = getattr(args, "name", None)
+
+    if name:
+        canon = name.removesuffix(".md")
+        if canon not in catalog:
+            sys.exit(f"\n  {_YELLOW}Error:{_RESET} no record skill {_BOLD}{canon}{_RESET}.\n"
+                     f"  Run {_CYAN}watchdog show-skills{_RESET}{_DIM} to list them.{_RESET}\n")
+        print()
+        print(Path(catalog[canon]).read_text(encoding="utf-8"))
+        return
+
+    print()
+    print(f"  {_BOLD}Record skills{_RESET}  {_DIM}{len(catalog)} available{_RESET}")
+    print()
+    for n, path in catalog.items():
+        desc = skills_catalog._skill_descriptor(Path(path).read_text(encoding="utf-8"))
+        if len(desc) > 96:
+            desc = desc[:95].rstrip() + "…"
+        print(f"  {_CYAN}{n}{_RESET}")
+        print(f"  {_DIM}{desc}{_RESET}\n")
+
+    try:
+        ver = _pkg_version()
+    except Exception:
+        ver = None
+    url = skills_catalog.github_skills_url("main")
+    print(f"  {_DIM}Read the full text:{_RESET} {_CYAN}{url}{_RESET}")
+    print(f"  {_DIM}Print one:{_RESET} {_CYAN}watchdog show-skills <name>{_RESET}")
+    print(f"  {_DIM}Add your own:{_RESET} {_CYAN}{skills_catalog.USER_SKILLS_DIR}{_RESET}")
+    if ver:
+        print(f"  {_DIM}(installed watchdog-intel {ver}){_RESET}")
+    print()
+    try:
+        webbrowser.open(url)
+    except Exception:
+        pass
+
+
+def _pkg_version() -> str:
+    from importlib.metadata import version
+    return version("watchdog-intel")
+
+
 def cmd_configure(args) -> None:
     config = {}
     if CONFIG_FILE.exists():

--- a/src/watchdog/pipeline/ingest_setup.py
+++ b/src/watchdog/pipeline/ingest_setup.py
@@ -77,14 +77,6 @@ def run(vault: Path, extractor_model: str = "sonnet", finalizer_model: str = "so
     # gate counts only this run's documents.
     shutil.rmtree(vault / ".watchdog" / "tmp" / "entity-fragments", ignore_errors=True)
 
-    # Keep the skill index current with whatever is in records/ — including skills the
-    # user added directly to the vault — so it never goes stale between refreshes.
-    try:
-        from watchdog.setup_cmd import regenerate_records_index
-        regenerate_records_index(vault / ".claude" / "commands" / "records")
-    except Exception:
-        pass
-
     started_at = _iso_now()
     batch_start = int(time.time())
     lock_file.parent.mkdir(parents=True, exist_ok=True)

--- a/src/watchdog/pipeline/orchestrate.py
+++ b/src/watchdog/pipeline/orchestrate.py
@@ -17,7 +17,7 @@ import signal
 import sys
 from pathlib import Path
 
-from watchdog import model_client
+from watchdog import model_client, skills_catalog
 from watchdog.cmd.base import _BOLD, _CYAN, _DIM, _GREEN, _RESET, _YELLOW
 from watchdog.pipeline import (
     abort, merge, preflight, postflight, prompts, schemas, section, synthesis_bundle, timeline,
@@ -78,18 +78,9 @@ def _update_graph_colours(vault: Path) -> None:
         gpath.write_text(json.dumps(graph, indent=2) + "\n", encoding="utf-8")
 
 
-def _records_dir(vault: Path) -> Path:
-    return vault / ".claude" / "commands" / "records"
-
-
 def _read_brief(vault: Path) -> str | None:
     p = vault / "context.md"
     return p.read_text(encoding="utf-8") if p.exists() else None
-
-
-def _read_skill(vault: Path, skill_filename: str) -> str:
-    p = _records_dir(vault) / skill_filename
-    return p.read_text(encoding="utf-8") if p.exists() else ""
 
 
 def _pages_text(pages: list[dict]) -> str:
@@ -103,12 +94,10 @@ def _read_sidecar(vault: Path, filename: str) -> str | None:
     return sc.read_text(encoding="utf-8") if sc.exists() else None
 
 
-async def _classify(vault: Path, doc_excerpt: str, model: str) -> str:
-    index = _records_dir(vault) / "_index.md"
-    index_text = index.read_text(encoding="utf-8") if index.exists() else ""
+async def _classify(doc_excerpt: str, model: str) -> str:
     r = await model_client.acomplete_json(
         task="classify", model=model, schema=schemas.CLASSIFY,
-        prompt=prompts.build_classify_prompt(doc_excerpt, index_text),
+        prompt=prompts.build_classify_prompt(doc_excerpt, skills_catalog.build_index()),
     )
     return r.parsed.get("skill") or "general-records.md"
 
@@ -137,7 +126,7 @@ def _write_postflight(vault: Path, sha: str, extraction: dict) -> tuple[bool, li
     return ("errors" not in outcome), outcome.get("errors", [])
 
 
-async def _simple_extract(vault, sha, pf, skill_text, brief, model):
+async def _simple_extract(vault, sha, pf, skill_text, brief, model, skill_label):
     """Whole-document extraction, with one repair attempt if post-flight rejects."""
     base = prompts.build_extract_prompt(
         pages_text=_pages_text(pf["pages"]), existing_entities=pf.get("existing_entities", []),
@@ -158,6 +147,7 @@ async def _simple_extract(vault, sha, pf, skill_text, brief, model):
         cost += r.cost_usd or 0.0
         extraction = r.parsed
         scratchpad = extraction.pop("scratchpad", "")
+        extraction.setdefault("document", {})["record_skill"] = skill_label   # provenance
         ok, errors = _write_postflight(vault, sha, extraction)
         if ok:
             return extraction, scratchpad, cost, True, []
@@ -174,7 +164,7 @@ def _carry_block(part: dict) -> str:
     return "\n".join(lines) + "\n"
 
 
-async def _extract_sectioned(vault, sha, pf, skill_text, plan, model):
+async def _extract_sectioned(vault, sha, pf, skill_text, plan, model, skill_label):
     """Sequential per-section extraction with carry-forward, then deterministic merge."""
     parts, carry, cost = [], "", 0.0
     sections = plan["sections"]
@@ -194,6 +184,7 @@ async def _extract_sectioned(vault, sha, pf, skill_text, plan, model):
 
     extraction = merge.merge_extractions(parts)
     scratchpad = "\n".join(p["observations"] for p in parts if p.get("observations"))
+    extraction.setdefault("document", {})["record_skill"] = skill_label   # provenance
     ok, errors = _write_postflight(vault, sha, extraction)
     return extraction, scratchpad, cost, ok, errors
 
@@ -222,26 +213,27 @@ async def _extract_document(vault: Path, sha: str, brief: str | None,
     pages = pf.get("pages", [])
     page_count = pf.get("page_count") or len(pages)
     if pinned_skill:
-        # Skill pinned for the whole run — skip per-document classification entirely.
-        skill = pinned_skill if pinned_skill.endswith(".md") else f"{pinned_skill}.md"
+        # Skill pinned for the whole run (a resolved skill-file path) — skip classification.
+        skill_text = Path(pinned_skill).read_text(encoding="utf-8")
+        skill_label = Path(pinned_skill).stem
     else:
         _say(f"{_DIM}→  {filename}  classifying ({page_count} page{'s' if page_count != 1 else ''})…{_RESET}")
         # Classify on the first N pages (page-aware, not a mid-page char cut); the char cap is a guard.
         excerpt = _pages_text(pages[:max(1, classify_pages)])[:_CLASSIFY_EXCERPT_CHARS]
-        skill = await _classify(vault, excerpt, classify_model)
-    skill_text = _read_skill(vault, skill)
-    skill_label = skill.removesuffix(".md")
+        skill = await _classify(excerpt, classify_model)
+        skill_text = skills_catalog.read_skill(skill)
+        skill_label = skill.removesuffix(".md")
 
     plan = section.run(vault, sha)
     if plan.get("sectioned"):
         n_sections = len(plan.get("sections", []))
         _say(f"{_DIM}→  {filename}  extracting · {skill_label} · {n_sections} sections…{_RESET}")
         extraction, scratchpad, cost, ok, errors = await _extract_sectioned(
-            vault, sha, pf, skill_text, plan, extract_model)
+            vault, sha, pf, skill_text, plan, extract_model, skill_label)
     else:
         _say(f"{_DIM}→  {filename}  extracting · {skill_label}…{_RESET}")
         extraction, scratchpad, cost, ok, errors = await _simple_extract(
-            vault, sha, pf, skill_text, brief, extract_model)
+            vault, sha, pf, skill_text, brief, extract_model, skill_label)
         # Whole-document extraction can overrun the model's output ceiling on entity-dense
         # docs (the agent-SDK backend can't cap output) — the JSON truncates and is rejected.
         # Fall back to the sectioned path, which bounds per-call output, before giving up.
@@ -253,7 +245,7 @@ async def _extract_document(vault: Path, sha: str, brief: str | None,
                      f"re-extracting in {n_sections} sections…{_RESET}")
                 whole_cost = cost
                 extraction, scratchpad, cost, ok, errors = await _extract_sectioned(
-                    vault, sha, pf, skill_text, fb, extract_model)
+                    vault, sha, pf, skill_text, fb, extract_model, skill_label)
                 cost += whole_cost   # account for the failed whole-doc attempt
 
     if not ok:
@@ -393,7 +385,7 @@ async def run(vault: Path, *, concurrency: int = DEFAULT_CONCURRENCY,
     `extract_model` drives extraction (whole-doc + section); `post_model` drives
     synthesis/timeline/briefing; `classify_model` the cheap document classifier,
     which sees the first `classify_pages` pages of each document. `pinned_skill`
-    (a record-skill name) skips classification and uses that skill for every document.
+    (a path to a skill file) skips classification and uses that skill for every document.
     """
     queue_dir = vault / ".watchdog" / "queue"
     shas = [f.stem for f in sorted(queue_dir.glob("*.json"))] if queue_dir.exists() else []

--- a/src/watchdog/pipeline/write_vault.py
+++ b/src/watchdog/pipeline/write_vault.py
@@ -549,6 +549,7 @@ def _build_document_note(doc: dict, entity_entries: list[dict], morgue_path: str
         ],
         "page_count":       doc.get("page_count"),
         "near_duplicate_of": doc.get("near_duplicate_of"),
+        "record_skill":     doc.get("record_skill"),
     })
 
     body = ""
@@ -703,6 +704,7 @@ def run(extraction_path: Path, vault_path: Path, skip_timeline: bool = False, ne
             "ingested_at":      _now_iso(),
             "page_count":       doc.get("page_count"),
             "document_type":    doc.get("document_type"),
+            "record_skill":     doc.get("record_skill"),
             "entities_extracted": [e["id"] for e in incoming_entities],
             "near_duplicate_of": doc.get("near_duplicate_of"),
             "minhash":          sig,

--- a/src/watchdog/setup_cmd.py
+++ b/src/watchdog/setup_cmd.py
@@ -51,63 +51,17 @@ def _check_deps() -> list[str]:
     return blocking_missing
 
 
-def _skill_descriptor(text: str) -> str:
-    """The first content paragraph of a record skill, minus the boilerplate lead-in.
-
-    Each skill opens with an H1, then a sentence naming the document types it covers
-    (per the authoring template). That sentence is the index descriptor.
-    """
-    line = next(
-        (s for s in (ln.strip() for ln in text.splitlines()) if s and not s.startswith("#")),
-        "",
-    )
-    for prefix in (
-        "This skill is loaded by `/ingest` when the document type is ",
-        "Loaded by `/ingest` when the document type is ",
-    ):
-        line = line.removeprefix(prefix)
-    return line.rstrip(".")
-
-
-def regenerate_records_index(records_dir: Path) -> None:
-    """Rebuild records/_index.md from every skill actually present in records_dir.
-
-    Scans the destination directory — not the package — so user-added skills are
-    indexed too, and the index self-heals on add/edit/delete. Cheap enough (one
-    short read per skill, one write) to run unconditionally on every ingest, so a
-    dropped-in skill is picked up without a manual refresh.
-    """
-    if not records_dir.is_dir():
-        return
-    entries = [
-        (f.name, _skill_descriptor(f.read_text(encoding="utf-8")))
-        for f in sorted(records_dir.glob("*.md"))
-        if not f.name.startswith("_")
-    ]
-    lines = [
-        "# Record skill index",
-        "",
-        "One line per domain skill. Match the document to the closest description, then",
-        "read that one skill file. Generated from the skills in this directory — do not edit.",
-        "",
-    ]
-    lines += [f"- `{name}` — {descriptor}" for name, descriptor in entries]
-    lines.append("")
-    (records_dir / "_index.md").write_text("\n".join(lines), encoding="utf-8")
-
-
 def install_skills(commands_dir: Path) -> None:
-    records_dir = commands_dir / "records"
-    records_dir.mkdir(parents=True, exist_ok=True)
+    """Install the per-vault Claude Code command skills (e.g. /watchdog-query).
+
+    Record (domain extraction) skills are NOT copied here — they live globally and are
+    read by the ingest orchestrator from `watchdog.skills_catalog` (see ARCHITECTURE D21).
+    """
+    commands_dir.mkdir(parents=True, exist_ok=True)
     skills = importlib.resources.files("watchdog") / "skills"
     for item in skills.iterdir():
-        if item.name == "records":
-            for f in item.iterdir():
-                if f.name.endswith(".md") and not f.name.startswith("_"):
-                    (records_dir / f.name).write_bytes(f.read_bytes())
-        elif item.name.endswith(".md") and not item.name.startswith("_"):
+        if item.name.endswith(".md") and not item.name.startswith("_"):
             (commands_dir / item.name).write_bytes(item.read_bytes())
-    regenerate_records_index(records_dir)
 
 
 def _ask_projects_dir() -> Path:

--- a/src/watchdog/skills/records/_template.md
+++ b/src/watchdog/skills/records/_template.md
@@ -1,3 +1,6 @@
+---
+description: [one line naming the document types this skill covers — shown in the classifier index]
+---
 # Domain knowledge — [Document type name]
 
 This skill is loaded by `/ingest` when the document type is a [list the trigger document types]. [One sentence on what the skill helps extract or identify.]

--- a/src/watchdog/skills/records/academic-research.md
+++ b/src/watchdog/skills/records/academic-research.md
@@ -1,3 +1,6 @@
+---
+description: a grant application, research ethics board decision, conflict-of-interest disclosure, retraction notice, research agreement, or similar academic or scientific accountability document
+---
 # Domain knowledge — Academic and research documents
 
 This skill is loaded by `/ingest` when the document type is a grant application, research ethics board decision, conflict-of-interest disclosure, retraction notice, research agreement, or similar academic or scientific accountability document.

--- a/src/watchdog/skills/records/administrative-tribunals.md
+++ b/src/watchdog/skills/records/administrative-tribunals.md
@@ -1,3 +1,6 @@
+---
+description: a decision, order, or ruling from a quasi-judicial administrative tribunal that is not a court of law, not a labour or employment arbitration (covered by `labour-arbitration`), not an immigration body (covered by `immigration-refugee`), and not a professional licensing panel (covered by `professional-licensing` or `healthcare-licensing`). Administrative tribunals are government-created bodies with statutory powers to hear disputes and make binding decisions
+---
 # Domain knowledge — Administrative tribunal records
 
 This skill is loaded by `/ingest` when the document type is a decision, order, or ruling from a quasi-judicial administrative tribunal that is not a court of law, not a labour or employment arbitration (covered by `labour-arbitration`), not an immigration body (covered by `immigration-refugee`), and not a professional licensing panel (covered by `professional-licensing` or `healthcare-licensing`). Administrative tribunals are government-created bodies with statutory powers to hear disputes and make binding decisions.

--- a/src/watchdog/skills/records/aircraft-logs.md
+++ b/src/watchdog/skills/records/aircraft-logs.md
@@ -1,3 +1,6 @@
+---
+description: an aircraft registration, flight log, airworthiness record, ADS-B flight track, safety investigation report, or similar aviation document
+---
 # Domain knowledge — Aircraft logs and aviation records
 
 This skill is loaded by `/ingest` when the document type is an aircraft registration, flight log, airworthiness record, ADS-B flight track, safety investigation report, or similar aviation document.

--- a/src/watchdog/skills/records/audio-video.md
+++ b/src/watchdog/skills/records/audio-video.md
@@ -1,3 +1,6 @@
+---
+description: a YouTube video transcript, podcast transcript, broadcast transcript, recorded speech, deposition video, or similar audio or video-derived text
+---
 # Domain knowledge — Audio and video content
 
 This skill is loaded by `/ingest` when the document type is a YouTube video transcript, podcast transcript, broadcast transcript, recorded speech, deposition video, or similar audio or video-derived text.

--- a/src/watchdog/skills/records/audit-reports.md
+++ b/src/watchdog/skills/records/audit-reports.md
@@ -1,3 +1,6 @@
+---
+description: an auditor general report, value-for-money audit, performance audit, internal audit report, public accounts, inspector general report, or similar public accountability document
+---
 # Domain knowledge — Audit reports
 
 This skill is loaded by `/ingest` when the document type is an auditor general report, value-for-money audit, performance audit, internal audit report, public accounts, inspector general report, or similar public accountability document.

--- a/src/watchdog/skills/records/bankruptcy.md
+++ b/src/watchdog/skills/records/bankruptcy.md
@@ -1,3 +1,6 @@
+---
+description: a bankruptcy filing, proposal, creditor list, trustee report, receiving order, or similar insolvency record
+---
 # Domain knowledge — Bankruptcy and insolvency records
 
 Loaded by `/ingest` when the document type is a bankruptcy filing, proposal, creditor list, trustee report, receiving order, or similar insolvency record.

--- a/src/watchdog/skills/records/corporate-filings.md
+++ b/src/watchdog/skills/records/corporate-filings.md
@@ -1,3 +1,6 @@
+---
+description: an annual report, corporate registration, director filing, or similar corporate record
+---
 # Domain knowledge — Corporate filings
 
 This skill is loaded by `/ingest` when the document type is an annual report, corporate registration, director filing, or similar corporate record.

--- a/src/watchdog/skills/records/corrections-records.md
+++ b/src/watchdog/skills/records/corrections-records.md
@@ -1,3 +1,6 @@
+---
+description: a parole board decision, probation order, correctional investigator report, prison inspection report, institutional grievance decision, conditional release record, or similar document originating from correctional services, parole boards, or corrections oversight bodies. For police-generated documents (use-of-force reports, occurrence reports, misconduct decisions), use `police-records` instead
+---
 # Domain knowledge — Corrections, parole, and custody records
 
 This skill is loaded by `/ingest` when the document type is a parole board decision, probation order, correctional investigator report, prison inspection report, institutional grievance decision, conditional release record, or similar document originating from correctional services, parole boards, or corrections oversight bodies. For police-generated documents (use-of-force reports, occurrence reports, misconduct decisions), use `police-records` instead.

--- a/src/watchdog/skills/records/court-documents.md
+++ b/src/watchdog/skills/records/court-documents.md
@@ -1,3 +1,6 @@
+---
+description: a statement of claim, affidavit, judgment, court order, or similar legal proceeding record
+---
 # Domain knowledge — Court documents
 
 Loaded by `/ingest` when the document type is a statement of claim, affidavit, judgment, court order, or similar legal proceeding record.

--- a/src/watchdog/skills/records/criminal-proceedings.md
+++ b/src/watchdog/skills/records/criminal-proceedings.md
@@ -1,3 +1,6 @@
+---
+description: a criminal court document — including a charging document, bail or remand decision, preliminary hearing transcript, trial decision, sentencing decision, or appeal in a criminal matter
+---
 # Domain knowledge — Criminal proceedings
 
 This skill is loaded by `/ingest` when the document type is a criminal court document — including a charging document, bail or remand decision, preliminary hearing transcript, trial decision, sentencing decision, or appeal in a criminal matter.

--- a/src/watchdog/skills/records/dns-whois.md
+++ b/src/watchdog/skills/records/dns-whois.md
@@ -1,3 +1,6 @@
+---
+description: a WHOIS registration record, DNS zone file excerpt, domain registration history, IP address allocation, or related internet infrastructure record
+---
 # Domain knowledge — DNS and WHOIS records
 
 This skill is loaded by `/ingest` when the document type is a WHOIS registration record, DNS zone file excerpt, domain registration history, IP address allocation, or related internet infrastructure record.

--- a/src/watchdog/skills/records/election-filings.md
+++ b/src/watchdog/skills/records/election-filings.md
@@ -1,3 +1,6 @@
+---
+description: a campaign finance disclosure, donor list, third-party advertising return, or similar electoral record
+---
 # Domain knowledge — Election filings
 
 This skill is loaded by `/ingest` when the document type is a campaign finance disclosure, donor list, third-party advertising return, or similar electoral record.

--- a/src/watchdog/skills/records/environmental-filings.md
+++ b/src/watchdog/skills/records/environmental-filings.md
@@ -1,3 +1,6 @@
+---
+description: a pollutant release inventory report, environmental assessment, spill record, inspection report, compliance order, or similar environmental regulatory document
+---
 # Domain knowledge — Environmental filings
 
 This skill is loaded by `/ingest` when the document type is a pollutant release inventory report, environmental assessment, spill record, inspection report, compliance order, or similar environmental regulatory document.

--- a/src/watchdog/skills/records/financial-statements.md
+++ b/src/watchdog/skills/records/financial-statements.md
@@ -1,3 +1,6 @@
+---
+description: a balance sheet, income statement, auditor's report, management discussion and analysis (MD&A), or similar financial disclosure
+---
 # Domain knowledge — Financial statements
 
 Loaded by `/ingest` when the document type is a balance sheet, income statement, auditor's report, management discussion and analysis (MD&A), or similar financial disclosure.

--- a/src/watchdog/skills/records/foi-responses.md
+++ b/src/watchdog/skills/records/foi-responses.md
@@ -1,3 +1,6 @@
+---
+description: a freedom of information or access to information response package, severance log, exemption index, or related disclosure record
+---
 # Domain knowledge — Freedom of information responses
 
 This skill is loaded by `/ingest` when the document type is a freedom of information or access to information response package, severance log, exemption index, or related disclosure record.

--- a/src/watchdog/skills/records/general-records.md
+++ b/src/watchdog/skills/records/general-records.md
@@ -1,3 +1,6 @@
+---
+description: This skill is loaded by `/ingest` when the document type does not match any specific record skill. It provides a universal framework for reading an unfamiliar document: how to orient yourself, what to extract regardless of type, and what patterns are worth flagging in any record
+---
 # Domain knowledge — General records
 
 This skill is loaded by `/ingest` when the document type does not match any specific record skill. It provides a universal framework for reading an unfamiliar document: how to orient yourself, what to extract regardless of type, and what patterns are worth flagging in any record.

--- a/src/watchdog/skills/records/government-contracts.md
+++ b/src/watchdog/skills/records/government-contracts.md
@@ -1,3 +1,6 @@
+---
+description: a procurement record, tender document, contract award, access-to-information/FOIA response, or similar government contracting record
+---
 # Domain knowledge — Government contracts and procurement records
 
 Loaded by `/ingest` when the document type is a procurement record, tender document, contract award, access-to-information/FOIA response, or similar government contracting record.

--- a/src/watchdog/skills/records/government-reports.md
+++ b/src/watchdog/skills/records/government-reports.md
@@ -1,3 +1,6 @@
+---
+description: a government-produced report, departmental evaluation, royal commission report, public inquiry report, task force report, advisory council report, or similar policy document produced by or for a government body
+---
 # Domain knowledge — Government reports
 
 This skill is loaded by `/ingest` when the document type is a government-produced report, departmental evaluation, royal commission report, public inquiry report, task force report, advisory council report, or similar policy document produced by or for a government body.

--- a/src/watchdog/skills/records/healthcare-licensing.md
+++ b/src/watchdog/skills/records/healthcare-licensing.md
@@ -1,3 +1,6 @@
+---
+description: a health regulatory body discipline decision, fitness to practise finding, hospital incident report, public health inspection report, or similar professional licensing or healthcare regulatory document
+---
 # Domain knowledge — Healthcare licensing and regulatory records
 
 This skill is loaded by `/ingest` when the document type is a health regulatory body discipline decision, fitness to practise finding, hospital incident report, public health inspection report, or similar professional licensing or healthcare regulatory document.

--- a/src/watchdog/skills/records/immigration-refugee.md
+++ b/src/watchdog/skills/records/immigration-refugee.md
@@ -1,3 +1,6 @@
+---
+description: an immigration tribunal decision, asylum ruling, deportation order, refugee protection decision, or related immigration record
+---
 # Domain knowledge — Immigration and refugee documents
 
 This skill is loaded by `/ingest` when the document type is an immigration tribunal decision, asylum ruling, deportation order, refugee protection decision, or related immigration record.

--- a/src/watchdog/skills/records/insurance-filings.md
+++ b/src/watchdog/skills/records/insurance-filings.md
@@ -1,3 +1,6 @@
+---
+description: an insurance regulatory return, actuarial report, reinsurance treaty, market conduct review report, or similar insurance industry regulatory document
+---
 # Domain knowledge — Insurance filings
 
 This skill is loaded by `/ingest` when the document type is an insurance regulatory return, actuarial report, reinsurance treaty, market conduct review report, or similar insurance industry regulatory document.

--- a/src/watchdog/skills/records/labour-arbitration.md
+++ b/src/watchdog/skills/records/labour-arbitration.md
@@ -1,3 +1,6 @@
+---
+description: a grievance arbitration award, labour board decision, collective agreement, interest arbitration award, unfair labour practice ruling, or similar labour relations document
+---
 # Domain knowledge — Labour and arbitration records
 
 This skill is loaded by `/ingest` when the document type is a grievance arbitration award, labour board decision, collective agreement, interest arbitration award, unfair labour practice ruling, or similar labour relations document.

--- a/src/watchdog/skills/records/land-registries.md
+++ b/src/watchdog/skills/records/land-registries.md
@@ -1,3 +1,6 @@
+---
+description: a land registry extract, title search, cadastral record, RDPRM registration, or similar document from a property rights registration system
+---
 # Domain knowledge — Land registries and title systems
 
 This skill is loaded by `/ingest` when the document type is a land registry extract, title search, cadastral record, RDPRM registration, or similar document from a property rights registration system.

--- a/src/watchdog/skills/records/legislation.md
+++ b/src/watchdog/skills/records/legislation.md
@@ -1,3 +1,6 @@
+---
+description: a statute, regulation, order-in-council, government policy directive, government white paper, consultation paper, or similar primary or secondary legislation. This skill covers the documents through which governments create legal obligations and policy frameworks — not the decisions applying them (see `court-documents`, `administrative-tribunals`, and others for adjudicative records)
+---
 # Domain knowledge — Laws, regulations, and policy documents
 
 This skill is loaded by `/ingest` when the document type is a statute, regulation, order-in-council, government policy directive, government white paper, consultation paper, or similar primary or secondary legislation. This skill covers the documents through which governments create legal obligations and policy frameworks — not the decisions applying them (see `court-documents`, `administrative-tribunals`, and others for adjudicative records).

--- a/src/watchdog/skills/records/legislature-transcripts.md
+++ b/src/watchdog/skills/records/legislature-transcripts.md
@@ -1,3 +1,6 @@
+---
+description: a Hansard transcript, committee transcript, parliamentary debate record, legislative assembly record, or similar verbatim record of legislative proceedings
+---
 # Domain knowledge — Legislature transcripts
 
 This skill is loaded by `/ingest` when the document type is a Hansard transcript, committee transcript, parliamentary debate record, legislative assembly record, or similar verbatim record of legislative proceedings.

--- a/src/watchdog/skills/records/lobbying-records.md
+++ b/src/watchdog/skills/records/lobbying-records.md
@@ -1,3 +1,6 @@
+---
+description: a lobbyist registration, communication report, client-registrant relationship filing, or similar lobbying disclosure
+---
 # Domain knowledge — Lobbying records
 
 This skill is loaded by `/ingest` when the document type is a lobbyist registration, communication report, client-registrant relationship filing, or similar lobbying disclosure.

--- a/src/watchdog/skills/records/municipal-records.md
+++ b/src/watchdog/skills/records/municipal-records.md
@@ -1,3 +1,6 @@
+---
+description: a council agenda or minutes, development permit, variance application, zoning amendment, conflict-of-interest disclosure, or other municipal government record
+---
 # Domain knowledge — Municipal records
 
 This skill is loaded by `/ingest` when the document type is a council agenda or minutes, development permit, variance application, zoning amendment, conflict-of-interest disclosure, or other municipal government record.

--- a/src/watchdog/skills/records/news-clippings.md
+++ b/src/watchdog/skills/records/news-clippings.md
@@ -1,3 +1,6 @@
+---
+description: a news article, press clipping, wire story, press release, or similar published or distributed text
+---
 # Domain knowledge — News stories and clippings
 
 This skill is loaded by `/ingest` when the document type is a news article, press clipping, wire story, press release, or similar published or distributed text.

--- a/src/watchdog/skills/records/police-records.md
+++ b/src/watchdog/skills/records/police-records.md
@@ -1,3 +1,6 @@
+---
+description: a police occurrence report, use-of-force report, disciplinary decision, public complaint decision, coroner's inquest, or similar law enforcement document. For parole board decisions, probation records, prison inspection reports, and corrections oversight documents, use `corrections-records` instead
+---
 # Domain knowledge — Police records
 
 This skill is loaded by `/ingest` when the document type is a police occurrence report, use-of-force report, disciplinary decision, public complaint decision, coroner's inquest, or similar law enforcement document. For parole board decisions, probation records, prison inspection reports, and corrections oversight documents, use `corrections-records` instead.

--- a/src/watchdog/skills/records/procurement-records.md
+++ b/src/watchdog/skills/records/procurement-records.md
@@ -1,3 +1,6 @@
+---
+description: a standing offer, task authorization, supply arrangement, vendor performance report, contract amendment, or similar post-award procurement document
+---
 # Domain knowledge — Procurement and contract records
 
 This skill is loaded by `/ingest` when the document type is a standing offer, task authorization, supply arrangement, vendor performance report, contract amendment, or similar post-award procurement document.

--- a/src/watchdog/skills/records/professional-licensing.md
+++ b/src/watchdog/skills/records/professional-licensing.md
@@ -1,3 +1,6 @@
+---
+description: a discipline decision, conduct review, fitness-to-practise order, licence revocation or suspension, or similar regulatory action from a professional licensing body for non-healthcare professions. For healthcare professions (medicine, nursing, pharmacy, dentistry), use `healthcare-licensing` instead
+---
 # Domain knowledge — Professional licensing and discipline records
 
 This skill is loaded by `/ingest` when the document type is a discipline decision, conduct review, fitness-to-practise order, licence revocation or suspension, or similar regulatory action from a professional licensing body for non-healthcare professions. For healthcare professions (medicine, nursing, pharmacy, dentistry), use `healthcare-licensing` instead.

--- a/src/watchdog/skills/records/real-estate.md
+++ b/src/watchdog/skills/records/real-estate.md
@@ -1,3 +1,6 @@
+---
+description: a title transfer, deed, mortgage instrument, lien, property assessment, or similar real property market transaction record
+---
 # Domain knowledge — Real estate records
 
 Loaded by `/ingest` when the document type is a title transfer, deed, mortgage instrument, lien, property assessment, or similar real property market transaction record.

--- a/src/watchdog/skills/records/regulatory-filings.md
+++ b/src/watchdog/skills/records/regulatory-filings.md
@@ -1,3 +1,6 @@
+---
+description: a securities disclosure, insider trading report, continuous disclosure document, prospectus, or similar filing with a securities regulator
+---
 # Domain knowledge — Regulatory filings
 
 This skill is loaded by `/ingest` when the document type is a securities disclosure, insider trading report, continuous disclosure document, prospectus, or similar filing with a securities regulator.

--- a/src/watchdog/skills/records/tax-documents.md
+++ b/src/watchdog/skills/records/tax-documents.md
@@ -1,3 +1,6 @@
+---
+description: a charity information return, nonprofit tax filing, trust return, or similar tax filing by a nonprofit, charity, or trust
+---
 # Domain knowledge — Tax documents
 
 This skill is loaded by `/ingest` when the document type is a charity information return, nonprofit tax filing, trust return, or similar tax filing by a nonprofit, charity, or trust.

--- a/src/watchdog/skills/records/vehicle-registrations.md
+++ b/src/watchdog/skills/records/vehicle-registrations.md
@@ -1,3 +1,6 @@
+---
+description: a motor vehicle registration, certificate of title, vehicle lien record, vessel registration, or related transport registration document. For aircraft, use `aircraft-logs` instead, which covers aircraft registration, airworthiness, and flight tracking
+---
 # Domain knowledge — Vehicle and vessel registration records
 
 This skill is loaded by `/ingest` when the document type is a motor vehicle registration, certificate of title, vehicle lien record, vessel registration, or related transport registration document. For aircraft, use `aircraft-logs` instead, which covers aircraft registration, airworthiness, and flight tracking.

--- a/src/watchdog/skills_catalog.py
+++ b/src/watchdog/skills_catalog.py
@@ -1,0 +1,119 @@
+"""Global record-skill catalog.
+
+Record skills (domain extraction knowledge) live in two **global** places, not per
+vault:
+
+  - the package's bundled skills (``watchdog/skills/records/*.md``) — the canonical set;
+  - the user's custom dir (``~/.watchdog/skills/records/*.md``) — additions / overrides.
+
+The ingest orchestrator reads skills from here and builds the classification index in
+memory; nothing is copied into individual vaults (see ARCHITECTURE D21). A user skill
+overrides a package skill of the same name.
+"""
+
+import importlib.resources
+from pathlib import Path
+
+WATCHDOG_HOME = Path.home() / ".watchdog"
+USER_SKILLS_DIR = WATCHDOG_HOME / "skills" / "records"
+
+# Where the canonical skills are browsable. Pinned to a ref by `watchdog show-skills`.
+GITHUB_REPO = "tomcardoso/watchdog"
+_GITHUB_SKILLS_PATH = "src/watchdog/skills/records"
+
+
+def github_skills_url(ref: str = "main", name: str | None = None) -> str:
+    base = f"https://github.com/{GITHUB_REPO}/tree/{ref}/{_GITHUB_SKILLS_PATH}"
+    return f"{base}/{name}.md".replace("/tree/", "/blob/") if name else base
+
+
+def _split_frontmatter(text: str) -> tuple[dict, str]:
+    """Parse a leading ``---`` YAML-ish frontmatter block into a flat {key: value} dict
+    plus the remaining body. Only simple ``key: value`` lines are read (no nesting)."""
+    if not text.startswith("---"):
+        return {}, text
+    lines = text.splitlines()
+    end = next((i for i in range(1, len(lines)) if lines[i].strip() == "---"), None)
+    if end is None:
+        return {}, text
+    meta: dict[str, str] = {}
+    for ln in lines[1:end]:
+        if ":" in ln:
+            k, _, v = ln.partition(":")
+            meta[k.strip()] = v.strip().strip('"\'')
+    return meta, "\n".join(lines[end + 1:])
+
+
+def _skill_descriptor(text: str) -> str:
+    """A skill's one-line index descriptor.
+
+    Prefers an explicit ``description:`` in YAML frontmatter (so a user can set their own);
+    otherwise falls back to the first content sentence after the H1 (the authoring template
+    opens with a sentence naming the document types covered).
+    """
+    meta, body = _split_frontmatter(text)
+    if meta.get("description"):
+        return meta["description"]
+    line = next(
+        (s for s in (ln.strip() for ln in body.splitlines()) if s and not s.startswith("#")),
+        "",
+    )
+    for prefix in (
+        "This skill is loaded by `/ingest` when the document type is ",
+        "Loaded by `/ingest` when the document type is ",
+    ):
+        line = line.removeprefix(prefix)
+    return line.rstrip(".")
+
+
+def _package_records():
+    """Traversable for the package's bundled records dir."""
+    return importlib.resources.files("watchdog") / "skills" / "records"
+
+
+def catalog() -> dict[str, str]:
+    """Map skill name (no ``.md``) → file path, from package skills + the user custom dir.
+
+    User skills override package skills of the same name. Internal ``_`` files are excluded.
+    """
+    out: dict[str, str] = {}
+    try:
+        for f in _package_records().iterdir():
+            if f.name.endswith(".md") and not f.name.startswith("_"):
+                out[f.name[:-3]] = str(f)
+    except (FileNotFoundError, NotADirectoryError, ModuleNotFoundError, OSError):
+        pass
+    if USER_SKILLS_DIR.is_dir():
+        for f in sorted(USER_SKILLS_DIR.glob("*.md")):
+            if not f.name.startswith("_"):
+                out[f.stem] = str(f)
+    return dict(sorted(out.items()))
+
+
+def read_skill(name: str) -> str:
+    """Full markdown of a skill by name (with or without ``.md``), or '' if unknown."""
+    path = catalog().get(name.removesuffix(".md"))
+    return Path(path).read_text(encoding="utf-8") if path else ""
+
+
+def build_index() -> str:
+    """The classification index text, generated in memory from the catalog.
+
+    Lists one ``- `name.md` — descriptor`` line per skill; the classifier returns the
+    matching ``name.md``.
+    """
+    lines = [
+        "# Record skill index",
+        "",
+        "One line per domain skill. Match the document to the closest description, then",
+        "read that one skill file.",
+        "",
+    ]
+    for name, path in catalog().items():
+        try:
+            desc = _skill_descriptor(Path(path).read_text(encoding="utf-8"))
+        except OSError:
+            desc = ""
+        lines.append(f"- `{name}.md` — {desc}")
+    lines.append("")
+    return "\n".join(lines)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1411,56 +1411,109 @@ def test_default_skill_is_a_configurable_key():
     assert "default_skill" in _CONFIGURE_KEYS
 
 
-# ── _resolve_pinned_skill ─────────────────────────────────────────────────────
+# ── show-skills ───────────────────────────────────────────────────────────────
 
-def _vault_with_skills(tmp_path, names=("general-records", "corporate-filings")):
-    records = tmp_path / "v" / ".claude" / "commands" / "records"
-    records.mkdir(parents=True)
+def _patch_catalog(monkeypatch, tmp_path, names=("court-documents",)):
+    from watchdog import skills_catalog as sc
+    pkg = tmp_path / "pkg"
+    pkg.mkdir()
     for n in names:
-        (records / f"{n}.md").write_text("skill")
-    (records / "_index.md").write_text("internal")     # excluded from choices
-    return tmp_path / "v"
+        (pkg / f"{n}.md").write_text(f"---\ndescription: {n} stuff\n---\n# {n} body\n")
+    monkeypatch.setattr(sc, "_package_records", lambda: pkg)
+    monkeypatch.setattr(sc, "USER_SKILLS_DIR", tmp_path / "nouser")
+    return pkg
 
 
-def test_resolve_pinned_skill_from_flag(tmp_path):
+def test_show_skills_lists_and_opens_github(tmp_path, monkeypatch, capsys):
+    from watchdog.cmd import setup as st
+    _patch_catalog(monkeypatch, tmp_path, names=("court-documents",))
+    opened = []
+    monkeypatch.setattr("webbrowser.open", lambda u: opened.append(u))
+    st.cmd_show_skills(args())
+    out = capsys.readouterr().out
+    assert "court-documents" in out and "github.com" in out
+    assert opened and "github.com" in opened[0]
+
+
+def test_show_skills_prints_one_skill(tmp_path, monkeypatch, capsys):
+    from watchdog.cmd import setup as st
+    _patch_catalog(monkeypatch, tmp_path, names=("court-documents",))
+    st.cmd_show_skills(args(name="court-documents"))
+    assert "court-documents body" in capsys.readouterr().out
+
+
+def test_show_skills_unknown_exits(tmp_path, monkeypatch):
+    from watchdog.cmd import setup as st
+    _patch_catalog(monkeypatch, tmp_path, names=("court-documents",))
+    with pytest.raises(SystemExit, match="no record skill"):
+        st.cmd_show_skills(args(name="nope"))
+
+
+# ── _resolve_pinned_skill (global catalog, returns paths) ─────────────────────
+
+def _fake_catalog(monkeypatch, tmp_path, names=("general-records", "corporate-filings")):
+    """Point the global skill catalog at a controlled package dir, no user dir."""
+    from watchdog import skills_catalog as sc
+    pkg = tmp_path / "pkg"
+    pkg.mkdir()
+    for n in names:
+        (pkg / f"{n}.md").write_text(f"# {n}\n")
+    monkeypatch.setattr(sc, "_package_records", lambda: pkg)
+    monkeypatch.setattr(sc, "USER_SKILLS_DIR", tmp_path / "nouser")
+    return pkg
+
+
+def test_resolve_pinned_skill_from_flag(tmp_path, monkeypatch):
     from watchdog.cmd import ingest as ing
-    assert ing._resolve_pinned_skill(args(skill="corporate-filings"), _vault_with_skills(tmp_path), {}) == "corporate-filings"
+    pkg = _fake_catalog(monkeypatch, tmp_path)
+    assert ing._resolve_pinned_skill(args(skill="corporate-filings"), {}) == str(pkg / "corporate-filings.md")
 
 
-def test_resolve_pinned_skill_strips_md_suffix(tmp_path):
+def test_resolve_pinned_skill_strips_md_suffix(tmp_path, monkeypatch):
     from watchdog.cmd import ingest as ing
-    assert ing._resolve_pinned_skill(args(skill="corporate-filings.md"), _vault_with_skills(tmp_path), {}) == "corporate-filings"
+    pkg = _fake_catalog(monkeypatch, tmp_path)
+    assert ing._resolve_pinned_skill(args(skill="corporate-filings.md"), {}) == str(pkg / "corporate-filings.md")
 
 
-def test_resolve_pinned_skill_unknown_exits(tmp_path):
+def test_resolve_pinned_skill_unknown_exits(tmp_path, monkeypatch):
     from watchdog.cmd import ingest as ing
-    with pytest.raises(SystemExit, match="unknown record skill"):
-        ing._resolve_pinned_skill(args(skill="nope"), _vault_with_skills(tmp_path), {})
+    _fake_catalog(monkeypatch, tmp_path)
+    with pytest.raises(SystemExit, match="not found"):
+        ing._resolve_pinned_skill(args(skill="nope"), {})
 
 
-def test_resolve_pinned_skill_from_config(tmp_path):
+def test_resolve_pinned_skill_from_config(tmp_path, monkeypatch):
     from watchdog.cmd import ingest as ing
-    vault = _vault_with_skills(tmp_path)
-    assert ing._resolve_pinned_skill(args(), vault, {"default_skill": "general-records"}) == "general-records"
+    pkg = _fake_catalog(monkeypatch, tmp_path)
+    assert ing._resolve_pinned_skill(args(), {"default_skill": "general-records"}) == str(pkg / "general-records.md")
 
 
-def test_resolve_pinned_skill_none_classifies(tmp_path):
+def test_resolve_pinned_skill_none_classifies(tmp_path, monkeypatch):
     from watchdog.cmd import ingest as ing
-    assert ing._resolve_pinned_skill(args(), _vault_with_skills(tmp_path), {}) is None
+    _fake_catalog(monkeypatch, tmp_path)
+    assert ing._resolve_pinned_skill(args(), {}) is None
+
+
+def test_resolve_pinned_skill_explicit_file_path(tmp_path, monkeypatch):
+    from watchdog.cmd import ingest as ing
+    _fake_catalog(monkeypatch, tmp_path)
+    custom = tmp_path / "custom-skill.md"
+    custom.write_text("body")
+    assert ing._resolve_pinned_skill(args(skill=str(custom)), {}) == str(custom.resolve())
 
 
 def test_resolve_pinned_skill_interactive_pick(tmp_path, monkeypatch):
     from watchdog.cmd import ingest as ing
-    vault = _vault_with_skills(tmp_path, names=("alpha", "beta"))   # sorted: alpha=1, beta=2
+    pkg = _fake_catalog(monkeypatch, tmp_path, names=("alpha", "beta"))  # sorted: alpha=1, beta=2
     monkeypatch.setattr("builtins.input", lambda *a: "2")
-    assert ing._resolve_pinned_skill(args(skill=ing._PICK_SKILL), vault, {}) == "beta"
+    assert ing._resolve_pinned_skill(args(skill=ing._PICK_SKILL), {}) == str(pkg / "beta.md")
 
 
 def test_resolve_pinned_skill_interactive_enter_classifies(tmp_path, monkeypatch):
     from watchdog.cmd import ingest as ing
-    vault = _vault_with_skills(tmp_path, names=("alpha", "beta"))
+    _fake_catalog(monkeypatch, tmp_path, names=("alpha", "beta"))
     monkeypatch.setattr("builtins.input", lambda *a: "")
-    assert ing._resolve_pinned_skill(args(skill=ing._PICK_SKILL), vault, {}) is None
+    assert ing._resolve_pinned_skill(args(skill=ing._PICK_SKILL), {}) is None
 
 
 # ── _notify ───────────────────────────────────────────────────────────────────

--- a/tests/test_orchestrate.py
+++ b/tests/test_orchestrate.py
@@ -255,7 +255,9 @@ def test_pinned_skill_skips_classification(tmp_path, monkeypatch):
                                         auth_mode="subscription", cost_usd=0.0)
     monkeypatch.setattr(orchestrate.model_client, "acomplete_json", fake)
 
-    summary = asyncio.run(orchestrate.run(vault, pinned_skill="general-records"))
+    skill_file = tmp_path / "pinned.md"
+    skill_file.write_text("PINNED SKILL BODY")
+    summary = asyncio.run(orchestrate.run(vault, pinned_skill=str(skill_file)))
     assert summary["extracted"] == 1
     assert "classify" not in tasks          # classification skipped entirely
 
@@ -263,9 +265,8 @@ def test_pinned_skill_skips_classification(tmp_path, monkeypatch):
 def test_pinned_skill_is_injected_into_extraction(tmp_path, monkeypatch):
     vault = make_vault(tmp_path)
     _queue_doc(vault)
-    records = vault / ".claude" / "commands" / "records"
-    records.mkdir(parents=True, exist_ok=True)
-    (records / "corporate-filings.md").write_text("CORPORATE FILINGS SKILL BODY")
+    skill_file = tmp_path / "corporate-filings.md"
+    skill_file.write_text("CORPORATE FILINGS SKILL BODY")
     seen = {}
     async def fake(*, task, prompt, schema, model=None, backend=None, max_retries=1):
         if task == "extract":
@@ -279,8 +280,20 @@ def test_pinned_skill_is_injected_into_extraction(tmp_path, monkeypatch):
                                         auth_mode="subscription", cost_usd=0.0)
     monkeypatch.setattr(orchestrate.model_client, "acomplete_json", fake)
 
-    asyncio.run(orchestrate.run(vault, pinned_skill="corporate-filings"))
+    asyncio.run(orchestrate.run(vault, pinned_skill=str(skill_file)))
     assert "CORPORATE FILINGS SKILL BODY" in seen["prompt"]
+
+
+def test_record_skill_provenance_is_persisted(tmp_path, monkeypatch):
+    vault = make_vault(tmp_path)
+    _queue_doc(vault)
+    _mock(monkeypatch, extraction=_extraction())     # classify mock returns general-records.md
+    asyncio.run(orchestrate.run(vault))
+
+    docs = json.loads((vault / ".watchdog" / "Registry" / "documents.json").read_text())
+    assert next(iter(docs.values()))["record_skill"] == "general-records"
+    note = next((vault / "documents").glob("*.md")).read_text(encoding="utf-8")
+    assert "record_skill: general-records" in note
 
 
 def test_orchestrator_cancels_gracefully_on_sigint(tmp_path, monkeypatch):

--- a/tests/test_setup_skills.py
+++ b/tests/test_setup_skills.py
@@ -1,63 +1,18 @@
-"""Tests for skill installation and the generated records index (setup_cmd.py)."""
+"""Tests for per-vault command-skill installation (setup_cmd.py).
 
-from watchdog.setup_cmd import install_skills, regenerate_records_index, _skill_descriptor
+Record (domain) skills are global now — see tests/test_skills_catalog.py.
+"""
 
-
-def test_skill_descriptor_strips_boilerplate():
-    assert _skill_descriptor(
-        "# Domain knowledge — Corporate filings\n\n"
-        "This skill is loaded by `/ingest` when the document type is an annual report, "
-        "or similar corporate record.\n"
-    ) == "an annual report, or similar corporate record"
-
-    # The other lead-in variant used across the skills.
-    assert _skill_descriptor(
-        "# Title\n\nLoaded by `/ingest` when the document type is a court order.\n"
-    ) == "a court order"
+from watchdog.setup_cmd import install_skills
 
 
-def test_skill_descriptor_falls_back_to_raw_first_line():
-    assert _skill_descriptor("# Title\n\nCovers police occurrence reports.\n") == \
-        "Covers police occurrence reports"
-
-
-def test_install_skills_generates_index(tmp_path):
+def test_install_skills_installs_command_skills(tmp_path):
     install_skills(tmp_path)
-    records = tmp_path / "records"
-
-    installed = {p.name for p in records.glob("*.md") if not p.name.startswith("_")}
-    assert "corporate-filings.md" in installed  # sanity: skills were copied
-
-    index = records / "_index.md"
-    assert index.exists()
-    body = index.read_text(encoding="utf-8")
-
-    # One entry per installed skill, and no underscore-prefixed source files leaked in.
-    entry_lines = [ln for ln in body.splitlines() if ln.startswith("- `")]
-    assert len(entry_lines) == len(installed)
-    assert "- `corporate-filings.md` —" in body
-    assert "_index.md" not in "\n".join(entry_lines)
+    installed = {p.name for p in tmp_path.glob("*.md")}
+    assert "watchdog-query.md" in installed          # a Claude Code command skill landed
 
 
-def test_regenerate_index_includes_user_added_skill(tmp_path):
+def test_install_skills_does_not_copy_records(tmp_path):
     install_skills(tmp_path)
-    records = tmp_path / "records"
-    # A journalist drops their own skill straight into the vault — not via the package.
-    (records / "my-beat.md").write_text(
-        "# Domain knowledge — My beat\n\n"
-        "Loaded by `/ingest` when the document type is a widget inspection report.\n",
-        encoding="utf-8",
-    )
-    regenerate_records_index(records)
-
-    body = (records / "_index.md").read_text(encoding="utf-8")
-    assert "- `my-beat.md` — a widget inspection report" in body
-
-
-def test_regenerate_index_drops_removed_skill(tmp_path):
-    install_skills(tmp_path)
-    records = tmp_path / "records"
-    (records / "corporate-filings.md").unlink()
-    regenerate_records_index(records)
-
-    assert "corporate-filings.md" not in (records / "_index.md").read_text(encoding="utf-8")
+    # Domain/record skills live globally now and are not seeded into the vault.
+    assert not (tmp_path / "records").exists()

--- a/tests/test_skills_catalog.py
+++ b/tests/test_skills_catalog.py
@@ -1,0 +1,59 @@
+"""Tests for the global record-skill catalog (skills_catalog.py)."""
+
+from watchdog import skills_catalog as sc
+
+
+def test_skill_descriptor_prefers_frontmatter():
+    text = "---\ndescription: My custom description\n---\n# Title\n\nSome other first line.\n"
+    assert sc._skill_descriptor(text) == "My custom description"
+
+
+def test_skill_descriptor_falls_back_to_heuristic():
+    assert sc._skill_descriptor(
+        "# Title\n\nThis skill is loaded by `/ingest` when the document type is a court order.\n"
+    ) == "a court order"
+    assert sc._skill_descriptor("# Title\n\nCovers police reports.\n") == "Covers police reports"
+
+
+def _fake_records(monkeypatch, tmp_path, package=("court-documents",), user=()):
+    pkg = tmp_path / "pkg"
+    pkg.mkdir()
+    for n in package:
+        (pkg / f"{n}.md").write_text(f"---\ndescription: {n} desc\n---\n# {n}\n")
+    udir = tmp_path / "user" / "records"
+    udir.mkdir(parents=True)
+    for n in user:
+        (udir / f"{n}.md").write_text(f"---\ndescription: {n} user desc\n---\n# {n}\n")
+    monkeypatch.setattr(sc, "_package_records", lambda: pkg)
+    monkeypatch.setattr(sc, "USER_SKILLS_DIR", udir)
+    return pkg, udir
+
+
+def test_catalog_merges_package_and_user(monkeypatch, tmp_path):
+    _fake_records(monkeypatch, tmp_path, package=("court-documents",), user=("my-beat",))
+    assert set(sc.catalog()) == {"court-documents", "my-beat"}
+
+
+def test_user_skill_overrides_package(monkeypatch, tmp_path):
+    _, udir = _fake_records(monkeypatch, tmp_path, package=("court-documents",), user=("court-documents",))
+    assert sc.catalog()["court-documents"] == str(udir / "court-documents.md")   # user wins
+
+
+def test_read_skill_and_index(monkeypatch, tmp_path):
+    _fake_records(monkeypatch, tmp_path, package=("court-documents",), user=("my-beat",))
+    assert "court-documents desc" in sc.read_skill("court-documents")
+    assert sc.read_skill("court-documents.md")                 # accepts a .md suffix
+    idx = sc.build_index()
+    assert "- `court-documents.md` — court-documents desc" in idx
+    assert "- `my-beat.md` — my-beat user desc" in idx
+
+
+def test_read_skill_unknown_returns_empty(monkeypatch, tmp_path):
+    _fake_records(monkeypatch, tmp_path)
+    assert sc.read_skill("nonexistent") == ""
+
+
+def test_github_skills_url():
+    assert sc.github_skills_url().endswith("/src/watchdog/skills/records")
+    one = sc.github_skills_url(name="court-documents")
+    assert one.endswith("court-documents.md") and "/blob/" in one


### PR DESCRIPTION
Record (domain) skills become **global** instead of being copied into every vault — plus a `show-skills` command, frontmatter descriptions, file-path pinning, and per-document skill provenance.

## Why

Copying skills into each vault's `.claude/commands/records/` was a holdover from the **Claude-Code-skill ingest**, which needed them there for discovery. Since the Python orchestrator (#118) just `read_text()`s the skill, the copy is vestigial — and it drifts: every vault is stale until you remember `refresh-skills`. (Discussed in the thread leading here.)

## What changed

- **`skills_catalog.py` (new)** — the catalog is the package's bundled skills **plus `~/.watchdog/skills/records/`** (user custom; a user skill overrides a built-in of the same name). The orchestrator reads skills from here; the classifier index is **built in memory**, so it never drifts.
- **No per-vault copies** — `install_skills` now installs only the per-vault Claude Code *command* skills (`/watchdog-query` etc.); records aren't copied and `ingest_setup` no longer regenerates a vault index.
- **Frontmatter `description:`** — baked into all 35 skills + `_template.md`; the descriptor prefers it (falling back to the first intro sentence), so a **user-added skill can set its own index line**.
- **`watchdog show-skills [name]`** — list the catalog and open the skills folder on GitHub, or print one skill in full.
- **`--skill NAME|PATH` / `default_skill`** — resolve against the global catalog *or* an arbitrary file path; classification is skipped.
- **Provenance** — the skill used (classified or pinned) is stamped into each document's note frontmatter and the `documents.json` registry as `record_skill`.

Closes #124 (file-path pinning was the remaining piece) and #126 already merged separately. Implements the "skills go global" direction from the design discussion.

## Decision to review

**Strictly global** (per the pre-production call): a vault's existing `.claude/commands/records/` copies are **ignored, not migrated**. Tradeoff captured in ARCHITECTURE **D21** — loses per-vault freezing/customization, mitigated by `--skill PATH` for one-offs and the new `record_skill` provenance. D12 (per-vault generated index) is marked superseded.

## Scope

Large diff (~50 files) but ~35 are the mechanical frontmatter additions (each prepends one `description:` line preserving today's exact index text). ARCHITECTURE (D12/D21, §5/§6, layout), README, GETTING_STARTED, CLAUDE.md updated. New tests for the catalog, show-skills, global pinning, and provenance; setup-skills tests rewritten. **488 pass.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
