### PR TITLE
Ingest progress: live in-place status rows + up-front timing warning

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -190,7 +190,7 @@ Watchdog scans the queue, confirms, and runs the extraction pipeline in your ter
 
 By default, Watchdog uses Sonnet for extraction, and Haiku for classification and post-ingest. Configure persistent defaults with `watchdog configure` (e.g. `watchdog configure extractor_model haiku`), or override per run with `--extractor-model`, `--finalizer-model`, and `--concurrency`. See the [Commands](README.md#processing) and [Configuration](README.md#configuration) sections of the README for details.
 
-Claude will work through each chewed file, extract entities, relationships, and key facts, and write everything to your vault. At the end it produces a briefing showing:
+Watchdog works through the chewed files in parallel, showing one live status row per document as it moves from classifying to extracting to done; finished files settle into the log above. Large documents can take several minutes each, so a long pause on a row is normal, not a stall. It extracts entities, relationships, and key facts and writes everything to your vault. At the end it produces a briefing showing:
 - What documents were processed
 - What entities (people, companies, addresses) were found
 - Connections between entities that were already in your vault

--- a/src/watchdog/cmd/ingest.py
+++ b/src/watchdog/cmd/ingest.py
@@ -262,6 +262,8 @@ def cmd_ingest(args, *, confirm: bool = True) -> None:
         log_path.write_text(_render_template("log.md"))
     print(f"\n  {_DIM}Extracting (≤{concurrency} parallel) — the model is called only for reasoning; "
           f"the pipeline runs in Python.{_RESET}")
+    print(f"  {_YELLOW}Large documents can take several minutes each{_RESET}{_DIM} — a long pause on a "
+          f"row is normal, not a stall.{_RESET}")
     print(f"  {_DIM}Press {_RESET}{_CYAN}Ctrl+C{_RESET}{_DIM} to stop; finished documents are kept.{_RESET}\n")
     try:
         summary = asyncio.run(orchestrate.run(

--- a/src/watchdog/cmd/live.py
+++ b/src/watchdog/cmd/live.py
@@ -1,0 +1,116 @@
+"""A small live-region renderer for long-running CLI commands (#151).
+
+Owns a block of rows at the bottom of the terminal that are redrawn in place — one row per
+in-flight unit of work — while finished/failed lines and notes scroll up into the permanent
+scrollback above. No TUI dependency: a handful of ANSI cursor escapes, matching the app's
+hand-rolled palette (see the CLI style guide in CLAUDE.md / cmd.base).
+
+When stdout is not a TTY (CI, piped, `tee`), it degrades to append-only printing — every
+`update`/`finish`/`note` just prints its line — so logs stay readable and unchanged.
+
+Reusable: any command with concurrent or long-running steps can drive one of these. Callers
+pass fully-formatted lines (including the 2-space indent and colour codes); the region only
+truncates live rows to the terminal width so the redraw math stays one physical line per row.
+"""
+
+import re
+import shutil
+import sys
+
+_ANSI = re.compile(r"\033\[[0-9;]*m")
+_RESET = "\033[0m"
+
+
+def _truncate(line: str, width: int) -> str:
+    """Clip a line to `width` visible columns, preserving ANSI codes (zero visible width)
+    and closing with a reset so colour never bleeds past the cut."""
+    if width <= 0:
+        return line
+    out: list[str] = []
+    visible = 0
+    i = 0
+    while i < len(line):
+        m = _ANSI.match(line, i)
+        if m:
+            out.append(m.group())
+            i = m.end()
+            continue
+        if visible >= width - 1:
+            out.append("…")
+            out.append(_RESET)
+            return "".join(out)
+        out.append(line[i])
+        visible += 1
+        i += 1
+    return "".join(out)
+
+
+class LiveRegion:
+    """A redraw-in-place region of keyed rows with a scrollback of finished lines above it."""
+
+    def __init__(self, stream=None, *, enabled: bool | None = None):
+        self.stream = stream if stream is not None else sys.stdout
+        self.enabled = self.stream.isatty() if enabled is None else enabled
+        self._rows: dict[str, str] = {}
+        self._order: list[str] = []
+        self._rendered = 0          # live rows currently drawn (== physical lines, post-truncation)
+
+    # ── public API ────────────────────────────────────────────────────────────
+
+    def update(self, key: str, tty_line: str, plain_line: str | None = None) -> None:
+        """Add or mutate the in-flight row for `key`. Non-TTY prints `plain_line` (or `tty_line`)."""
+        if not self.enabled:
+            self._print(plain_line if plain_line is not None else tty_line)
+            return
+        if key not in self._rows:
+            self._order.append(key)
+        self._rows[key] = tty_line
+        self._render()
+
+    def finish(self, key: str, line: str) -> None:
+        """Settle `key`: print `line` permanently above the region and drop its live row."""
+        if not self.enabled:
+            self._print(line)
+            return
+        self._emit_above(line)
+        if key in self._rows:
+            self._order.remove(key)
+            del self._rows[key]
+        self._render()
+
+    def note(self, line: str) -> None:
+        """Print a permanent line above the live region (a log entry not tied to a row)."""
+        if not self.enabled:
+            self._print(line)
+            return
+        self._emit_above(line)
+        self._render()
+
+    def stop(self) -> None:
+        """Leave the final region on screen and flush. Call once when work is done."""
+        if self.enabled:
+            self.stream.flush()
+
+    # ── rendering ─────────────────────────────────────────────────────────────
+
+    def _print(self, line: str) -> None:
+        self.stream.write(line + "\n")
+        self.stream.flush()
+
+    def _clear(self) -> None:
+        """Move to the top of the live region and erase it; cursor ends where it began."""
+        if self._rendered:
+            self.stream.write(f"\033[{self._rendered}A\033[J")
+        self._rendered = 0
+
+    def _render(self) -> None:
+        self._clear()
+        width = shutil.get_terminal_size((80, 24)).columns
+        for key in self._order:
+            self.stream.write(_truncate(self._rows[key], width) + "\n")
+        self._rendered = len(self._order)
+        self.stream.flush()
+
+    def _emit_above(self, line: str) -> None:
+        self._clear()
+        self.stream.write(line + "\n")

--- a/src/watchdog/pipeline/orchestrate.py
+++ b/src/watchdog/pipeline/orchestrate.py
@@ -22,6 +22,7 @@ import yaml
 
 from watchdog import model_client, skills_catalog
 from watchdog.cmd.base import _BOLD, _CYAN, _DIM, _GREEN, _RESET, _YELLOW
+from watchdog.cmd.live import LiveRegion
 from watchdog.pipeline import (
     abort, merge, preflight, postflight, prompts, schemas, section, synthesis_bundle, timeline,
 )
@@ -30,9 +31,28 @@ from watchdog.pipeline.write_vault import _doc_slug
 DEFAULT_CONCURRENCY = 5
 
 
+# During extraction this holds the live status region (#151); per-document rows redraw in
+# place and finished/failed lines + notes scroll above it. None outside extraction (and when
+# stdout isn't a TTY), so `_say` falls back to plain append-only printing.
+_board: LiveRegion | None = None
+
+
 def _say(msg: str) -> None:
-    """Print a styled progress line to the terminal (indented per the CLI style guide)."""
-    print(f"  {msg}", flush=True)
+    """Print a styled progress line to the terminal (indented per the CLI style guide).
+    Routes through the live region as a scrollback note when one is active."""
+    line = f"  {msg}"
+    if _board is not None:
+        _board.note(line)
+    else:
+        print(line, flush=True)
+
+
+def _settle(sha: str, line: str) -> None:
+    """Print a document's terminal line (OK / ✗), clearing its in-flight live row if present."""
+    if _board is not None:
+        _board.finish(sha, line)
+    else:
+        print(line, flush=True)
 DEFAULT_CLASSIFY_PAGES = 5
 # Per-section input budget when falling back to sectioning after a whole-doc extraction
 # overruns the output ceiling. Small, so each section's output stays well under the cap;
@@ -270,7 +290,7 @@ def _fail(vault: Path, sha: str, filename: str, reason: str) -> dict:
     # Resolve the filename (the catch-all path has only the sha) *before* abort.run moves
     # the queue file, so the ✗ line and log name the file instead of a bare sha.
     name = filename or _queued_filename(vault, sha) or sha[:7]
-    _say(f"{_YELLOW}✗{_RESET}  {name}  {_DIM}{reason}{_RESET}")
+    _settle(sha, f"  {_YELLOW}✗{_RESET}  {name}  {_DIM}{reason}{_RESET}")
     _log(vault, f"FAILED {name}: {reason}")
     abort.run(vault, sha)   # removes staging/section temp, moves the queue file to _failed/
     return {"sha256": sha, "filename": filename or name, "status": "failed", "reason": reason}
@@ -290,27 +310,43 @@ async def _extract_document(vault: Path, sha: str, brief: str | None,
     filename = pf["filename"]
     pages = pf.get("pages", [])
     page_count = pf.get("page_count") or len(pages)
+    pg = f"{page_count}p"
+
+    def _step(tty: str, plain: str) -> None:
+        """Mutate this document's single in-flight live row (TTY); append the plain transition
+        line when there's no live region (non-TTY) — keeping logged output unchanged."""
+        if _board is not None:
+            _board.update(sha, f"  {tty}", f"  {plain}")
+        else:
+            _say(plain)
+
     if pinned_skill:
         # Skill pinned for the whole run (a resolved skill-file path) — skip classification.
         skill_text = Path(pinned_skill).read_text(encoding="utf-8")
         skill_label = Path(pinned_skill).stem
     else:
-        _say(f"{_DIM}→  {filename}  classifying ({page_count} page{'s' if page_count != 1 else ''})…{_RESET}")
+        _step(f"{_DIM}→  {filename}  {pg} · classifying…{_RESET}",
+              f"{_DIM}→  {filename}  classifying ({page_count} page{'s' if page_count != 1 else ''})…{_RESET}")
         # Classify on the first N pages (page-aware, not a mid-page char cut); the char cap is a guard.
         excerpt = _pages_text(pages[:max(1, classify_pages)])[:_CLASSIFY_EXCERPT_CHARS]
         skill = await _classify(excerpt, classify_model)
         skill_text = skills_catalog.read_skill(skill)
         skill_label = skill.removesuffix(".md")
-        _say(f"{_DIM}·  {filename}  classified ·{_RESET} {_CYAN}{skill_label}{_RESET}")
+        _step(f"{_DIM}→  {filename}  {pg} · {skill_label}{_RESET}",
+              f"{_DIM}·  {filename}  classified ·{_RESET} {_CYAN}{skill_label}{_RESET}")
+
+    flow = f"{pg} · {skill_label}"        # the accumulated in-flight prefix for this document's row
 
     plan = section.run(vault, sha)
     if plan.get("sectioned"):
         n_sections = len(plan.get("sections", []))
-        _say(f"{_DIM}→  {filename}  extracting · {n_sections} sections…{_RESET}")
+        _step(f"{_DIM}→  {filename}  {flow} · extracting · {n_sections} sections…{_RESET}",
+              f"{_DIM}→  {filename}  extracting · {n_sections} sections…{_RESET}")
         extraction, scratchpad, cost, ok, errors = await _extract_sectioned(
             vault, sha, pf, skill_text, plan, extract_model, skill_label)
     else:
-        _say(f"{_DIM}→  {filename}  extracting…{_RESET}")
+        _step(f"{_DIM}→  {filename}  {flow} · extracting…{_RESET}",
+              f"{_DIM}→  {filename}  extracting…{_RESET}")
         extraction, scratchpad, cost, ok, errors = await _simple_extract(
             vault, sha, pf, skill_text, brief, extract_model, skill_label)
         # Whole-document extraction can overrun the model's output ceiling on entity-dense
@@ -320,8 +356,9 @@ async def _extract_document(vault: Path, sha: str, brief: str | None,
             fb = section.run(vault, sha, force_budget=_FALLBACK_SECTION_TOKENS)
             if fb.get("sectioned"):
                 n_sections = len(fb.get("sections", []))
-                _say(f"{_DIM}↻  {filename}  whole-doc extraction rejected — "
-                     f"re-extracting in {n_sections} sections…{_RESET}")
+                _step(f"{_DIM}↻  {filename}  {flow} · re-extracting in {n_sections} sections…{_RESET}",
+                      f"{_DIM}↻  {filename}  whole-doc extraction rejected — "
+                      f"re-extracting in {n_sections} sections…{_RESET}")
                 whole_cost = cost
                 extraction, scratchpad, cost, ok, errors = await _extract_sectioned(
                     vault, sha, pf, skill_text, fb, extract_model, skill_label)
@@ -336,8 +373,9 @@ async def _extract_document(vault: Path, sha: str, brief: str | None,
         stale.unlink(missing_ok=True)
     (vault / ".watchdog" / "queue" / f"{sha}.json").unlink(missing_ok=True)
     n_entities = len(extraction.get("entities", []))
-    _say(f"{_GREEN}OK{_RESET}  {filename}  {_DIM}{n_entities} entit{'ies' if n_entities != 1 else 'y'}{_RESET}  "
-         f"{_CYAN}documents/{_doc_slug(filename)}{_RESET}")
+    _settle(sha, f"  {_GREEN}OK{_RESET}  {filename}  "
+            f"{_DIM}{n_entities} entit{'ies' if n_entities != 1 else 'y'}{_RESET}  "
+            f"{_CYAN}documents/{_doc_slug(filename)}{_RESET}")
     _log(vault, f"OK {filename}: {n_entities} entities")
     warn = _coverage_warning(extraction, page_count)
     if warn:
@@ -566,6 +604,11 @@ async def run(vault: Path, *, concurrency: int = DEFAULT_CONCURRENCY,
         return {"results": [], "extracted": 0, "skipped": 0, "failed": 0}
 
     brief = _read_brief(vault)
+    # Live status region for the concurrent extraction phase (#151): one in-place row per
+    # in-flight document, finished/failed lines scrolling above. Auto-disables off a TTY,
+    # where it degrades to the previous append-only output.
+    global _board
+    _board = LiveRegion()
     sem = asyncio.Semaphore(max(1, concurrency))
     cancelled = asyncio.Event()
     stop_reason: dict = {}          # {"rate_limit": "<notice>"} when a limit stopped the batch
@@ -627,6 +670,10 @@ async def run(vault: Path, *, concurrency: int = DEFAULT_CONCURRENCY,
     finally:
         if handler_set:
             loop.remove_signal_handler(signal.SIGINT)
+        # Close the live region: extraction is done, so post-processing (sequential) and the
+        # summary print plainly. _say falls back to plain printing once _board is None.
+        _board.stop()
+        _board = None
 
     results = [t.result() for t in tasks if t.done() and not t.cancelled()]
     by_status = lambda s: sum(1 for r in results if r.get("status") == s)

--- a/tests/test_live.py
+++ b/tests/test_live.py
@@ -1,0 +1,113 @@
+"""LiveRegion: in-place TTY status rows with append-only non-TTY fallback (#151)."""
+
+import io
+
+from watchdog.cmd.live import LiveRegion, _truncate
+
+
+class _Stream(io.StringIO):
+    """StringIO that can claim to be (or not be) a TTY."""
+    def __init__(self, tty: bool):
+        super().__init__()
+        self._tty = tty
+    def isatty(self) -> bool:
+        return self._tty
+
+
+# ── _truncate ──────────────────────────────────────────────────────────────────
+
+def test_truncate_keeps_short_line_unchanged():
+    assert _truncate("hello", 80) == "hello"
+
+
+def test_truncate_clips_to_visible_width_with_ellipsis():
+    out = _truncate("abcdefghij", 5)
+    # width-1 visible chars, then ellipsis + reset
+    assert out == "abcd…\x1b[0m"
+
+
+def test_truncate_ignores_ansi_in_width_then_resets():
+    colored = "\x1b[2mabcdefghij\x1b[0m"
+    out = _truncate(colored, 5)
+    assert out.startswith("\x1b[2m")          # opening code preserved
+    assert "abcd" in out and "efgh" not in out  # only 4 visible chars kept
+    assert out.endswith("\x1b[0m")
+
+
+# ── non-TTY fallback ─────────────────────────────────────────────────────────────
+
+def test_non_tty_appends_every_call_without_escapes():
+    s = _Stream(tty=False)
+    r = LiveRegion(s, enabled=None)
+    assert r.enabled is False
+    r.update("a", "  row-A-tty", "  classifying A")
+    r.update("a", "  row-A-tty2", "  classified A")
+    r.finish("a", "  OK A")
+    r.note("  a note")
+    out = s.getvalue()
+    assert "\x1b[" not in out                  # no cursor escapes off a TTY
+    assert out.splitlines() == ["  classifying A", "  classified A", "  OK A", "  a note"]
+
+
+def test_non_tty_update_uses_tty_line_when_no_plain_given():
+    s = _Stream(tty=False)
+    r = LiveRegion(s, enabled=False)
+    r.update("a", "  only-line")
+    assert s.getvalue() == "  only-line\n"
+
+
+# ── TTY in-place behavior ────────────────────────────────────────────────────────
+
+def test_tty_first_update_writes_row_no_clear():
+    s = _Stream(tty=True)
+    r = LiveRegion(s, enabled=True)
+    r.update("a", "row-A", "plain-A")
+    out = s.getvalue()
+    assert "row-A" in out
+    assert "plain-A" not in out                # plain line is the non-TTY form only
+    assert "\x1b[" not in out.split("row-A")[0]  # nothing to clear on the first draw
+
+
+def test_tty_second_update_redraws_in_place():
+    s = _Stream(tty=True)
+    r = LiveRegion(s, enabled=True)
+    r.update("a", "row-A1")
+    r.update("a", "row-A2")
+    out = s.getvalue()
+    assert "\x1b[1A\x1b[J" in out              # moved up 1 line and cleared before redraw
+    assert out.rstrip().endswith("row-A2")
+
+
+def test_tty_finish_emits_permanent_line_and_drops_row():
+    s = _Stream(tty=True)
+    r = LiveRegion(s, enabled=True)
+    r.update("a", "row-A")
+    r.update("b", "row-B")
+    r.finish("a", "OK A")
+    out = s.getvalue()
+    assert "OK A" in out
+    assert "a" not in r._rows and "b" in r._rows  # only b remains live
+    # after finishing, the live region should re-render just the surviving row
+    assert out.rstrip().endswith("row-B")
+
+
+def test_tty_note_prints_above_region():
+    s = _Stream(tty=True)
+    r = LiveRegion(s, enabled=True)
+    r.update("a", "row-A")
+    r.note("a scrollback note")
+    out = s.getvalue()
+    assert "a scrollback note" in out
+    assert out.rstrip().endswith("row-A")      # region re-rendered below the note
+    assert r._rendered == 1
+
+
+def test_tty_truncates_rows_to_terminal_width(monkeypatch):
+    monkeypatch.setattr("watchdog.cmd.live.shutil.get_terminal_size",
+                        lambda fallback=(80, 24): __import__("os").terminal_size((10, 24)))
+    s = _Stream(tty=True)
+    r = LiveRegion(s, enabled=True)
+    r.update("a", "0123456789ABCDEF")
+    out = s.getvalue()
+    assert "…\x1b[0m" in out                    # row was clipped to width
+    assert "ABCDEF" not in out


### PR DESCRIPTION
Closes #151.

## What

Replaces the append-only, interleaved per-transition log during parallel extraction with a **live status region**: one in-place row per in-flight document that mutates through its lifecycle (`classifying → classified · <skill> → extracting…`), while finished/failed lines and notes scroll up into the permanent scrollback above. Plus an up-front warning that large documents can take several minutes each.

## How

- **`cmd/live.py`** — a small, reusable `LiveRegion` renderer on a handful of ANSI cursor escapes. No TUI dependency: it matches the app's existing hand-rolled palette and CLI style guide, and is reusable by any long-running command (chew, etc.). ANSI-aware width truncation keeps each live row to one physical line so the cursor-up redraw math stays correct.
- **Non-TTY fallback** — off a TTY (CI, piped, `tee`) it degrades to the previous append-only output, unchanged.
- **`orchestrate`** — per-document transitions drive `LiveRegion` rows via a module `_board` created for the extraction phase and torn down before the sequential post-processing + summary (which print plainly). `_say`/`_settle` route through it.
- **`ingest`** — the timing warning near the existing "Extracting (≤N parallel)" block.

## Acceptance (from the issue)

- [x] Interactive TTY run shows one live, in-place row per in-flight document; completed docs scroll into static scrollback.
- [x] Non-TTY run is unchanged (append-only), suitable for logs/CI.
- [x] Opening block warns that large documents can take several minutes each.

## Tests

`tests/test_live.py` covers width truncation (ANSI-aware), the non-TTY append fallback, and the in-place redraw / finish / note behavior. Full suite green (561 passed). Verified the real redraw via a PTY smoke test.

## Docs

`INSTALL.md` ingest walkthrough updated to describe the live rows + timing note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)