### PR TITLE
Vault scaffolding: move CLAUDE.md into .claude/, add a human README.md (#139)

### DIFF
--- a/src/watchdog/cmd/vault.py
+++ b/src/watchdog/cmd/vault.py
@@ -112,6 +112,18 @@ def cmd_register(args) -> None:
     print(f"  {_CYAN}{vault}{_RESET}\n")
 
 
+def _pkg_version() -> str:
+    """Installed watchdog-intel version, for stamping into a new vault's README."""
+    try:
+        from importlib.metadata import version, PackageNotFoundError
+        try:
+            return version("watchdog-intel")
+        except PackageNotFoundError:
+            return "dev"
+    except Exception:
+        return "dev"
+
+
 def cmd_new(args) -> None:
     name = args.name or getattr(args, "name_flag", None)
     description = getattr(args, "description", None) or ""
@@ -197,7 +209,11 @@ def cmd_new(args) -> None:
     )
 
     (vault / "index.md").write_text(_render_template("index.md", name=name, today=today))
-    (vault / "CLAUDE.md").write_text(_render_template("CLAUDE.md", name=name))
+    # CLAUDE.md (Claude's internal instructions) lives in .claude/ to keep the vault root
+    # clean — Claude Code loads ./.claude/CLAUDE.md the same as ./CLAUDE.md. README.md is the
+    # human-facing entry point for anyone who opens the folder.
+    (vault / ".claude" / "CLAUDE.md").write_text(_render_template("CLAUDE.md", name=name))
+    (vault / "README.md").write_text(_render_template("README.md", name=name, version=_pkg_version()))
 
     from watchdog.setup_cmd import install_skills
     install_skills(vault / ".claude" / "commands")

--- a/src/watchdog/templates/vault/README.md
+++ b/src/watchdog/templates/vault/README.md
@@ -1,0 +1,50 @@
+# {name}
+
+An investigation vault built with **[Watchdog](https://github.com/tomcardoso/watchdog)** — document intelligence for investigative journalism. Drop public records in; get linked, source-cited notes you can explore in [Obsidian](https://obsidian.md).
+
+> Created with Watchdog `v{version}` · [GitHub](https://github.com/tomcardoso/watchdog) · [Report an issue](https://github.com/tomcardoso/watchdog/issues)
+
+## ⚠️ Public records only
+
+Never add confidential source material, leaked documents, private correspondence, or anything obtained under a promise of confidentiality. **Every document in here is read by an AI** — there is no taking that back.
+
+## How to use it
+
+1. Drop documents into `_INCOMING/`.
+2. From this folder in your terminal:
+   - `watchdog chew` — OCR and prepare the documents
+   - `watchdog ingest` — extract entities, relationships, and timelines
+3. Browse the results in [Obsidian](https://obsidian.md), or open this folder in Claude Code to ask questions across the whole vault.
+
+## Common commands
+
+In your terminal, from this folder:
+
+| Command | What it does |
+|---------|--------------|
+| `watchdog chew` | Process the files in `_INCOMING/` |
+| `watchdog ingest` | Extract from the chewed documents |
+| `watchdog finalize` | Finish post-processing if an ingest was interrupted |
+| `watchdog status` | Vault stats, plus anything queued or pending |
+| `watchdog requeue` | Retry documents that failed extraction |
+
+In a Claude Code session opened on this folder:
+
+| Command | What it does |
+|---------|--------------|
+| `/watchdog-query <question>` | Answer a question from the vault |
+| `/watchdog-surface` | Surface connections and anomalies |
+| `/watchdog-wiki` | Build investigation thread pages |
+
+## What's in here
+
+| Path | Purpose |
+|------|---------|
+| `_INCOMING/` | Drop zone for new documents |
+| `_CONTEXT/` | Background material (prior stories, notes) that seeds the investigation |
+| `entities/` | One note per person, company, address… |
+| `documents/` | One note per ingested document |
+| `briefings/` | Post-ingest summaries of what was found |
+| `timeline.md` | Chronology across the whole investigation |
+| `morgue/` | Your original files, kept after ingest |
+| `.watchdog/` | Internal state — leave it alone |

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -170,10 +170,22 @@ def test_cmd_new_registry_initialized(configured):
     assert reg["schema_version"] == "1"
 
 
-def test_cmd_new_claude_md_contains_name(configured):
+def test_cmd_new_claude_md_in_dot_claude_not_root(configured):
     cli.cmd_new(args(name="City Hall Probe", dir=str(configured)))
-    text = (configured / "city-hall-probe" / "CLAUDE.md").read_text()
+    vault = configured / "city-hall-probe"
+    # CLAUDE.md lives in .claude/ (Claude Code loads ./.claude/CLAUDE.md the same), keeping the root clean
+    assert not (vault / "CLAUDE.md").exists()
+    text = (vault / ".claude" / "CLAUDE.md").read_text()
     assert "City Hall Probe" in text
+
+
+def test_cmd_new_creates_readme(configured):
+    cli.cmd_new(args(name="City Hall Probe", dir=str(configured)))
+    readme = (configured / "city-hall-probe" / "README.md").read_text()
+    assert "City Hall Probe" in readme
+    assert "github.com/tomcardoso/watchdog" in readme        # GitHub link
+    assert "/issues" in readme                                # report-an-issue link
+    assert "Public records only" in readme
 
 
 def test_cmd_new_registers_project(configured, wdg_home):


### PR DESCRIPTION
Closes #139.

New vaults shipped an internal `CLAUDE.md` (Claude's own instructions) in the vault root, cluttering the folder a journalist opens in Obsidian/Finder/GitHub. This:

- **Moves the vault `CLAUDE.md` into `.claude/`.** Verified against the [Claude Code memory docs](https://code.claude.com/docs/en/memory): project instructions load from `./CLAUDE.md` **or** `./.claude/CLAUDE.md`, so this is a no-op for Claude Code behavior — the file is still loaded in full at session start.
- **Adds a `README.md`** as the human-facing entry point: what the vault is, common terminal + Claude Code commands, the layout, a **public-records-only** warning, and a **version pin** (`v<installed>`) linking back to the repo and the issue tracker.

Scope:
- Only changes what `watchdog new` scaffolds. **Existing vaults are unaffected** — a root `CLAUDE.md` still loads identically, so nothing breaks and no migration is forced.
- No CLI flags/commands/config changed, so the repo docs (README/GETTING_STARTED/INSTALL) don't need updates; the vault README is itself the user-facing doc.

Tests: updated the cmd_new CLAUDE.md test (now asserts `.claude/CLAUDE.md` present, root `CLAUDE.md` absent) and added a README test (name + GitHub/issues links + public-records warning). Full suite green (510).

🤖 Generated with [Claude Code](https://claude.com/claude-code)