### PR TITLE
Coverage warning: plain-language wording with an actionable page range

### DIFF
--- a/src/watchdog/pipeline/orchestrate.py
+++ b/src/watchdog/pipeline/orchestrate.py
@@ -163,8 +163,9 @@ def _coverage_warning(extraction: dict, page_count: int | None) -> str | None:
     max_cited = cited[-1]
     if max_cited >= page_count * _COVERAGE_TAIL_FRACTION:
         return None
-    return (f"facts cite pages {cited[0]}–{max_cited} of {page_count} "
-            f"({len(cited)} distinct); nothing past page {max_cited} — possible skim, review")
+    return (f"facts were only extracted from pages {cited[0]}–{max_cited} of {page_count} — the "
+            f"model may have stopped reading early; check pages {max_cited + 1}–{page_count} "
+            f"of the source for anything missed")
 
 
 def _compact_result(sha: str, filename: str, extraction: dict, near_dup: dict, cost: float | None) -> dict:

--- a/tests/test_orchestrate.py
+++ b/tests/test_orchestrate.py
@@ -67,7 +67,8 @@ def _ext_with_fact_pages(pages):
 def test_coverage_warning_flags_front_loaded_extraction():
     # 36-page doc, facts only on pages 1-4 → nothing past page 4 (< 18) → warn
     warn = orchestrate._coverage_warning(_ext_with_fact_pages([1, 2, 3, 4]), 36)
-    assert warn and "possible skim" in warn and "of 36" in warn
+    assert warn and "may have stopped reading early" in warn and "of 36" in warn
+    assert "check pages 5–36" in warn        # actionable range = first uncited page → end
 
 
 def test_coverage_warning_silent_when_well_covered():


### PR DESCRIPTION
## What

Rewords the advisory page-coverage warning (D32) so it reads in plain, blunt language and tells the reporter what to do.

**Before:**
> facts cite pages 2–14 of 36 (13 distinct); nothing past page 14 — possible skim, review

**After:**
> facts were only extracted from pages 2–14 of 36 — the model may have stopped reading early; check pages 15–36 of the source for anything missed

## Why

"possible skim" is jargon — it assumes the reader knows the term and doesn't say what the signal means or what to do. The new wording names what likely happened (the model may have stopped reading early) and gives an **actionable range** (`check pages <first-uncited>–<end>`).

## Scope

Behavior is unchanged — same heuristic, same threshold, still advisory (it emits a warning, never fails extraction). Only the user-facing string changes. `tests/test_orchestrate.py` updated to assert the new wording (incl. the computed page range).

🤖 Generated with [Claude Code](https://claude.com/claude-code)