### PR TITLE
Note decision-log ordering convention

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -400,6 +400,8 @@ registry for every document would be wasteful. The manifest is the cheap index.
 
 ## 14. Decision log (summary)
 
+*Append new decisions in ascending number order — newest at the bottom.*
+
 | # | Decision | Rationale | Tradeoff |
 |---|---|---|---|
 | D1 | Local-first preprocessing | Source documents never leave the machine; no API cost for chew | Bound by local compute for OCR/layout |


### PR DESCRIPTION
One-line note in the ARCHITECTURE decision-log header that new rows are appended in ascending number order (newest at the bottom) — guards against the out-of-order insertions that crept into D18–D25.

🤖 Generated with [Claude Code](https://claude.com/claude-code)