### PR TITLE
Unified fact primitive: emit each fact once, retain source text (#140)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -127,15 +127,20 @@ registry/note writes so the concurrent document workers write safely.
    one skill and injects it into the extraction prompt. **Skipped entirely when a skill is
    pinned** for the run (`--skill` / `default_skill`) — that one skill is used for every
    document, saving a model call per doc on known-homogeneous batches.
-3. **Extract** — one model call against the `EXTRACTION` schema: title, date, entities
-   (deduped against the pre-flight candidates), roles, timeline events, key facts (each with
-   an optional verbatim `quote`), per-entity summary + structured **evidence fragments**
-   (claim/page/confidence/reason, plus an optional verbatim `quote` — see D22), contradictions,
-   morgue fields, and a briefing scratchpad.
+3. **Extract** — one model call against the `EXTRACTION` schema. The model emits two layers
+   (D26): a **fact layer** — `document.key_facts`, each a single material fact written once,
+   carrying an optional `date` (when the fact *is* a datable occurrence) and an optional
+   `entities` list (the ids the fact is about) plus an optional verbatim `quote`; and a **graph
+   layer** — entities (deduped against the pre-flight candidates) with aliases, roles, and
+   contradictions. It no longer restates the document as per-entity summaries, evidence
+   fragments, or timeline events, nor pads `key_facts` to a fixed count — the full Docling text
+   is retained in the morgue (§3, §12), so extraction indexes it rather than reproducing it.
    Schema validation + a same-model retry live in `model_client` (no automatic tier
    escalation — see D20); the orchestrator adds one post-flight repair retry.
 4. **Post-flight** (`postflight.run`, a function call) — validates the JSON, applies
-   `match_id` merges, and calls `write_vault.run()`.
+   `match_id` merges (remapping `key_facts.entities` tags onto canonical ids), **explodes** the
+   unified key_facts into the per-entity `evidence_fragments` + `timeline_events` that the
+   writers consume (`explode_key_facts`, D26), then calls `write_vault.run()`.
 
 `write_vault` is the single deterministic writer: it merges entities (reconciling
 near-duplicate slugs coined by concurrent workers via the shared `entity_norm`
@@ -205,10 +210,10 @@ differently:
 
 | Section | Kind | Treatment |
 |---|---|---|
-| `## Summary` | synthesized prose | model — carryforward interim, then bundled synthesis |
-| `## Analysis` | evidence-fragment claims → synthesized prose | deterministic claims for single-mention; model-synthesized prose once 2+ mentions (D22) |
+| `## Summary` | synthesized prose | model — provisional one-liner from the entity's top tagged fact, then bundled synthesis once 2+ mentions (D26) |
+| `## Analysis` | tagged-fact claims → synthesized prose | deterministic claims (key_facts tagged to the entity, exploded per D26) for single-mention; model-synthesized prose once 2+ mentions |
 | `## Contradictions` | cited callouts | deterministic — append-only, deduped, audit-managed |
-| `## Timeline` | structured events | deterministic — merged, sorted by **event** date |
+| `## Timeline` | structured events | deterministic — the entity's dated tagged facts, merged, sorted by **event** date |
 | `## Relationships` | structured roles | deterministic — merged |
 | `## Notes` | journalist annotations | never touched by the pipeline |
 
@@ -241,42 +246,48 @@ model.
 
 Synthesizing an entity's prose across all its documents on every ingest would be
 expensive. Synthesizing nothing (the old behaviour) let a later document's summary
-clobber an earlier, richer one. The solution is **two complementary mechanisms covering
-disjoint cases:**
+clobber an earlier, richer one. The gate is **project-wide recurrence** (D26): an entity
+earns a synthesized summary once it appears in **2+ documents across the whole
+investigation**, otherwise it stays a deterministic stub.
 
-| Case (this ingest) | Mechanism | Cost |
+| Entity's project-wide reach | Treatment | Cost |
 |---|---|---|
-| Brand-new entity, 1 mention | plain write (extraction summary) | free |
-| Pre-existing entity, 1 mention | **inline carryforward** | ~free, parallel |
-| Any entity, **2+ mentions** | **bundled synthesis in `_post_ingest`** | bounded |
+| In **1 document** total | deterministic stub — facts in `## Analysis`, relationships; **no Summary section** | free |
+| In **2+ documents** total (`appears_in ≥ 2`) | **bundled synthesis** — short model-written Summary (1–3 paragraphs) | bounded |
 
-- **Inline carryforward.** Pre-flight carries each matched entity's current
-  `## Summary` into the extraction prompt's candidate list; extraction *revises* it with
-  the new document rather than writing a fresh single-document summary. Handles the common
-  single-touch case in the extraction call that's already running — no extra call.
-- **Gated synthesis.** As `write_vault` writes each entity, it appends a per-entity
-  **fragment** (the entity's slice of the extraction JSON — summary, evidence-fragment claims
-  with any quotes, roles — plus document attribution) to `.watchdog/tmp/entity-fragments/<id>.md`
-  and bumps a
-  count in `_queue.json`. This is a *free byproduct* of data the extractor already
-  produced. In `_post_ingest`, `synthesis_bundle.build_bundle` selects entities with
-  **count ≥ 2** and packs each one's fragments + current prose into one compact bundle;
-  a single model call synthesizes them all; `synthesis_bundle.apply_bundle` bulk-writes
-  the Summary/Analysis via the shared writer in `pipeline/finalize_entity.py`.
-- **The gate is the cost control.** Most entities in a batch are single-mention and
-  never hit synthesis. Cost scales with *contested* entities, not all entities.
+- **Recurrence is the signal, counted across the project — not the batch.** `synthesis_bundle.build_bundle`
+  gates on the registry entity's `appears_in` length, so a registering agent or a law firm that
+  surfaces in a second document *in a later batch, years apart* is promoted the moment its
+  `appears_in` crosses 2. Only entities *touched this run* (present in the fragment queue) are
+  candidates — an untouched entity has nothing new to reconcile. (The `count` still written to
+  `_queue.json` is now just the touched-set marker, no longer the gate.)
+- **No summary for single-document entities, and no inline revision.** Under D26 the extractor emits
+  no per-entity summary, so the old carryforward trick (pre-flight feeds the current `## Summary`
+  back and extraction *revises* it) is gone. A one-document entity simply has no Summary section —
+  its facts live in `## Analysis` and its connections in `## Relationships`, which is all an
+  incidental actor needs. Summaries are only ever written by bundled synthesis, so a single new
+  document can never silently overwrite an established one.
+- **Association needs no special code.** An incidental entity tied to an important one — the
+  paralegal who filed for a tracked party — is captured for free: it gets a stub note whose
+  `## Relationships` records the link (and the reverse link lands on the tracked party's note). If
+  it keeps reappearing, its own `appears_in` promotes it to synthesis.
+- **No recency bias.** The synthesis prompt instructs the model to weight the full body of
+  evidence: an entity established across many documents is *not* redefined by a new passing
+  mention — a minor new reference is folded in without reshaping a settled account.
+- **Gated synthesis mechanics.** As `write_vault` writes each entity, it appends a per-entity
+  **fragment** (the entity's slice of the exploded extraction — its tagged-fact claims with any
+  quotes, roles — plus document attribution) to `.watchdog/tmp/entity-fragments/<id>.md`.
+  This is a *free byproduct* of data the extractor already produced. In `_post_ingest`,
+  `build_bundle` selects the recurring entities and packs each one's fragments + current prose
+  into one compact bundle; a single model call synthesizes them all; `synthesis_bundle.apply_bundle`
+  bulk-writes the Summary/Analysis via the shared writer in `pipeline/finalize_entity.py`.
 - **Why fragments are a byproduct, not extractor-written prose.** Having the extractor
   narrate per-entity notes would add token cost to the expensive parallel phase. The
   extraction JSON already contains everything a fragment needs.
-- **Why gate on "≥2 this ingest" specifically.** That is exactly the case inline
-  carryforward can't handle (multiple simultaneous fragments → last-write-wins) and
-  where reconciliation earns its cost.
-- **Known limitation.** Fragments are run-scoped (cleared at ingest start). A
-  pre-existing entity touched by a single new document is handled by carryforward, not
-  bundled synthesis — its summary is revised incrementally, not re-synthesized from all
-  history. The deep, on-demand `/watchdog-entity` pass (`pipeline/write_entity.py`,
-  which also re-synthesizes the Timeline) remains the tool for a full rebuild of a
-  central figure.
+- **Known limitation.** Synthesis reconciles this run's fragments with the entity note's *carried
+  prose*, not a fresh re-read of every source document. The deep, on-demand `/watchdog-entity`
+  pass (`pipeline/write_entity.py`, which also re-synthesizes the Timeline) remains the tool for a
+  full rebuild of a central figure from all its sources.
 
 Bundled synthesis writes **only** Summary and Analysis; Contradictions,
 Timeline, Relationships, and Notes are preserved untouched. `apply_bundle` skips
@@ -292,7 +303,9 @@ prose stays in place.
 
 Each document's extraction stages its events to **raw** per-document files
 `{date}_{sha7}.ndjson` (`timeline.stage_timeline_events`, called from post-flight) —
-write-only and lock-free, since each filename is unique. All merge/dedup and the briefing
+the events being the document's **dated** `key_facts`, with each fact's `entities` tags
+supplying the contributing entity ids (D26) — write-only and lock-free, since each filename
+is unique. All merge/dedup and the briefing
 then run in `_post_ingest` (model: `post_model`) after extraction:
 
 - `timeline.collisions(vault)` promotes dates with no prior canonical to **canonical**
@@ -336,7 +349,8 @@ This is the same model the removed classifier used, retained solely for search.
 ```
 entities/<type>/<id>.md     entity notes
 documents/<slug>.md         document notes
-morgue/<entity>/<type>/…     original source files, filed by subject
+morgue/<entity>/<type>/…     original source files + a sibling <name>.md of the
+                            Docling full text, filed by subject (D26)
 timeline.md                 rendered global timeline
 briefings/<date>.md         per-ingest briefings
 context.md / hot.md / log.md investigation context, hot cache, run log
@@ -425,7 +439,8 @@ registry for every document would be wasteful. The manifest is the cheap index.
 | D19 | Force-section on whole-doc output overrun (§5) | Sectioning triggers on *input* size (`section_token_threshold`), but truncation is *output*-driven — a moderate-input, entity-dense doc overruns the model's output ceiling on the agent-SDK backend (which can't cap output), truncating the JSON and escalating the retry toward a pricier tier. On a multi-page doc whose whole-doc extraction is rejected, the orchestrator re-runs it through the sectioned path with a small forced budget (≥2 sections) to bound per-call output | Adds one (failed) whole-doc attempt before the fallback; single-page docs can't be split, so they still just fail |
 | D20 | Configured model only — no automatic escalation; classifier model is its own knob | `model_client` originally bumped the tier up (haiku→sonnet→opus) on a JSON-validation failure. That makes ingest cost unpredictable and can silently spend opus money — the opposite of a budgeted pipeline. Now a failed call retries on the **same** configured model (the orchestrator's post-flight repair + D19 sectioning handle genuine failures), and the classify step gets its own `classifier_model` knob (default haiku) alongside `extractor_model`/`finalizer_model`, so each stage's model is explicit and stable | A doc that a stronger model would have salvaged now fails instead of auto-upgrading — the user opts into a stronger model deliberately via config |
 | D21 | Record skills are global, not per-vault (`skills_catalog`) | Copying skills into every vault was a holdover from the Claude-Code-skill ingest, which needed them under `.claude/commands/` for discovery. The Python orchestrator (D18) just reads the file, so the copy was vestigial and created drift (each vault stale until `refresh-skills`). Skills now live in the package + `~/.watchdog/skills/records/` (user overrides) and are read directly; the classify index is built in memory (supersedes D12); per-skill `description:` frontmatter lets a user-added skill set its own index line. Pinning (`--skill`/`default_skill`, a name or path) and `watchdog show-skills` round it out. Pre-production, so vault-local copies are simply ignored (strictly global) rather than migrated | Loses per-vault skill freezing/customization; mitigated by `--skill PATH` for one-offs and by stamping the skill used into each document's note + registry (`record_skill`) for provenance. Custom skills in `~/.watchdog` aren't carried with a shared vault |
-| D22 | Extractor emits structured **evidence fragments** instead of prose `analysis`; optional verbatim `quote` on fragments and `key_facts` (#107) | The per-entity `analysis` prose was thrown away and rewritten by synthesis for every multi-mention entity (D7/D17), so the extractor did prose work twice. Replacing it with `{claim, page, confidence, reason}` fragments gives the synthesizer a clean, page-anchored, citable digest to compose from rather than re-prosing prose — and single-mention notes render the claims directly under `## Analysis`. Quotes are *captured* at extraction only when the wording is significant, and on entity fragments are *surfaced* into synthesized prose only in exceptional cases (the synthesis prompt gates this); on `key_facts` the quote renders verbatim in the document note (terminal, reader-facing — the strongest placement). This is a **quality/citability** change, not a cost trim (structured fragments cost slightly more output tokens than the prose they replace) — the cost trim is the separate #127 | More structured extractor output; a captured quote against garbled OCR isn't verified to appear on the page (that check is the deferred #106 evaluator); existing notes keep their old prose `## Analysis` until the entity is next extracted |
+| D22 | Extractor emits structured **evidence fragments** instead of prose `analysis`; optional verbatim `quote` on fragments and `key_facts` (#107) **— the extractor no longer emits fragments directly (D26); they are reconstructed from tagged `key_facts`, but everything downstream (the structured-claims-feed-synthesis digest, the `## Analysis` render) is unchanged.** | The per-entity `analysis` prose was thrown away and rewritten by synthesis for every multi-mention entity (D7/D17), so the extractor did prose work twice. Replacing it with `{claim, page, confidence, reason}` fragments gives the synthesizer a clean, page-anchored, citable digest to compose from rather than re-prosing prose — and single-mention notes render the claims directly under `## Analysis`. Quotes are *captured* at extraction only when the wording is significant, and on entity fragments are *surfaced* into synthesized prose only in exceptional cases (the synthesis prompt gates this); on `key_facts` the quote renders verbatim in the document note (terminal, reader-facing — the strongest placement). This is a **quality/citability** change, not a cost trim (structured fragments cost slightly more output tokens than the prose they replace) — the cost trim is the separate #127 | More structured extractor output; a captured quote against garbled OCR isn't verified to appear on the page (that check is the deferred #106 evaluator); existing notes keep their old prose `## Analysis` until the entity is next extracted |
 | D23 | Post-ingest is a re-runnable `finalize` step over per-run on-disk inputs (#135) | Post-ingest (synthesis + timeline + briefing) calls the model, so a rate limit can interrupt it *after* extraction has already written the vault — and `ingest_setup` wipes the fragment queue at the next ingest's start, so a re-ingest would silently drop the un-synthesized batch. Post-ingest is now `orchestrate.finalize`, fed inputs that persist in `tmp` (entity fragments + per-doc `result_*.json` + scratchpads); `watchdog ingest` calls it at its tail, and `watchdog finalize` re-runs it standalone to complete an interrupted batch. A clean pass clears the inputs (idempotent, and fixes a latent scratchpad-accumulation bug where briefings re-included prior runs); an interrupted pass leaves them for retry. A new `watchdog ingest` over a pending batch prompts to **merge** (keep the inputs via `wipe_pending=False` so both batches finalize together), **finalize** first, or **discard**; `watchdog status` flags a pending batch | No cross-run finalization queue beyond the merge prompt; synthesis re-runs are idempotent (bulk overwrite), so a partial finalize is safe to repeat |
 | D24 | Roles are extracted by `target_id` only; `target_name`/`target_type` are re-inflated deterministically (#140) | Extraction output is ~95% of run cost and roles were the single largest field — and ~43% of the roles payload was the target's `target_name`/`target_type`, both *derivable from `target_id`* via the registry, re-typed by the model on every role (e.g. an 86-char case name repeated across a dozen roles). The extractor now emits roles by id; `write_vault._resolve_role_targets` fills name/type from this batch's entities + the registry right after id reconciliation, so every downstream consumer (note links, pre-flight context, synthesis digest) is unchanged. First concrete cut from #140 — moves derivable data out of paid model output into free deterministic code | A dangling `target_id` (no matching entity) falls back to the id as name + `Unknown` type; the win is only realized while extraction stays on a metered tier (Sonnet output is the cost) |
 | D25 | `confidence` is omitted when `high`; absent ⇒ `high` (#140) | Measured across a 5-doc run, **99% of all confidence values were `high`** (411 rendered, 8 non-high). Requiring it on every fact/role/event/key-fact paid model output to restate the default ~99% of the time (~6% of extraction output). The extractor now emits `confidence` only for `medium`/`low`/`disputed`; the schema makes it optional and every consumer defaults absent → `high`, so notes render identically and the rare exception stands out instead of hiding in a sea of `high`. Same omit-defaults pattern extends to `page` (omit when no marker) and empty arrays | Defaulting absent → `high` is the *optimistic* direction — a forgotten mark silently reads as `high` — but empirically the model flagged all 8 non-high cases, so exposure is ~8-in-411. Whether `confidence` is well-calibrated at all (≈always `high`) is a separate quality question (#143) |
+| D26 | Unified **fact primitive**: the model emits each material fact once on `document.key_facts`, tagged with `entities` + an optional `date`; postflight fans it back out (#140) | The extractor restated the same fact up to three times — as a `document.key_fact`, as each involved entity's `evidence_fragment`, and (if dated) as each entity's `timeline_event` — plus a per-entity `summary`, so a 5-page order emitted ~4× the source text in JSON (32K chars from 7.7K of Docling markdown). That redundancy was rational only because the Docling text was **discarded** after extraction, making the JSON the sole text record. D26 retains the full text in the morgue as a sibling `<name>.md` (deterministic, $0), then collapses the restatement: the model emits a fact once with `entities` tags (who it's about) and an optional `date` (when it occurred); `postflight.explode_key_facts` deterministically reconstructs the per-entity `evidence_fragments` and `timeline_events` the writers already consume, and `stage_timeline_events` reads the dated facts directly. Entities keep only the graph layer (identity, aliases, roles, contradictions); no per-entity summary/fragments/timeline. `key_facts` is materiality-driven with no fixed count. Stacks on D24/D25. Synthesis is now gated on **project-wide recurrence** (`appears_in ≥ 2`) rather than batch-local mention count, so an entity recurring across separate batches/years is promoted; single-document entities are deterministic stubs with no Summary section (§8) | A single-document entity gets no synthesized summary at all (by design — its facts sit in `## Analysis`), and a model only ever judges an entity from one document plus carried prose, never a fresh re-read of all sources (that's `/watchdog-entity`). A dated fact must be *tagged* to reach an entity's per-entity timeline (the global timeline still gets it untagged). Timeline recall now depends on the model attaching `date` to occurrence-facts rather than filling a dedicated field |

--- a/README.md
+++ b/README.md
@@ -275,8 +275,8 @@ my-investigation/
 ├── _INCOMING/              ← Drop public records here
 │   └── _FAILED/           ← Files that could not be processed
 ├── _CONTEXT/               ← Background material (prior stories, notes)
-├── morgue/                 ← Original files after successful ingest
-│   └── <entity>/
+├── morgue/                 ← Original files after successful ingest, each beside
+│   └── <entity>/             a <name>.md of its full extracted text (greppable)
 │       └── <doc-type>/
 ├── .watchdog/
 │   ├── queue/             ← Extracted data awaiting ingest (.json per file)

--- a/src/watchdog/pipeline/merge.py
+++ b/src/watchdog/pipeline/merge.py
@@ -6,9 +6,10 @@ Sectioned extraction carries a running scratchpad forward, so each section
 reuses the entity ids found by earlier sections. That makes this merge a pure
 set-union — no LLM reasoning:
 
-  * entities grouped by id; aliases / evidence_fragments / timeline_events / roles unioned
+  * entities grouped by id; aliases / roles unioned (the graph layer)
   * a normalized-name pass folds any id drift (OCR variance) onto one id
-  * document key_facts concatenated and deduped
+  * document key_facts concatenated and deduped (the fact layer, including each
+    fact's date / entity tags — postflight fans these back out per entity)
 
 The output is shape-identical to a single-document extraction JSON, so it feeds
 straight into `watchdog post-flight` unchanged.
@@ -21,16 +22,8 @@ from pathlib import Path
 from watchdog.pipeline.entity_norm import normalize_entity_name
 
 
-def _event_key(ev: dict) -> str:
-    return f"{ev.get('date', '')}|{(ev.get('event') or '')[:80].lower()}"
-
-
 def _role_key(role: dict) -> tuple:
     return ((role.get("relationship") or "").lower(), role.get("target_id"))
-
-
-def _fragment_key(f: dict) -> str:
-    return (f.get("claim") or "")[:120].lower()
 
 
 def _merge_into(acc: list, incoming: list, key_fn) -> None:
@@ -43,12 +36,28 @@ def _merge_into(acc: list, incoming: list, key_fn) -> None:
 
 
 def _dedup_key_facts(facts: list) -> list:
-    out, seen = [], set()
+    """Dedup by fact text; union entity tags and keep a date if any duplicate carries one."""
+    out: list = []
+    by_key: dict[str, dict] = {}
     for f in facts:
         k = (f.get("fact") or "")[:120].lower()
-        if k and k not in seen:
-            seen.add(k)
-            out.append(f)
+        if not k:
+            continue
+        if k not in by_key:
+            kept = dict(f)
+            kept["entities"] = list(f.get("entities") or [])
+            by_key[k] = kept
+            out.append(kept)
+        else:
+            kept = by_key[k]
+            for eid in f.get("entities") or []:
+                if eid not in kept["entities"]:
+                    kept["entities"].append(eid)
+            if not kept.get("date") and f.get("date"):
+                kept["date"] = f["date"]
+    for kept in out:
+        if not kept.get("entities"):
+            kept.pop("entities", None)
     return out
 
 
@@ -90,9 +99,6 @@ def merge_extractions(sections: list[dict]) -> dict:
                     "name": ent.get("name", ""),
                     "type": ent.get("type", ""),
                     "_surfaces": set(),
-                    "summary": None,
-                    "evidence_fragments": [],
-                    "timeline_events": [],
                     "roles": [],
                 }
                 by_id[eid] = cur
@@ -100,13 +106,12 @@ def merge_extractions(sections: list[dict]) -> dict:
             if len(ent.get("name", "")) > len(cur["name"]):
                 cur["name"] = ent["name"]
             cur["type"] = cur["type"] or ent.get("type", "")
-            cur["summary"] = cur["summary"] or ent.get("summary")
+            if ent.get("contradictions"):
+                cur.setdefault("contradictions", []).extend(ent["contradictions"])
 
             for nm in surfaces:
                 if nm:
                     cur["_surfaces"].add(nm)
-            _merge_into(cur["evidence_fragments"], ent.get("evidence_fragments", []), _fragment_key)
-            _merge_into(cur["timeline_events"], ent.get("timeline_events", []), _event_key)
             _merge_into(cur["roles"], ent.get("roles", []), _role_key)
 
             for nm in surfaces:
@@ -126,10 +131,6 @@ def merge_extractions(sections: list[dict]) -> dict:
             seen.add(low)
             aliases.append(nm)
         cur["aliases"] = aliases
-        if not cur["summary"]:
-            cur.pop("summary")
-        if not cur["evidence_fragments"]:
-            cur.pop("evidence_fragments")
         entities.append(cur)
 
     document.pop("key_facts", None)

--- a/src/watchdog/pipeline/postflight.py
+++ b/src/watchdog/pipeline/postflight.py
@@ -30,8 +30,11 @@ def _validate(data: dict) -> list[str]:
         for i, fact in enumerate(doc.get("key_facts", [])):
             if not isinstance(fact, dict):
                 errors.append(f"document.key_facts[{i}] is not an object")
-            elif fact.get("confidence") and fact["confidence"] not in _VALID_CONFIDENCE:
-                errors.append(f"document.key_facts[{i}].confidence '{fact['confidence']}' must be one of: {', '.join(sorted(_VALID_CONFIDENCE))}")
+            else:
+                if fact.get("confidence") and fact["confidence"] not in _VALID_CONFIDENCE:
+                    errors.append(f"document.key_facts[{i}].confidence '{fact['confidence']}' must be one of: {', '.join(sorted(_VALID_CONFIDENCE))}")
+                if "entities" in fact and not isinstance(fact["entities"], list):
+                    errors.append(f"document.key_facts[{i}].entities must be a list of entity ids")
 
     entities = data.get("entities")
     if not isinstance(entities, list):
@@ -44,16 +47,6 @@ def _validate(data: dict) -> list[str]:
             for field in ("id", "name", "type"):
                 if not ent.get(field):
                     errors.append(f"entities[{i}].{field} is missing or empty")
-            for j, ev in enumerate(ent.get("timeline_events", [])):
-                if not isinstance(ev, dict):
-                    errors.append(f"entities[{i}].timeline_events[{j}] is not an object")
-                elif ev.get("confidence") and ev["confidence"] not in _VALID_CONFIDENCE:
-                    errors.append(f"entities[{i}].timeline_events[{j}].confidence '{ev['confidence']}' must be one of: {', '.join(sorted(_VALID_CONFIDENCE))}")
-            for j, frag in enumerate(ent.get("evidence_fragments", [])):
-                if not isinstance(frag, dict):
-                    errors.append(f"entities[{i}].evidence_fragments[{j}] is not an object")
-                elif frag.get("confidence") and frag["confidence"] not in _VALID_CONFIDENCE:
-                    errors.append(f"entities[{i}].evidence_fragments[{j}].confidence '{frag['confidence']}' must be one of: {', '.join(sorted(_VALID_CONFIDENCE))}")
             for j, role in enumerate(ent.get("roles", [])):
                 if not isinstance(role, dict):
                     errors.append(f"entities[{i}].roles[{j}] must be an object with relationship/target_id/page/confidence/date_range keys — not a string")
@@ -67,12 +60,63 @@ def _validate(data: dict) -> list[str]:
 
 
 def _apply_match_ids(extraction: dict) -> dict:
-    """Rewrite entity IDs based on Claude's match_id merge decisions."""
+    """Rewrite entity IDs based on Claude's match_id merge decisions.
+
+    Also remaps any ``key_facts.entities`` tags that referenced the extraction-time id onto the
+    canonical matched id, so the explode step files facts under the right entity.
+    """
+    remap: dict[str, str] = {}
     for entity in extraction.get("entities", []):
         match_id = entity.pop("match_id", None)
         if match_id:
+            remap[entity["id"]] = match_id
             entity["id"] = match_id
+    if remap:
+        for fact in extraction.get("document", {}).get("key_facts", []):
+            tags = fact.get("entities")
+            if tags:
+                fact["entities"] = [remap.get(t, t) for t in tags]
     return extraction
+
+
+def explode_key_facts(extraction: dict) -> None:
+    """Reconstruct the per-entity views from the unified `key_facts` primitive (#140).
+
+    The model emits each material fact once on ``document.key_facts``, tagged with the entity ids
+    it concerns and an optional ``date``. Here we deterministically fan those tags back out onto
+    each entity as ``evidence_fragments`` (every tagged fact) and ``timeline_events`` (tagged facts
+    that carry a date), the per-entity shapes that write_vault already renders. Mutates the entities
+    in place. The document-level ``key_facts`` are left intact (the document note and the global
+    timeline read them directly).
+    """
+    by_id = {e["id"]: e for e in extraction.get("entities", []) if e.get("id")}
+    for fact in extraction.get("document", {}).get("key_facts", []):
+        text = (fact.get("fact") or "").strip()
+        if not text:
+            continue
+        page = fact.get("page")
+        confidence = fact.get("confidence")
+        quote = fact.get("quote")
+        date = (fact.get("date") or "").strip()
+        for eid in fact.get("entities", []) or []:
+            ent = by_id.get(eid)
+            if ent is None:
+                continue
+            frag = {"claim": text}
+            if page is not None:
+                frag["page"] = page
+            if confidence:
+                frag["confidence"] = confidence
+            if quote:
+                frag["quote"] = quote
+            ent.setdefault("evidence_fragments", []).append(frag)
+            if date:
+                event = {"date": date, "event": text}
+                if page is not None:
+                    event["page"] = page
+                if confidence:
+                    event["confidence"] = confidence
+                ent.setdefault("timeline_events", []).append(event)
 
 
 def run(vault: Path, extraction_path: Path, quiet: bool = False) -> dict:
@@ -89,6 +133,10 @@ def run(vault: Path, extraction_path: Path, quiet: bool = False) -> dict:
         return {"errors": errors}
 
     extraction = _apply_match_ids(extraction)
+
+    # Fan the unified key_facts out into the per-entity evidence_fragments / timeline_events that
+    # write_vault and timeline staging consume (#140).
+    explode_key_facts(extraction)
 
     # Get near-dup minhash from queue file (computed at chew time)
     sha256 = extraction.get("document", {}).get("sha256", "")

--- a/src/watchdog/pipeline/prompts.py
+++ b/src/watchdog/pipeline/prompts.py
@@ -21,53 +21,67 @@ def build_classify_prompt(doc_excerpt: str, index_text: str) -> str:
 
 
 _EXTRACT_INSTRUCTIONS = """\
-Extract every real-world entity, relationship, datable event, and key fact from this document \
-for an investigative-records vault.
+The full text of this document is preserved in the vault, so do NOT restate or summarize it. \
+Your job is to produce a journalist's working notes: (1) the material FACTS worth writing down, \
+and (2) the GRAPH of entities and their relationships. Each fact is written ONCE and then tagged \
+so it can be filed under the entities it concerns and, if it is a datable occurrence, onto the \
+timeline.
 
-Use EXISTING_ENTITIES for deduplication — match on name or any alias (OCR errors are common; be \
-generous). For each entity:
+KEY FACTS — `document.key_facts` is the heart of the extraction. Capture the investigatively \
+material facts a reporter would jot down: who, amounts, dates, identifiers, addresses, ownership, \
+obligations, decisions, occurrences. Each fact is an OBJECT:
+- `fact`: one factual sentence, in your own words.
+- `entities`: the ids of the entities this fact is about (usually one or two — the people, \
+companies, addresses, or cases it concerns). Omit if the fact is about no specific entity.
+- `date`: set ONLY when the fact is itself a datable occurrence (something that happened, was \
+decided, or changed on a specific date) — this is what places it on the timeline. Omit for facts \
+that merely mention a date or have no single date (a ratio, a balance, a structural fact).
+- `page`, `confidence`: as below.
+- `quote`: an optional verbatim source sentence — include ONLY when the exact wording is itself \
+significant or quotable (an admission, a precise figure, distinctive language). Usually omit it.
+
+How many facts: as many as the document has material facts, and no more — a dense order may have \
+fifteen, a routine form two. Do NOT pad to a quota. Let MATERIALITY decide: omit boilerplate, \
+procedural recitation, jurisdictional/standard-form language, and reasoning or analysis that does \
+not establish a fact (e.g. recited case-law or argument). The loaded DOMAIN SKILL tells you what \
+matters most for this document type — lean on it. When in doubt, err toward capturing a hard fact \
+(a name, date, figure, address) rather than dropping it; err toward dropping prose and reasoning.
+
+ENTITIES — the graph. Use EXISTING_ENTITIES for deduplication — match on name or any alias (OCR \
+errors are common; be generous). For each entity:
 - `id`: the existing id from EXISTING_ENTITIES if matched, otherwise a new kebab-case slug.
 - `match_id`: set to the matched entity's id if this matches an existing entity; OMIT entirely \
 for new entities (do not set null or "").
 - `name`: the canonical full name as it appears most completely.
 - `type`: Person / Company / Address / Property / CourtCase / Transaction / or a new type if apt.
 - `aliases`: every other name or abbreviation used in this document.
-- `summary`: one sentence — who this entity is and the role it plays. If EXISTING_ENTITIES carries \
-a `summary` for a matched entity, REVISE that carried summary to fold in what this document adds — \
-do not discard it and write a single-document summary from scratch.
-- `evidence_fragments`: the investigatively significant claims this document makes about this \
-entity — each an OBJECT with `claim` (one factual sentence), `page`, `confidence`, an optional \
-`reason` (why it matters), and an optional `quote`. Summarize each claim in your own words by \
-default; include a verbatim `quote` ONLY when the exact wording is itself significant or quotable \
-(an admission, a precise figure, distinctive language) — usually omit it. Omit the whole array if \
-the document says nothing notable about this entity. Never put contradiction callouts here.
-- `timeline_events`: datable events directly involving this entity — anything a journalist would \
-want the date of (something that happened, was decided, or changed). Exclude pure stamp/filing \
-dates unless they connect causally to something substantive.
 - `roles`: relationships to other entities, each an OBJECT with relationship/target_id/page/\
 confidence/date_range — never a plain string. Identify the target by `target_id` only; its name \
 and type are filled in automatically, so do not emit them.
+Create an entity for anything a fact, a role, or the timeline needs to refer to — including \
+incidental actors (counsel, a clerk) named in a fact. Do NOT write a summary or per-entity prose: \
+who the entity is follows from the facts tagged to it.
 
-Confidence (events, facts, roles): emit `confidence` ONLY when it is `medium` (one inference), \
-`low` (multi-statement inference), or `disputed` (contradicts the vault). OMIT it entirely when the \
-claim is directly stated — absent means `high`, which is the default. Never upgrade a claim past its \
-weakest element. Likewise omit `page` when there is no page marker (don't emit null), and omit empty \
-arrays rather than emitting `[]`.
+Confidence (facts, roles): emit `confidence` ONLY when it is `medium` (one inference), `low` \
+(multi-statement inference), or `disputed` (contradicts the vault). OMIT it entirely when the \
+claim is directly stated — absent means `high`, which is the default. Never upgrade a claim past \
+its weakest element. Likewise omit `page` when there is no page marker (don't emit null), and omit \
+empty arrays rather than emitting `[]`.
 
 CONTRADICTION CHECK — for each entity that matched an EXISTING_ENTITIES entry, compare key dates, \
-roles, and relationships in this document against that entry's `timeline_events`, `roles`, and \
-recorded claims. Flag a material discrepancy only when both sides are high or medium confidence and you \
-are confident it is genuine — this is the only verification step; any callout is saved as-is. Put \
-each as a string in that entity's `contradictions` array, formatted exactly:
+roles, and relationships in this document against that entry's recorded roles and claims. Flag a \
+material discrepancy only when both sides are high or medium confidence and you are confident it \
+is genuine — this is the only verification step; any callout is saved as-is. Put each as a string \
+in that entity's `contradictions` array, formatted exactly:
 > [!contradiction] <short label>
 > - **<existing value>** — [[documents/<slug>|<title>]], p. <n> (confidence: <level>)
 > - **<new value>** — [[documents/<new-slug>|<title>]], p. <n> (confidence: <level>)
 Do not flag low-confidence differences, trivial name variations, or contradictions already present.
 
 Also produce:
-- `document.summary`: one paragraph. `document.key_facts`: the 5–15 most important facts (fact, \
-page, confidence, and an optional verbatim `quote` — include the exact source sentence only when \
-its precise wording matters; otherwise just summarize the fact).
+- `document.summary`: ONE or two sentences orienting the reader — what this document is and why it \
+exists. Not a recap of the facts (those are in key_facts and the full text); just enough to know \
+what you are looking at.
 - `morgue_entity_id`: the kebab-case id of the entity this document is primarily *about* (debtor \
 for a bankruptcy, company for an annual report, defendant for a court order).
 - `morgue_document_type`: a type slug like annual-report, court-order, bankruptcy-filing.
@@ -130,14 +144,19 @@ def build_section_prompt(*, pages_text: str, existing_entities: list, skill_text
 
 def build_synthesis_prompt(bundle: dict) -> str:
     return (
-        "Synthesize Summary and Analysis prose for each entity below. Each was mentioned by two or "
-        "more documents this ingest, so reconcile all of its fragments with its carried prose into "
-        "a single coherent account — do not concatenate per-document sentences, and do not lose "
-        "specific detail (titles, figures, relationships) any source established. Where sources "
-        "genuinely conflict, prefer the higher-confidence one and note the uncertainty; do not "
-        "invent a resolution. `analysis` is the investigative narrative (patterns, significance, "
-        "open threads) — empty string if nothing beyond the summary. NEVER include "
-        "[!contradiction] callouts; contradictions live in their own section.\n\n"
+        "Synthesize Summary and Analysis prose for each entity below. Each appears in two or more "
+        "documents across the investigation, so reconcile all of its fragments with its carried "
+        "prose into a single coherent account — do not concatenate per-document sentences, and do "
+        "not lose specific detail (titles, figures, relationships) any source established. Keep the "
+        "`summary` SHORT: one to three paragraphs, scaled to the entity's complexity — a paragraph "
+        "for a simple recurring actor, up to three for a central figure with a tangled history. "
+        "Weight the full body of evidence: an entity established across many documents is not "
+        "redefined by a new passing mention — fold a minor new reference in without letting it "
+        "reshape an account the prior sources already settled. Where sources genuinely conflict, "
+        "prefer the higher-confidence one and note the uncertainty; do not invent a resolution. "
+        "`analysis` is the investigative narrative (patterns, significance, open threads) — empty "
+        "string if nothing beyond the summary. NEVER include [!contradiction] callouts; "
+        "contradictions live in their own section.\n\n"
         "The fragments contain structured claims, some carrying a verbatim `quote`. Compose the "
         "prose from the claims in your own words; weave a verbatim quote into the prose ONLY in "
         "exceptional cases where the quote itself is unusually strong or important — by default, "

--- a/src/watchdog/pipeline/schemas.py
+++ b/src/watchdog/pipeline/schemas.py
@@ -18,38 +18,23 @@ def _obj(properties: dict, required: list[str]) -> dict:
     }
 
 
+# The unified fact primitive (#140). Each material fact is emitted once and rendered into
+# multiple views deterministically: the document note's key-facts list, plus — via its optional
+# dimensions — the entity notes (`entities`: which entities the fact is about) and the timeline
+# (`date`: the date of the occurrence, set only when the fact IS a datable event). This replaces
+# the former separate per-entity `evidence_fragments` and `timeline_events`, which postflight now
+# reconstructs from these tags. `quote` is an optional verbatim source sentence (only when wording
+# matters).
 _KEY_FACT = _obj(
     {
         "fact": {"type": "string"},
         "page": {"type": ["integer", "null"]},
         "confidence": _CONFIDENCE,
+        "date": {"type": "string"},                                   # set ⇒ also a timeline event
+        "entities": {"type": "array", "items": {"type": "string"}},   # entity ids the fact is about
         "quote": {"type": "string"},   # optional verbatim source sentence (only when wording matters)
     },
     ["fact"],   # confidence omitted ⇒ high (the overwhelming default)
-)
-
-# A single investigatively-significant claim a document makes about an entity. Replaces the
-# extractor's free-text per-entity `analysis`: the post-ingest finalizer composes prose from
-# these. `quote` is an optional verbatim source sentence, set only when the exact wording matters.
-_EVIDENCE_FRAGMENT = _obj(
-    {
-        "claim": {"type": "string"},
-        "page": {"type": ["integer", "null"]},
-        "confidence": _CONFIDENCE,
-        "reason": {"type": "string"},   # why it matters (optional)
-        "quote": {"type": "string"},    # verbatim source sentence (optional)
-    },
-    ["claim"],
-)
-
-_TIMELINE_EVENT = _obj(
-    {
-        "date": {"type": "string"},
-        "event": {"type": "string"},
-        "page": {"type": ["integer", "null"]},
-        "confidence": _CONFIDENCE,
-    },
-    ["date", "event"],
 )
 
 _ROLE = _obj(
@@ -63,6 +48,9 @@ _ROLE = _obj(
     ["relationship", "target_id"],
 )
 
+# The graph layer (#140): entity identity + relationships + contradictions. What a document
+# *says* about an entity (claims, dated events) is no longer carried here — it lives in the
+# document's `key_facts`, tagged by entity id, and postflight reconstructs the per-entity views.
 _ENTITY = _obj(
     {
         "id": {"type": "string"},
@@ -70,10 +58,7 @@ _ENTITY = _obj(
         "name": {"type": "string"},
         "type": {"type": "string"},
         "aliases": {"type": "array", "items": {"type": "string"}},
-        "summary": {"type": "string"},
-        "evidence_fragments": {"type": "array", "items": _EVIDENCE_FRAGMENT},   # omit if nothing notable
         "contradictions": {"type": "array", "items": {"type": "string"}},
-        "timeline_events": {"type": "array", "items": _TIMELINE_EVENT},
         "roles": {"type": "array", "items": _ROLE},
     },
     ["id", "name", "type"],

--- a/src/watchdog/pipeline/synthesis_bundle.py
+++ b/src/watchdog/pipeline/synthesis_bundle.py
@@ -37,21 +37,29 @@ def _fragments_dir(vault_path: Path) -> Path:
 
 
 def build_bundle(vault_path: Path, min_docs: int = 2) -> dict:
-    """Gather every entity with >= min_docs fragments this run into one bundle.
+    """Gather every entity that recurs across the project into one synthesis bundle (#140).
 
-    Mirrors the selection the orchestrator previously made (``count >= 2``):
-    single-mention entities already have correct carried-forward notes and are
-    skipped here.
+    The gate is **project-wide recurrence**: an entity earns a synthesized summary once it
+    appears in ``min_docs`` (default 2) distinct documents across the whole investigation — read
+    from its registry ``appears_in``, not from this batch's mention count. Only entities *touched
+    this run* (present in the fragment queue) are candidates — an untouched entity has nothing new
+    to reconcile. Single-document entities are left as deterministic stubs (facts + relationships,
+    no summary section); a recurring entity that only got a fresh stub this run is promoted here as
+    its ``appears_in`` crosses the threshold, even when the two documents arrived in different
+    batches years apart.
     """
     frag_dir = _fragments_dir(vault_path)
     queue_path = frag_dir / "_queue.json"
     if not queue_path.exists():
         return {"entities": []}
 
+    entities_path = vault_path / ".watchdog" / "Registry" / "entities.json"
+    entities_reg = json.loads(entities_path.read_text(encoding="utf-8")) if entities_path.exists() else {}
+
     queue = json.loads(queue_path.read_text(encoding="utf-8"))
     entities = []
     for eid, rec in queue.items():
-        if rec.get("count", 0) < min_docs:
+        if len(entities_reg.get(eid, {}).get("appears_in", [])) < min_docs:
             continue
         frag_path = frag_dir / f"{eid}.md"
         if not frag_path.exists():

--- a/src/watchdog/pipeline/timeline.py
+++ b/src/watchdog/pipeline/timeline.py
@@ -46,41 +46,41 @@ def _stage_dedup_key(date: str, event: str) -> str:
 def stage_timeline_events(vault: Path, extraction: dict) -> int:
     """Write raw per-date NDJSON timeline files from an extraction blob.
 
-    Replaces the subagent's manual per-date writes (formerly Step 10). Collects
-    every entity's timeline_events, attaches the document sha and contributing
-    entity ids, deduplicates within the document by (date, event text) while
-    unioning entity ids, groups by date, and writes one raw
-    ``.watchdog/timeline/{date}_{sha[:7]}.ndjson`` file per date. The existing
-    ``timeline-collisions`` / ``rebuild-timeline`` flow consumes these unchanged.
+    Reads the dated facts on ``document.key_facts`` (#140): every key_fact carrying a ``date`` is a
+    timeline event, with its ``entities`` tags supplying the contributing entity ids. Attaches the
+    document sha, deduplicates within the document by (date, event text) while unioning entity ids,
+    groups by date, and writes one raw ``.watchdog/timeline/{date}_{sha[:7]}.ndjson`` file per date.
+    The existing ``timeline-collisions`` / ``rebuild-timeline`` flow consumes these unchanged.
 
     Returns the number of dates written.
     """
-    sha = (extraction.get("document") or {}).get("sha256", "")
+    doc = extraction.get("document") or {}
+    sha = doc.get("sha256", "")
     if not sha:
         return 0
 
     # date -> dedup_key -> record
     by_date: dict[str, dict[str, dict]] = {}
-    for entity in extraction.get("entities", []):
-        eid = entity.get("id")
-        for ev in entity.get("timeline_events", []):
-            date = (ev.get("date") or "").strip()
-            event_text = (ev.get("event") or "").strip()
-            if not date or not event_text:
-                continue
-            key = _stage_dedup_key(date, event_text)
-            bucket = by_date.setdefault(date, {})
-            if key in bucket:
-                if eid and eid not in bucket[key]["entity_ids"]:
+    for fact in doc.get("key_facts", []):
+        date = (fact.get("date") or "").strip()
+        event_text = (fact.get("fact") or "").strip()
+        if not date or not event_text:
+            continue
+        tags = [e for e in (fact.get("entities") or []) if e]
+        key = _stage_dedup_key(date, event_text)
+        bucket = by_date.setdefault(date, {})
+        if key in bucket:
+            for eid in tags:
+                if eid not in bucket[key]["entity_ids"]:
                     bucket[key]["entity_ids"].append(eid)
-            else:
-                bucket[key] = {
-                    "date": date,
-                    "event": event_text,
-                    "source_sha256": sha,
-                    "entity_ids": [eid] if eid else [],
-                    "confidence": ev.get("confidence", "high"),
-                }
+        else:
+            bucket[key] = {
+                "date": date,
+                "event": event_text,
+                "source_sha256": sha,
+                "entity_ids": list(tags),
+                "confidence": fact.get("confidence", "high"),
+            }
 
     if not by_date:
         return 0

--- a/src/watchdog/pipeline/write_vault.py
+++ b/src/watchdog/pipeline/write_vault.py
@@ -8,7 +8,10 @@ write so Claude's per-file work is: read text → output JSON → done.
 Usage:
     watchdog-write-vault --extraction .watchdog/tmp/extraction.json [--vault .]
 
-Extraction JSON schema:
+Extraction JSON schema (as consumed here — i.e. AFTER postflight.explode_key_facts has fanned the
+unified `key_facts` out into per-entity `evidence_fragments` / `timeline_events`, #140). The model
+itself emits only `key_facts` (with `date` / `entities` tags) plus the entity graph; it no longer
+emits per-entity summaries, fragments, or timeline events:
 {
   "document": {
     "sha256": str, "filename": str, "original_path": str,
@@ -16,18 +19,19 @@ Extraction JSON schema:
     "page_count": int, "source": str|null, "obtained": str|null,
     "near_duplicate_of": str|null, "shingles": [],
     "summary": str,
-    "key_facts": [{"fact": str, "page": int|null, "confidence": str, "quote": str|null}]
+    "key_facts": [{"fact": str, "page": int|null, "confidence": str,
+                   "date": str|null, "entities": [str], "quote": str|null}]
   },
   "entities": [
     {
       "id": str, "name": str, "type": str, "aliases": [],
-      "summary": str|null,
-      "evidence_fragments": [          // significant claims about this entity (no callouts)
-        {"claim": str, "page": int|null, "confidence": str,
-         "reason": str|null, "quote": str|null}
+      // summary is no longer emitted by the model — synthesized post-ingest, with a provisional
+      // one-liner from the entity's top tagged fact in the meantime.
+      "evidence_fragments": [          // reconstructed by postflight from facts tagged to this id
+        {"claim": str, "page": int|null, "confidence": str, "quote": str|null}
       ],
       "contradictions": [str]|null,    // each a `> [!contradiction]` callout block
-      "timeline_events": [
+      "timeline_events": [             // reconstructed by postflight from this id's dated facts
         {
           "date": str,   // YYYY-MM-DD, YYYY-MM, or YYYY
           "event": str,
@@ -509,6 +513,31 @@ def _add_reverse_role(
 
 # ── Note builders ─────────────────────────────────────────────────────────────
 
+def _write_morgue_markdown(vault_path: Path, sha256: str, morgue_dir: Path, stem: str) -> None:
+    """Write the Docling per-page markdown next to the original in the morgue (#140).
+
+    Best-effort: the page markdown lives in the chew-time queue descriptor, which is present during
+    ingest but gone on a re-run from disk (`watchdog finalize`); skip silently if unavailable.
+    Pages are joined with `<!-- PAGE N -->` markers so the file is both greppable and page-aligned.
+    """
+    queue_file = vault_path / ".watchdog" / "queue" / f"{sha256}.json"
+    if not queue_file.exists():
+        return
+    try:
+        pages = json.loads(queue_file.read_text(encoding="utf-8")).get("pages", [])
+    except (OSError, json.JSONDecodeError):
+        return
+    if not pages:
+        return
+    body = "\n\n".join(
+        f"<!-- PAGE {p.get('page')} -->\n\n{p.get('markdown', '')}".rstrip() for p in pages
+    )
+    try:
+        (morgue_dir / f"{stem}.md").write_text(body + "\n", encoding="utf-8")
+    except OSError:
+        pass
+
+
 def _render_evidence_fragments(fragments: list, morgue_path: str = "") -> str:
     """Render evidence-fragment claims as Markdown bullets.
 
@@ -604,6 +633,8 @@ def _build_document_note(doc: dict, entity_entries: list[dict], morgue_path: str
     body = ""
     if morgue_path:
         body += f"\n**Source file:** [[{morgue_path}]]\n"
+        md_path = str(Path(morgue_path).with_suffix(".md"))
+        body += f"\n**Full text:** [[{md_path}]]\n"
 
     body += f"\n## Summary\n\n{doc.get('summary', '')}\n"
 
@@ -778,6 +809,10 @@ def run(extraction_path: Path, vault_path: Path, skip_timeline: bool = False, ne
             notes_section = _extract_notes_section(note_path)
 
             incoming = incoming_by_id.get(eid, {})
+            # Extraction no longer emits a per-entity summary (#140). A recurring entity
+            # (appears_in >= 2) gets a model-synthesized summary in post-ingest; a single-document
+            # entity is a deterministic stub with no Summary section (its facts live in ## Analysis).
+            # So the only summary at write time is a carried one from a prior synthesis.
             new_summary = incoming.get("summary") or _extract_summary(note_path)
 
             existing_analysis = _extract_analysis(note_path)
@@ -873,6 +908,9 @@ def run(extraction_path: Path, vault_path: Path, skip_timeline: bool = False, ne
         sidecar = Path(str(source) + ".yml")
         if sidecar.exists():
             shutil.move(str(sidecar), str(morgue_dir / sidecar.name))
+        # Preserve the Docling text alongside the original so the full document stays greppable in
+        # the vault — extraction now indexes this substrate rather than restating it (#140).
+        _write_morgue_markdown(vault_path, doc_sha256, morgue_dir, source.stem)
 
         incoming_dir = vault_path / "_INCOMING"
         parent = source.parent

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -8,21 +8,18 @@ from watchdog.pipeline.merge import merge_extractions
 def test_merge_unions_entities_by_id():
     sections = [
         {"document": {"sha256": "x", "filename": "f",
-                      "key_facts": [{"fact": "A", "page": 1, "confidence": "high"}]},
+                      "key_facts": [{"fact": "Incorporated in Ontario", "date": "2020",
+                                     "page": 1, "entities": ["acme"]}]},
          "entities": [{"id": "acme", "name": "Acme Corp", "type": "Company",
-                       "aliases": ["the Company"],
-                       "timeline_events": [{"date": "2020", "event": "incorporated", "confidence": "high"}],
-                       "roles": []}],
+                       "aliases": ["the Company"], "roles": []}],
          "morgue_entity_id": "acme", "morgue_document_type": "annual-report"},
-        {"document": {"key_facts": [{"fact": "B", "page": 60, "confidence": "high"}]},
+        {"document": {"key_facts": [{"fact": "Filed its annual report", "date": "2021",
+                                     "page": 60, "entities": ["acme"]}]},
          "entities": [
              {"id": "acme", "name": "Acme Corp", "type": "Company", "aliases": [],
-              "timeline_events": [{"date": "2021", "event": "filed report", "confidence": "medium"}],
-              "roles": [{"relationship": "Director of", "target_id": "jane",
-                         "target_type": "Person", "target_name": "Jane", "page": 61,
-                         "confidence": "high", "date_range": None}]},
-             {"id": "jane", "name": "Jane Doe", "type": "Person", "aliases": [],
-              "timeline_events": [], "roles": []}],
+              "roles": [{"relationship": "Director of", "target_id": "jane", "page": 61,
+                         "date_range": None}]},
+             {"id": "jane", "name": "Jane Doe", "type": "Person", "aliases": [], "roles": []}],
          "morgue_entity_id": None, "morgue_document_type": None},
     ]
     merged = merge_extractions(sections)
@@ -30,9 +27,10 @@ def test_merge_unions_entities_by_id():
 
     assert set(ents) == {"acme", "jane"}
     assert "the Company" in ents["acme"]["aliases"]
-    assert {ev["date"] for ev in ents["acme"]["timeline_events"]} == {"2020", "2021"}
     assert len(ents["acme"]["roles"]) == 1
-    assert {f["fact"] for f in merged["document"]["key_facts"]} == {"A", "B"}
+    assert {f["fact"] for f in merged["document"]["key_facts"]} == {
+        "Incorporated in Ontario", "Filed its annual report"}
+    assert {f["date"] for f in merged["document"]["key_facts"]} == {"2020", "2021"}
     assert merged["document"]["sha256"] == "x"          # document from first non-empty
     assert merged["morgue_entity_id"] == "acme"          # first non-null wins
 
@@ -41,56 +39,55 @@ def test_merge_folds_id_drift_by_normalized_name():
     sections = [
         {"document": {"sha256": "x", "filename": "f"},
          "entities": [{"id": "acme-corp", "name": "Acme Corp", "type": "Company",
-                       "aliases": [], "timeline_events": [], "roles": []}]},
+                       "aliases": [], "roles": []}]},
         {"document": {},
          "entities": [{"id": "acme-corp-2", "name": "ACME  CORP", "type": "Company",
-                       "aliases": [], "timeline_events": [{"date": "2021", "event": "x", "confidence": "high"}],
-                       "roles": []}]},
+                       "aliases": ["ACME"],
+                       "roles": [{"relationship": "Owns", "target_id": "widget"}]}]},
     ]
     merged = merge_extractions(sections)
     assert len(merged["entities"]) == 1                  # drift folded onto one id
     assert merged["entities"][0]["id"] == "acme-corp"
-    assert len(merged["entities"][0]["timeline_events"]) == 1
+    assert merged["entities"][0]["roles"][0]["target_id"] == "widget"   # roles carried over
 
 
-def test_merge_dedups_timeline_and_key_facts():
+def test_merge_dedups_key_facts():
     section = {
-        "document": {"sha256": "x", "key_facts": [{"fact": "Same fact", "page": 1, "confidence": "high"}]},
-        "entities": [{"id": "a", "name": "A", "type": "Person", "aliases": [],
-                      "timeline_events": [{"date": "2020", "event": "did thing", "confidence": "high"}],
-                      "roles": []}],
+        "document": {"sha256": "x", "key_facts": [
+            {"fact": "Same fact", "page": 1, "entities": ["a"]},
+            {"fact": "Did a thing", "date": "2020", "entities": ["a"]},
+        ]},
+        "entities": [{"id": "a", "name": "A", "type": "Person", "aliases": [], "roles": []}],
     }
     merged = merge_extractions([section, json.loads(json.dumps(section))])  # identical twice
-    assert len(merged["entities"][0]["timeline_events"]) == 1
-    assert len(merged["document"]["key_facts"]) == 1
+    assert len(merged["document"]["key_facts"]) == 2
 
 
-def test_merge_omits_empty_summary_and_evidence_fragments():
+def test_merge_entity_has_no_fact_or_timeline_fields():
+    """The merged entity is graph-only; facts/timeline live on document.key_facts (#140)."""
     merged = merge_extractions([
         {"document": {"sha256": "x"},
-         "entities": [{"id": "a", "name": "A", "type": "Person", "aliases": [],
-                       "timeline_events": [], "roles": []}]},
+         "entities": [{"id": "a", "name": "A", "type": "Person", "aliases": [], "roles": []}]},
     ])
     ent = merged["entities"][0]
     assert "summary" not in ent
     assert "evidence_fragments" not in ent
+    assert "timeline_events" not in ent
+    assert set(ent) >= {"id", "name", "type", "aliases", "roles"}
 
 
-def test_merge_unions_evidence_fragments_across_sections():
+def test_merge_unions_key_fact_entity_tags_across_sections():
+    """The same fact tagged with different entities in two sections folds, unioning the tags."""
     sections = [
-        {"document": {"sha256": "x", "filename": "f"},
-         "entities": [{"id": "a", "name": "A", "type": "Person", "aliases": [],
-                       "evidence_fragments": [{"claim": "Claim one.", "confidence": "high"}],
-                       "timeline_events": [], "roles": []}]},
-        {"document": {},
-         "entities": [{"id": "a", "name": "A", "type": "Person", "aliases": [],
-                       "evidence_fragments": [
-                           {"claim": "Claim one.", "confidence": "high"},      # dup → folded
-                           {"claim": "Claim two.", "confidence": "medium"}],
-                       "timeline_events": [], "roles": []}]},
+        {"document": {"sha256": "x", "filename": "f",
+                      "key_facts": [{"fact": "Shared an address.", "entities": ["a"]}]},
+         "entities": [{"id": "a", "name": "A", "type": "Person", "aliases": [], "roles": []}]},
+        {"document": {"key_facts": [{"fact": "Shared an address.", "entities": ["b"]}]},
+         "entities": [{"id": "b", "name": "B", "type": "Person", "aliases": [], "roles": []}]},
     ]
-    frags = merge_extractions(sections)["entities"][0]["evidence_fragments"]
-    assert {f["claim"] for f in frags} == {"Claim one.", "Claim two."}
+    facts = merge_extractions(sections)["document"]["key_facts"]
+    assert len(facts) == 1
+    assert sorted(facts[0]["entities"]) == ["a", "b"]
 
 
 def test_run_merges_section_files(tmp_path):
@@ -99,13 +96,11 @@ def test_run_merges_section_files(tmp_path):
     tmp.mkdir(parents=True)
     (tmp / "section_ex_doc1_01.json").write_text(json.dumps({
         "document": {"sha256": "doc1", "filename": "f"},
-        "entities": [{"id": "a", "name": "A", "type": "Person", "aliases": [],
-                      "timeline_events": [], "roles": []}],
+        "entities": [{"id": "a", "name": "A", "type": "Person", "aliases": [], "roles": []}],
         "morgue_entity_id": "a", "morgue_document_type": "t"}))
     (tmp / "section_ex_doc1_02.json").write_text(json.dumps({
         "document": {},
-        "entities": [{"id": "b", "name": "B", "type": "Person", "aliases": [],
-                      "timeline_events": [], "roles": []}]}))
+        "entities": [{"id": "b", "name": "B", "type": "Person", "aliases": [], "roles": []}]}))
 
     result = merge.run(vault, "doc1")
     assert result["ok"] is True
@@ -130,8 +125,8 @@ def test_run_splits_new_vs_updated_against_registry(tmp_path):
     (tmp / "section_ex_doc1_01.json").write_text(json.dumps({
         "document": {"sha256": "doc1", "filename": "f"},
         "entities": [
-            {"id": "a", "name": "A", "type": "Person", "aliases": [], "timeline_events": [], "roles": []},
-            {"id": "b", "name": "B", "type": "Person", "aliases": [], "timeline_events": [], "roles": []},
+            {"id": "a", "name": "A", "type": "Person", "aliases": [], "roles": []},
+            {"id": "b", "name": "B", "type": "Person", "aliases": [], "roles": []},
         ],
         "morgue_entity_id": "a", "morgue_document_type": "t"}))
 

--- a/tests/test_postflight.py
+++ b/tests/test_postflight.py
@@ -1,0 +1,140 @@
+import json
+from pathlib import Path
+
+from watchdog.pipeline.postflight import _apply_match_ids, explode_key_facts
+from watchdog.pipeline.postflight import run as postflight_run
+
+
+# ── explode_key_facts (the unified-fact fan-out, #140) ──────────────────────
+
+def test_explode_fans_facts_to_tagged_entities():
+    extraction = {
+        "document": {"key_facts": [
+            {"fact": "Paid $842,018.34 to the fund.", "date": "2021-03-30", "page": 3,
+             "entities": ["lu", "pbgf"]},
+            {"fact": "Transfer ratio set at 65.8%.", "page": 2, "entities": ["lu"]},
+            {"fact": "Boilerplate with no entity tag.", "page": 4},
+        ]},
+        "entities": [
+            {"id": "lu", "name": "LU", "type": "Company"},
+            {"id": "pbgf", "name": "PBGF", "type": "Fund"},
+        ],
+    }
+    explode_key_facts(extraction)
+
+    lu = next(e for e in extraction["entities"] if e["id"] == "lu")
+    pbgf = next(e for e in extraction["entities"] if e["id"] == "pbgf")
+
+    assert {f["claim"] for f in lu["evidence_fragments"]} == {
+        "Paid $842,018.34 to the fund.", "Transfer ratio set at 65.8%."}
+    assert [f["claim"] for f in pbgf["evidence_fragments"]] == ["Paid $842,018.34 to the fund."]
+    # Only the dated fact becomes a timeline event, and on every entity it tags.
+    assert [ev["date"] for ev in lu["timeline_events"]] == ["2021-03-30"]
+    assert [ev["date"] for ev in pbgf["timeline_events"]] == ["2021-03-30"]
+    # The document-level key_facts are left intact (doc note + global timeline read them).
+    assert len(extraction["document"]["key_facts"]) == 3
+
+
+def test_explode_carries_page_and_confidence_but_not_to_event_when_undated():
+    extraction = {
+        "document": {"key_facts": [
+            {"fact": "An inferred claim.", "page": 7, "confidence": "medium", "entities": ["a"]},
+        ]},
+        "entities": [{"id": "a", "name": "A", "type": "Person"}],
+    }
+    explode_key_facts(extraction)
+    frag = extraction["entities"][0]["evidence_fragments"][0]
+    assert frag == {"claim": "An inferred claim.", "page": 7, "confidence": "medium"}
+    assert "timeline_events" not in extraction["entities"][0]
+
+
+def test_explode_ignores_unknown_tags():
+    extraction = {"document": {"key_facts": [{"fact": "x", "entities": ["ghost"]}]},
+                  "entities": [{"id": "real", "name": "R", "type": "Person"}]}
+    explode_key_facts(extraction)
+    assert "evidence_fragments" not in extraction["entities"][0]
+
+
+def test_apply_match_ids_remaps_key_fact_tags():
+    extraction = {
+        "document": {"key_facts": [{"fact": "x", "entities": ["new-slug", "other"]}]},
+        "entities": [{"id": "new-slug", "match_id": "canonical", "name": "N", "type": "Person"}],
+    }
+    _apply_match_ids(extraction)
+    assert extraction["entities"][0]["id"] == "canonical"
+    assert extraction["document"]["key_facts"][0]["entities"] == ["canonical", "other"]
+
+
+# ── end-to-end through postflight ───────────────────────────────────────────
+
+def _full_vault(tmp_path: Path) -> Path:
+    vault = tmp_path / "vault"
+    reg = vault / ".watchdog" / "Registry"
+    reg.mkdir(parents=True)
+    (vault / ".watchdog" / "tmp").mkdir()
+    (vault / ".watchdog" / "queue").mkdir()
+    (vault / "_INCOMING").mkdir()
+    (vault / "documents").mkdir()
+    (reg / "entities.json").write_text("{}\n")
+    (reg / "documents.json").write_text("{}\n")
+    (reg / "registry.json").write_text(json.dumps({"document_count": 0, "entity_count": 0}) + "\n")
+    (reg / "ingest.log").write_text("")
+    return vault
+
+
+def _extraction(sha="sha777aaa"):
+    return {
+        "document": {
+            "sha256": sha, "filename": "doc.pdf", "original_path": "_INCOMING/doc.pdf",
+            "title": "Doc", "document_type": "Order", "page_count": 2,
+            "summary": "A court order.",
+            "key_facts": [
+                {"fact": "Transfer ratio set at 65.8%.", "page": 2, "entities": ["lu"]},
+                {"fact": "Stayed a $842,018.34 payment.", "date": "2021-03-30", "page": 3,
+                 "entities": ["lu", "pbgf"]},
+            ],
+        },
+        "entities": [
+            {"id": "lu", "name": "Laurentian University", "type": "Company", "aliases": [], "roles": []},
+            {"id": "pbgf", "name": "PBGF", "type": "Fund", "aliases": [], "roles": []},
+        ],
+        "morgue_entity_id": "lu", "morgue_document_type": "court-order",
+    }
+
+
+def test_postflight_builds_entity_analysis_from_tagged_facts(tmp_path):
+    vault = _full_vault(tmp_path)
+    (vault / "_INCOMING" / "doc.pdf").write_text("pdf")
+    ext_path = vault / ".watchdog" / "tmp" / "wdg_ex_sha777aaa.json"
+    ext_path.write_text(json.dumps(_extraction()), encoding="utf-8")
+
+    result = postflight_run(vault, ext_path)
+    assert result.get("ok"), result
+
+    lu_note = (vault / "entities" / "company" / "lu.md").read_text(encoding="utf-8")
+    assert "Transfer ratio set at 65.8%." in lu_note       # tagged fact → analysis
+    assert "Stayed a $842,018.34 payment." in lu_note
+    assert "2021-03-30" in lu_note or "30 Mar 2021" in lu_note   # dated fact → entity timeline
+
+    pbgf_note = (vault / "entities" / "fund" / "pbgf.md").read_text(encoding="utf-8")
+    assert "Stayed a $842,018.34 payment." in pbgf_note
+    assert "Transfer ratio set at 65.8%." not in pbgf_note  # not tagged to pbgf
+
+
+def test_postflight_writes_morgue_markdown(tmp_path):
+    vault = _full_vault(tmp_path)
+    (vault / "_INCOMING" / "doc.pdf").write_text("pdf")
+    (vault / ".watchdog" / "queue" / "sha777aaa.json").write_text(json.dumps({
+        "pages": [{"page": 1, "markdown": "# Heading one"},
+                  {"page": 2, "markdown": "Second page body."}],
+    }))
+    ext_path = vault / ".watchdog" / "tmp" / "wdg_ex_sha777aaa.json"
+    ext_path.write_text(json.dumps(_extraction()), encoding="utf-8")
+
+    assert postflight_run(vault, ext_path).get("ok")
+
+    md_files = list((vault / "morgue").rglob("*.md"))
+    assert len(md_files) == 1
+    text = md_files[0].read_text(encoding="utf-8")
+    assert "<!-- PAGE 1 -->" in text and "<!-- PAGE 2 -->" in text
+    assert "# Heading one" in text and "Second page body." in text

--- a/tests/test_synthesis_bundle.py
+++ b/tests/test_synthesis_bundle.py
@@ -45,6 +45,36 @@ def test_build_bundle_selects_multi_mention_with_fragments_and_prose(tmp_path):
     assert alice["note_path"].endswith("alice-smith")
 
 
+def test_build_bundle_gates_on_project_wide_appears_in(tmp_path):
+    """Recurrence is counted across the whole project (appears_in), not within the batch (#140):
+    an entity in 2 documents total is selected even if only touched once this run; an entity in
+    1 document total is skipped even when touched this run."""
+    vault = make_vault(tmp_path)
+    reg_path = vault / ".watchdog" / "Registry" / "entities.json"
+    reg = {
+        "recurring-co": {"id": "recurring-co", "name": "Recurring Co", "type": "Company",
+                         "note_path": "entities/company/recurring-co",
+                         "appears_in": ["sha-old", "sha-new"]},   # 2 docs, across batches
+        "one-off": {"id": "one-off", "name": "One Off", "type": "Person",
+                    "note_path": "entities/person/one-off", "appears_in": ["sha-new"]},   # 1 doc
+    }
+    reg_path.write_text(json.dumps(reg))
+
+    frag_dir = vault / ".watchdog" / "tmp" / "entity-fragments"
+    frag_dir.mkdir(parents=True, exist_ok=True)
+    queue = {}
+    for eid, e in reg.items():
+        (frag_dir / f"{eid}.md").write_text(f"### doc\nclaim about {eid}\n", encoding="utf-8")
+        note = vault / f"{e['note_path']}.md"
+        note.parent.mkdir(parents=True, exist_ok=True)
+        note.write_text(f"# {e['name']}\n\n## Summary\n\ns\n", encoding="utf-8")
+        queue[eid] = {"name": e["name"], "note_path": e["note_path"], "count": 1}   # touched once this run
+    (frag_dir / "_queue.json").write_text(json.dumps(queue), encoding="utf-8")
+
+    ids = {e["entity_id"] for e in build_bundle(vault)["entities"]}
+    assert ids == {"recurring-co"}   # promoted by project-wide recurrence; one-off stays a stub
+
+
 # ── apply_bundle ──────────────────────────────────────────────────────────────
 
 def _full_extraction(tmp_path):

--- a/tests/test_timeline.py
+++ b/tests/test_timeline.py
@@ -16,8 +16,9 @@ def _vault(tmp_path: Path) -> Path:
     return v
 
 
-def _extraction(entities: list[dict], sha: str = "abcdef1234567") -> dict:
-    return {"document": {"sha256": sha}, "entities": entities}
+def _extraction(key_facts: list[dict], sha: str = "abcdef1234567") -> dict:
+    """Build an extraction whose timeline derives from dated document.key_facts (#140)."""
+    return {"document": {"sha256": sha, "key_facts": key_facts}, "entities": []}
 
 
 def _read_ndjson(path: Path) -> list[dict]:
@@ -29,10 +30,9 @@ def _read_ndjson(path: Path) -> list[dict]:
 def test_stage_writes_one_file_per_date(tmp_path):
     vault = _vault(tmp_path)
     n = stage_timeline_events(vault, _extraction([
-        {"id": "alice", "timeline_events": [
-            {"date": "2020-03-15", "event": "Appointed director", "page": 2, "confidence": "high"},
-            {"date": "2021", "event": "Resigned", "page": 5, "confidence": "medium"},
-        ]},
+        {"fact": "Appointed director", "date": "2020-03-15", "page": 2, "entities": ["alice"]},
+        {"fact": "Resigned", "date": "2021", "page": 5, "confidence": "medium", "entities": ["alice"]},
+        {"fact": "Owns a controlling stake", "entities": ["alice"]},   # no date → not a timeline event
     ], sha="abcdef1234567"))
 
     assert n == 2
@@ -52,10 +52,8 @@ def test_stage_writes_one_file_per_date(tmp_path):
 def test_stage_dedups_same_event_across_entities(tmp_path):
     vault = _vault(tmp_path)
     stage_timeline_events(vault, _extraction([
-        {"id": "alice", "timeline_events": [
-            {"date": "2020-03-15", "event": "Acme filed for bankruptcy", "confidence": "high"}]},
-        {"id": "acme", "timeline_events": [
-            {"date": "2020-03-15", "event": "Acme filed for bankruptcy", "confidence": "high"}]},
+        {"fact": "Acme filed for bankruptcy", "date": "2020-03-15", "entities": ["alice"]},
+        {"fact": "Acme filed for bankruptcy", "date": "2020-03-15", "entities": ["acme"]},
     ], sha="sha12340000"))
 
     recs = _read_ndjson(vault / ".watchdog" / "timeline" / "2020-03-15_sha1234.ndjson")
@@ -66,23 +64,31 @@ def test_stage_dedups_same_event_across_entities(tmp_path):
 def test_stage_keeps_distinct_events_on_same_date(tmp_path):
     vault = _vault(tmp_path)
     stage_timeline_events(vault, _extraction([
-        {"id": "alice", "timeline_events": [
-            {"date": "2020-03-15", "event": "Event A", "confidence": "high"},
-            {"date": "2020-03-15", "event": "Event B", "confidence": "low"}]},
+        {"fact": "Event A", "date": "2020-03-15", "entities": ["alice"]},
+        {"fact": "Event B", "date": "2020-03-15", "confidence": "low", "entities": ["alice"]},
     ], sha="zzzzzzz9999"))
 
     recs = _read_ndjson(vault / ".watchdog" / "timeline" / "2020-03-15_zzzzzzz.ndjson")
     assert {r["event"] for r in recs} == {"Event A", "Event B"}
 
 
-def test_stage_skips_events_without_date_or_text(tmp_path):
+def test_stage_keeps_untagged_dated_fact(tmp_path):
+    vault = _vault(tmp_path)
+    stage_timeline_events(vault, _extraction([
+        {"fact": "The hearing was held by Zoom", "date": "2020-03-15"},   # no entity tags
+    ], sha="untag00000aa"))
+
+    recs = _read_ndjson(vault / ".watchdog" / "timeline" / "2020-03-15_untag00.ndjson")
+    assert recs[0]["event"] == "The hearing was held by Zoom"
+    assert recs[0]["entity_ids"] == []
+
+
+def test_stage_skips_facts_without_date_or_text(tmp_path):
     vault = _vault(tmp_path)
     n = stage_timeline_events(vault, _extraction([
-        {"id": "alice", "timeline_events": [
-            {"date": "", "event": "no date", "confidence": "high"},
-            {"date": "2020", "event": "", "confidence": "high"},
-            {"event": "missing date key", "confidence": "high"},
-        ]},
+        {"fact": "no date", "entities": ["alice"]},
+        {"fact": "", "date": "2020"},
+        {"date": "2021"},   # missing fact text
     ]))
     assert n == 0
     td = vault / ".watchdog" / "timeline"
@@ -91,7 +97,7 @@ def test_stage_skips_events_without_date_or_text(tmp_path):
 
 def test_stage_returns_zero_without_sha(tmp_path):
     vault = _vault(tmp_path)
-    assert stage_timeline_events(vault, {"document": {}, "entities": []}) == 0
+    assert stage_timeline_events(vault, {"document": {"key_facts": []}, "entities": []}) == 0
 
 
 # ── Integration with the collisions / rebuild flow ──────────────────────────
@@ -99,8 +105,7 @@ def test_stage_returns_zero_without_sha(tmp_path):
 def test_stage_then_collisions_promotes_and_rebuild_renders(tmp_path, capsys):
     vault = _vault(tmp_path)
     stage_timeline_events(vault, _extraction([
-        {"id": "alice", "timeline_events": [
-            {"date": "2020-03-15", "event": "Appointed director", "confidence": "high"}]},
+        {"fact": "Appointed director", "date": "2020-03-15", "entities": ["alice"]},
     ], sha="doc1xxxxxxx"))
 
     cmd_timeline_collisions(vault)
@@ -126,8 +131,7 @@ def test_stage_collision_reported_when_canonical_exists(tmp_path, capsys):
     )
 
     stage_timeline_events(vault, _extraction([
-        {"id": "bob", "timeline_events": [
-            {"date": "2020-03-15", "event": "New event", "confidence": "high"}]},
+        {"fact": "New event", "date": "2020-03-15", "entities": ["bob"]},
     ], sha="newdoc12345"))
 
     cmd_timeline_collisions(vault)
@@ -166,12 +170,12 @@ def test_postflight_stages_timeline_files(tmp_path):
             "date_of_document": "2024-01-15",
             "page_count": 1,
             "summary": "x",
-            "key_facts": [],
+            "key_facts": [
+                {"fact": "Appointed", "date": "2020-03-15", "entities": ["alice"]},
+            ],
         },
         "entities": [
-            {"id": "alice", "name": "Alice", "type": "Person", "aliases": [],
-             "timeline_events": [{"date": "2020-03-15", "event": "Appointed", "confidence": "high"}],
-             "roles": []},
+            {"id": "alice", "name": "Alice", "type": "Person", "aliases": [], "roles": []},
         ],
         "morgue_entity_id": "alice",
         "morgue_document_type": "report",


### PR DESCRIPTION
Closes part of #140 (the extraction-restructuring lever; the columnar-JSON benchmark remains open).

## The problem

The extractor restated the same fact up to **three times** — as a `document.key_fact`, as each involved entity's `evidence_fragment`, and (if dated) as each entity's `timeline_event` — plus a per-entity `summary`. The 5-page Laurentian pension order emitted **~4× the source text** in JSON (32K chars of JSON from 7.7K of Docling markdown). That redundancy was only rational because the Docling text was **discarded** after extraction, leaving the JSON as the sole text record.

## The change (ARCHITECTURE D26)

A **fact layer** and a **graph layer**:

- **Retain the source text.** The full Docling markdown is now stored in the morgue as a sibling `<name>.md` (deterministic, free), linked from each document note. Extraction *indexes* that substrate instead of reproducing it.
- **Emit each fact once.** The model writes a material fact a single time on `document.key_facts`, tagged with the `entities` it concerns and an optional `date` (set only when the fact *is* a datable occurrence). Entities carry only the graph — identity, aliases, roles, contradictions — no per-entity summary/fragments/timeline.
- **Deterministic fan-out.** `postflight.explode_key_facts` reconstructs the per-entity `evidence_fragments` + `timeline_events` the writers already consume, so all downstream rendering is unchanged. `stage_timeline_events` reads the dated facts directly. The token win is entirely in what the *model* emits; the internal vault representation is the same.
- **Materiality-driven, general skip rule.** No fixed key-fact count; the skip guidance is a single principle (omit boilerplate, recitation, reasoning that doesn't establish a fact), not a document-type-specific list.

## Measured result

Same document, same model (sonnet), single clean generation each:

| Metric | OLD (main) | NEW | Delta |
|---|---|---|---|
| **Output tokens** | 27,173 | 15,558 | **−42.7%** |
| Compact JSON chars | 22,251 | 11,807 | −46.9% |

Stacks on top of #142 (roles by-id) and #144 (omit-default confidence) already in main. Quality held — all material facts captured (entity-tagged, dated where they're occurrences); the only drops were procedural boilerplate.

## Synthesis: gated on project-wide recurrence

Reworked the entity-summary gate to match how recurrence actually signals importance:

- An entity earns a **model-written short summary (1–3 paragraphs)** once its `appears_in` reaches **2 documents across the whole investigation** — not batch-local mention count. So a registering agent or law firm that recurs in a *later batch, years apart* is promoted.
- **Single-document entities are deterministic stubs** — facts in `## Analysis`, links in `## Relationships`, no Summary section.
- **Association is free:** an incidental actor tied to a tracked entity (the paralegal who filed for a watched party) is captured via the relationship graph on both notes; its own recurrence promotes it.
- The synthesis prompt now **weights the full body of evidence** so a new passing mention can't reshape a settled account.

## Tests / docs

- 520 tests pass. Rewrote `test_merge` / `test_timeline` for the new shape; added `test_postflight` (explode shim, match-id tag remap, morgue-markdown) and a recurrence-gate test proving cross-batch promotion.
- ARCHITECTURE D26 + §5/§7/§8/§9/§12 updated; README morgue note.

## Follow-ups (deliberately out of scope)

- Columnar JSON benchmark (the remaining #140 lever) — stacks on this.
- #146 (sha-keyed chew cache) — newly feasible now that the markdown is retained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)