### PR TITLE
Bare `watchdog` guides the next sensible step: context → chew → ingest

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,8 @@ watchdog obsidian shell-company-investigation
 1. Drop background files (clips, notes, screenshots) into `_CONTEXT/`
 2. Run `watchdog context` from inside the vault — opens Claude Code with the context skill pre-loaded, which reads the material, asks you questions, and writes `context.md`
 
+Running `watchdog` with no arguments from inside a vault walks you through whatever's next — seed context, chew `_INCOMING/`, then ingest — offering each step that has pending work.
+
 For a full end-to-end walkthrough of a first investigation, see [GETTING_STARTED.md](GETTING_STARTED.md).
 
 ---
@@ -212,6 +214,7 @@ For a full end-to-end walkthrough of a first investigation, see [GETTING_STARTED
 | `watchdog ingest --skill [NAME\|PATH]` | Pin a record skill (a name or a path to a skill file) for every document, skipping classification. `--skill` with no value picks from the list |
 | `watchdog finalize` | Complete post-ingest (entity synthesis + timeline + briefing) for an already-extracted batch — run it if a rate limit or interrupt stopped post-processing before it finished. `--finalizer-model M` overrides the model |
 | `watchdog requeue` | Move documents quarantined in `queue/_failed/` back into the active queue, then re-run `watchdog ingest` to retry them |
+| `watchdog` | With no arguments inside a vault: walk the pipeline — offer to seed context, chew `_INCOMING/`, then ingest — skipping any stage with no pending work |
 | `watchdog context [name]` | Open Claude Code with the context seeding skill; omit name when inside the vault |
 | `watchdog context --model M` | Override the model for context seeding (`sonnet`/`opus`/`haiku`, default: `sonnet`) |
 | `watchdog watch [name]` | Watch `_INCOMING/` and chew files automatically as they arrive; omit name when inside the project directory |

--- a/src/watchdog/cli.py
+++ b/src/watchdog/cli.py
@@ -62,6 +62,7 @@ from watchdog.cmd.ingest import (
     cmd_chew,
     cmd_context,
     cmd_finalize,
+    cmd_guided,
     cmd_ingest,
     cmd_postflight,
     cmd_preflight,
@@ -352,7 +353,7 @@ def main() -> None:
         from pathlib import Path
         wddir = Path(".watchdog")
         if wddir.is_dir() and (wddir / "queue").is_dir():
-            _run_preprocess(Path(".").resolve(), confirm=True)
+            cmd_guided(args)
         else:
             _print_banner()
         return

--- a/src/watchdog/cmd/ingest.py
+++ b/src/watchdog/cmd/ingest.py
@@ -449,6 +449,47 @@ def cmd_context(args) -> None:
         print(f"\n  When ready, open Claude Code and run:  {_CYAN}/watchdog-context{_RESET}\n")
 
 
+def cmd_guided(args) -> None:
+    """Bare `watchdog` inside a project: walk the pipeline in order — context → chew → ingest —
+    offering each stage that has pending work and falling through to the next when declined (#132).
+
+    Each stage self-skips when its directory/queue is empty, so the flow always lands on the
+    sensible next step. Reuses the same prompt helpers as the individual commands for consistency.
+    """
+    from watchdog.pipeline.preprocess_batch import find_files
+    vault = Path(".").resolve()
+    did_offer = False
+
+    # 1. Context — when _CONTEXT/ has files and context.md hasn't been seeded yet. (Re-seeding an
+    #    existing context.md stays the explicit `watchdog context`; the guided flow won't nag.)
+    #    cmd_context offers to open Claude Code; accepting replaces this process (os.execvp), so
+    #    the walk ends there — seed context, then re-run `watchdog` for chew/ingest. Declining
+    #    returns here and falls through to chew below.
+    context_dir = vault / "_CONTEXT"
+    context_files = find_files([context_dir]) if context_dir.is_dir() else []
+    if context_files and not (vault / "context.md").exists():
+        did_offer = True
+        cmd_context(args)
+
+    # 2. Chew — when _INCOMING/ has files. _run_preprocess prompts and chews; the ingest offer
+    #    below then picks up whatever it queued.
+    incoming = vault / "_INCOMING"
+    if incoming.is_dir() and find_files([incoming]):
+        did_offer = True
+        _run_preprocess(vault, confirm=True, show_ingest_hint=False)
+
+    # 3. Ingest — when the queue has documents ready.
+    if _count_queued(vault):
+        did_offer = True
+        _offer_ingest(args, vault)
+        return
+
+    if not did_offer:
+        print(f"\n  {_DIM}Nothing pending — drop files in {_RESET}{_CYAN}_INCOMING/{_RESET}{_DIM} "
+              f"then run {_RESET}{_CYAN}watchdog{_RESET}{_DIM}, or {_RESET}{_CYAN}watchdog status{_RESET}"
+              f"{_DIM} for details.{_RESET}\n")
+
+
 def cmd_queue_status(args) -> None:
     cwd = Path(".").resolve()
     if (cwd / ".watchdog").is_dir():

--- a/tests/test_guided.py
+++ b/tests/test_guided.py
@@ -1,0 +1,77 @@
+"""Bare `watchdog` guided driver (#132): offer context → chew → ingest by pending state."""
+
+import argparse
+
+import pytest
+
+import watchdog.cmd.ingest as ing
+
+
+@pytest.fixture
+def vault(tmp_path, monkeypatch):
+    """A minimal vault with the dirs the guided driver inspects, set as cwd."""
+    v = tmp_path / "probe"
+    (v / ".watchdog" / "queue").mkdir(parents=True)
+    (v / "_CONTEXT").mkdir()
+    (v / "_INCOMING").mkdir()
+    monkeypatch.chdir(v)
+    monkeypatch.setattr(ing, "load_projects", lambda: {})
+    return v
+
+
+@pytest.fixture
+def spies(monkeypatch):
+    """Replace the three stage helpers with call recorders. (cmd_context offers the Claude
+    Code launch for the context stage; declining there returns and falls through to chew.)"""
+    calls = []
+    monkeypatch.setattr(ing, "cmd_context",
+                        lambda *a, **k: calls.append("context"))
+    monkeypatch.setattr(ing, "_run_preprocess",
+                        lambda *a, **k: calls.append("chew"))
+    monkeypatch.setattr(ing, "_offer_ingest",
+                        lambda *a, **k: calls.append("ingest"))
+    return calls
+
+
+def _queue(v, n=1):
+    for i in range(n):
+        (v / ".watchdog" / "queue" / f"{i:064d}.json").write_text("{}")
+
+
+def test_nothing_pending_offers_nothing(vault, spies, capsys):
+    ing.cmd_guided(argparse.Namespace())
+    assert spies == []
+    assert "Nothing pending" in capsys.readouterr().out
+
+
+def test_context_offered_when_context_dir_has_files_and_no_context_md(vault, spies):
+    (vault / "_CONTEXT" / "prior-story.txt").write_text("x")
+    ing.cmd_guided(argparse.Namespace())
+    assert spies == ["context"]
+
+
+def test_context_skipped_when_context_md_already_exists(vault, spies):
+    (vault / "_CONTEXT" / "prior-story.txt").write_text("x")
+    (vault / "context.md").write_text("# seeded")
+    ing.cmd_guided(argparse.Namespace())
+    assert "context" not in spies
+
+
+def test_chew_offered_when_incoming_has_files(vault, spies):
+    (vault / "_INCOMING" / "doc.pdf").write_text("x")
+    ing.cmd_guided(argparse.Namespace())
+    assert spies == ["chew"]
+
+
+def test_ingest_offered_when_queue_non_empty(vault, spies):
+    _queue(vault)
+    ing.cmd_guided(argparse.Namespace())
+    assert spies == ["ingest"]
+
+
+def test_full_pipeline_offers_all_stages_in_order(vault, spies):
+    (vault / "_CONTEXT" / "prior.txt").write_text("x")
+    (vault / "_INCOMING" / "doc.pdf").write_text("x")
+    _queue(vault)
+    ing.cmd_guided(argparse.Namespace())
+    assert spies == ["context", "chew", "ingest"]


### PR DESCRIPTION
Closes #132.

## What

Running `watchdog` with no arguments from inside a project now acts as a "do whatever makes sense next" driver, walking the pipeline in order and offering each stage that has pending work — falling through to the next when declined.

## The gap it closes

The bare command called `_run_preprocess(…, confirm=True)` directly, so after a chew it dropped back to the shell with only a `watchdog ingest` hint — it never offered ingest interactively. That `_offer_ingest` follow-up had only landed on `watchdog chew`. There was also no context step in the bare path.

## How

New `cmd_guided` driver:

1. **Context** — when `_CONTEXT/` has files and `context.md` isn't seeded yet, offer to seed it. Delegates to `cmd_context`, which opens Claude Code for the (adaptive) interview; accepting replaces the process via `os.execvp`, so the walk ends there — seed context, then re-run `watchdog` for chew/ingest. Declining falls through to chew. (Re-seeding an existing `context.md` stays the explicit `watchdog context` — the guided flow won't nag.)
2. **Chew** — when `_INCOMING/` has files, offer to chew them.
3. **Ingest** — when the queue has documents ready, offer to ingest.

Each stage guards on its directory/queue state so empty stages self-skip, and it reuses the existing prompt helpers (`_run_preprocess`, `_offer_ingest`, `cmd_context`) so wording and colour stay consistent with the CLI style guide.

> Note: companion issue #133 (abstracting context seeding into a Python function) was intentionally **not** taken — we're keeping the adaptive Claude Code interview for context seeding, so the guided flow's context stage hands off to it rather than a Python step.

## Tests

`tests/test_guided.py` covers stage selection by pending state and the `context.md` gate. Full suite green (557 passed).

## Docs

`README.md` documents the bare-command flow (a new row in the commands table + a note in the quick start).

🤖 Generated with [Claude Code](https://claude.com/claude-code)