### PR TITLE
Adopt the live status region in `watchdog chew` (and `watch`)

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -123,7 +123,7 @@ Chewing does the mechanical preprocessing work that runs outside Claude Code:
 
 Each file produces a `.json` file in `.watchdog/queue/` containing the extracted text and metadata. The original file moves to `.watchdog/staging/`. Nothing is written to the Obsidian vault yet.
 
-You'll see a progress bar as each file is processed. Each file shows one of three statuses: `OK` (queued for extraction), `SKP` (no text found — moved to `_INCOMING/_SKIPPED/`), or `ERR` (failed — moved to `_INCOMING/_FAILED/`). Files with noisy OCR output show a `· garbled OCR` note alongside `OK` — they're still queued, but worth verifying after extraction. On macOS, you'll receive a notification when the batch completes.
+Files are processed in parallel, each shown as a live status row while it's worked on, with an overall progress row beneath; finished files settle into the log above. Each settled file shows one of three statuses: `OK` (queued for extraction), `SKP` (no text found — moved to `_INCOMING/_SKIPPED/`), or `ERR` (failed — moved to `_INCOMING/_FAILED/`). Files with noisy OCR output show a `· garbled OCR` note alongside `OK` — they're still queued, but worth verifying after extraction. On macOS, you'll receive a notification when the batch completes.
 
 If a file fails (password-protected, corrupted, unsupported format), it moves to `_INCOMING/_FAILED/` with an error message. Fix the issue and move the file back to `_INCOMING/` to retry.
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -163,7 +163,7 @@ cd ~/Investigations/shell-company-investigation
 watchdog chew
 ```
 
-You'll see a progress bar as Watchdog reads each file, runs OCR if needed, and prepares it for extraction. Each file shows its status: `OK` (queued), `SKP` (no text found — moved to `_INCOMING/_SKIPPED/`), or `ERR` (failed — moved to `_INCOMING/_FAILED/` with an explanation). Files where OCR produced noisy output show a `· garbled OCR` note but are still queued for Claude to interpret.
+Watchdog reads the files in parallel, showing one live status row per file as it's read, OCR'd if needed, and prepared for extraction, with an overall progress row beneath; finished files settle into the log above. Each settled file shows its status: `OK` (queued), `SKP` (no text found — moved to `_INCOMING/_SKIPPED/`), or `ERR` (failed — moved to `_INCOMING/_FAILED/` with an explanation). Files where OCR produced noisy output show a `· garbled OCR` note but are still queued for Claude to interpret.
 
 On macOS, you'll receive a notification when chewing completes — useful if you've switched to another app. When it finishes, Watchdog asks `Ingest now? [Y/n]` — press Enter to extract the queued documents right away (it runs in your terminal, no Claude Code session needed). Decline and it prints the `watchdog ingest` command to run later.
 

--- a/src/watchdog/cmd/live.py
+++ b/src/watchdog/cmd/live.py
@@ -16,6 +16,7 @@ truncates live rows to the terminal width so the redraw math stays one physical 
 import re
 import shutil
 import sys
+import threading
 
 _ANSI = re.compile(r"\033\[[0-9;]*m")
 _RESET = "\033[0m"
@@ -46,7 +47,12 @@ def _truncate(line: str, width: int) -> str:
 
 
 class LiveRegion:
-    """A redraw-in-place region of keyed rows with a scrollback of finished lines above it."""
+    """A redraw-in-place region of keyed rows with a scrollback of finished lines above it.
+
+    Thread-safe: a single internal lock serialises every public call, so concurrent workers
+    (e.g. chew's ThreadPoolExecutor, #158) can drive one region without interleaved redraws or
+    torn output lines. Single-threaded callers (ingest's asyncio loop) pay only an uncontended
+    lock acquire per call."""
 
     def __init__(self, stream=None, *, enabled: bool | None = None):
         self.stream = stream if stream is not None else sys.stdout
@@ -54,42 +60,47 @@ class LiveRegion:
         self._rows: dict[str, str] = {}
         self._order: list[str] = []
         self._rendered = 0          # live rows currently drawn (== physical lines, post-truncation)
+        self._lock = threading.Lock()
 
     # ── public API ────────────────────────────────────────────────────────────
 
     def update(self, key: str, tty_line: str, plain_line: str | None = None) -> None:
         """Add or mutate the in-flight row for `key`. Non-TTY prints `plain_line` (or `tty_line`)."""
-        if not self.enabled:
-            self._print(plain_line if plain_line is not None else tty_line)
-            return
-        if key not in self._rows:
-            self._order.append(key)
-        self._rows[key] = tty_line
-        self._render()
+        with self._lock:
+            if not self.enabled:
+                self._print(plain_line if plain_line is not None else tty_line)
+                return
+            if key not in self._rows:
+                self._order.append(key)
+            self._rows[key] = tty_line
+            self._render()
 
     def finish(self, key: str, line: str) -> None:
         """Settle `key`: print `line` permanently above the region and drop its live row."""
-        if not self.enabled:
-            self._print(line)
-            return
-        self._emit_above(line)
-        if key in self._rows:
-            self._order.remove(key)
-            del self._rows[key]
-        self._render()
+        with self._lock:
+            if not self.enabled:
+                self._print(line)
+                return
+            self._emit_above(line)
+            if key in self._rows:
+                self._order.remove(key)
+                del self._rows[key]
+            self._render()
 
     def note(self, line: str) -> None:
         """Print a permanent line above the live region (a log entry not tied to a row)."""
-        if not self.enabled:
-            self._print(line)
-            return
-        self._emit_above(line)
-        self._render()
+        with self._lock:
+            if not self.enabled:
+                self._print(line)
+                return
+            self._emit_above(line)
+            self._render()
 
     def stop(self) -> None:
         """Leave the final region on screen and flush. Call once when work is done."""
-        if self.enabled:
-            self.stream.flush()
+        with self._lock:
+            if self.enabled:
+                self.stream.flush()
 
     # ── rendering ─────────────────────────────────────────────────────────────
 

--- a/src/watchdog/pipeline/preprocess_batch.py
+++ b/src/watchdog/pipeline/preprocess_batch.py
@@ -15,9 +15,13 @@ import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 
+from watchdog.cmd.live import LiveRegion
 from watchdog.pipeline.preprocess import _perf_cpu_count, sha256_file
 
 DEFAULT_FILE_TIMEOUT = 600
+
+# Key for the persistent progress/ETA row that sits above the in-flight file rows (#158).
+_PROGRESS_KEY = "__progress__"
 
 
 def _compute_near_dup(result: dict, vault: Path) -> dict:
@@ -352,17 +356,43 @@ def _run_ingest_inner(
         f"  {_DIM}({pre_workers} file · {chunk_workers} chunk workers{adaptive_tag}){_RESET}\n"
     )
 
-    sys.stdout.write(f"  {_DIM}Starting workers — first output may take a few seconds…{_RESET}")
-    sys.stdout.flush()
+    # Live status region (#158): one in-place row per in-flight file, finished/failed lines and
+    # notes scrolling above, plus a persistent progress/ETA row on top. Off a TTY it disables and
+    # only the finished lines + summary print (append-only), matching the previous logged output.
+    live = LiveRegion()
+
+    def _rel(path: Path) -> str:
+        try:
+            return str(path.relative_to(incoming))
+        except ValueError:
+            return path.name
+
+    def _refresh_progress(done: int) -> None:
+        if not live.enabled:
+            return
+        elapsed_wall = time.time() - batch_start
+        bar = _bar(done, total)
+        if done < total and done and elapsed_wall > 0:
+            tail = f"  {_DIM}{_fmt_eta(round((elapsed_wall / done) * (total - done)))}{_RESET}"
+        elif done == total:
+            tail = f"  {_DIM}{round(elapsed_wall)}s total{_RESET}"
+        else:
+            tail = ""
+        live.update(_PROGRESS_KEY, f"  {bar} {_BOLD}{done}/{total}{_RESET}{tail}")
+
+    def _chew(path: Path) -> dict:
+        # Runs in a worker thread: mark the file in-flight the moment a worker picks it up, so the
+        # row appears while OCR spins up. Gated to TTYs to keep non-TTY output to finished lines only.
+        if live.enabled:
+            live.update(str(path), f"  {_DIM}→  {_rel(path)}  chewing…{_RESET}")
+        return preprocess_one(path, str(vault), DEFAULT_FILE_TIMEOUT, chunk_workers)
 
     results: dict[str, dict] = {}
     _cancel_event.clear()
 
+    _refresh_progress(0)            # seed the progress row above any file rows
     pool = ThreadPoolExecutor(max_workers=pre_workers)
-    futures = {
-        pool.submit(preprocess_one, f, str(vault), DEFAULT_FILE_TIMEOUT, chunk_workers): f
-        for f in files
-    }
+    futures = {pool.submit(_chew, f): f for f in files}
     done = 0
     skipped = 0
     cancelled = False
@@ -375,7 +405,6 @@ def _run_ingest_inner(
             if done % 50 == 0:
                 _prune_empty_dirs(incoming)
 
-            elapsed_wall = time.time() - batch_start
             is_err     = "error" in result
             is_empty   = not is_err and result.get("char_count", 0) == 0
             is_garbled = not is_err and not is_empty and result.get("metadata", {}).get("garbled_detected", False)
@@ -386,32 +415,13 @@ def _run_ingest_inner(
             else:
                 status = f"{_GREEN}OK {_RESET}"
 
-            try:
-                rel = str(path.relative_to(incoming))
-            except ValueError:
-                rel = path.name
-
+            rel       = _rel(path)
             label     = _page_label(path, result.get("page_count", 0))
             label_str = f"  {_DIM}{label}{_RESET}" if label else ""
             garb_str  = f"  {_DIM}·  garbled OCR{_RESET}" if is_garbled else ""
 
-            # Progress bar + ETA
-            bar = _bar(done, total)
-            if done < total and elapsed_wall > 0:
-                eta       = round((elapsed_wall / done) * (total - done))
-                time_part = f"  {_DIM}{_fmt_eta(eta)}{_RESET}"
-            elif done == total:
-                time_part = f"  {_DIM}{round(elapsed_wall)}s total{_RESET}"
-            else:
-                time_part = ""
-
-            bar_display = f"{bar} {done}/{total}{time_part}          "
-
-            # Clear the bar line, print file result (scrolls), then re-print bar without newline
-            sys.stdout.write("\r\033[K")
-            print(f"  {status}  {_BOLD}{rel}{_RESET}{label_str}{garb_str}")
-            sys.stdout.write(f"  {bar_display}")
-            sys.stdout.flush()
+            # Settle this file's row: print its result above the live region, clearing the in-flight row.
+            live.finish(str(path), f"  {status}  {_BOLD}{rel}{_RESET}{label_str}{garb_str}")
 
             if is_err:
                 failed_dir = incoming / "_FAILED"
@@ -420,10 +430,7 @@ def _run_ingest_inner(
                     path.rename(failed_dir / path.name)
                 except OSError:
                     pass
-                sys.stdout.write("\r\033[K")
-                print(f"       {_YELLOW}→ _INCOMING/_FAILED/{_RESET}  {_DIM}{result['error'][:80]}{_RESET}")
-                sys.stdout.write(f"  {bar_display}")
-                sys.stdout.flush()
+                live.note(f"       {_YELLOW}→ _INCOMING/_FAILED/{_RESET}  {_DIM}{result['error'][:80]}{_RESET}")
             elif is_empty:
                 skipped += 1
                 skipped_dir = incoming / "_SKIPPED"
@@ -432,10 +439,7 @@ def _run_ingest_inner(
                     path.rename(skipped_dir / path.name)
                 except OSError:
                     pass
-                sys.stdout.write("\r\033[K")
-                print(f"       {_DIM}→ _INCOMING/_SKIPPED/  no text content extracted{_RESET}")
-                sys.stdout.write(f"  {bar_display}")
-                sys.stdout.flush()
+                live.note(f"       {_DIM}→ _INCOMING/_SKIPPED/  no text content extracted{_RESET}")
             else:
                 sha256 = result.get("sha256", "")
                 if sha256:
@@ -453,6 +457,8 @@ def _run_ingest_inner(
                         json.dumps(result, ensure_ascii=False)
                     )
 
+            _refresh_progress(done)
+
     except KeyboardInterrupt:
         cancelled = True
         _cancel_event.set()
@@ -460,14 +466,14 @@ def _run_ingest_inner(
             fut.cancel()
         pool.shutdown(wait=True, cancel_futures=True)
         _prune_empty_dirs(incoming)
-        sys.stdout.write("\r\033[K")
+        live.stop()
         print(f"\n  {_DIM}Cancelled — {done} of {total} files processed. Unfinished files remain in _INCOMING/.{_RESET}\n")
         return
     else:
         pool.shutdown(wait=False)
 
-    # Clear the progress bar before printing summary
-    sys.stdout.write("\r\033[K")
+    # Extraction phase done — leave the final region on screen and print the summary plainly.
+    live.stop()
 
     _prune_empty_dirs(incoming)
 

--- a/tests/test_live.py
+++ b/tests/test_live.py
@@ -1,6 +1,7 @@
 """LiveRegion: in-place TTY status rows with append-only non-TTY fallback (#151)."""
 
 import io
+import threading
 
 from watchdog.cmd.live import LiveRegion, _truncate
 
@@ -111,3 +112,30 @@ def test_tty_truncates_rows_to_terminal_width(monkeypatch):
     out = s.getvalue()
     assert "…\x1b[0m" in out                    # row was clipped to width
     assert "ABCDEF" not in out
+
+
+# ── thread-safety (#158) ─────────────────────────────────────────────────────────
+
+def test_concurrent_finishes_keep_every_line_intact():
+    """Many threads finishing rows at once must not interleave or drop any output line."""
+    s = _Stream(tty=True)
+    r = LiveRegion(s, enabled=True)
+    n = 50
+    start = threading.Barrier(n)
+
+    def worker(i):
+        key = f"k{i}"
+        r.update(key, f"row-{i}")
+        start.wait()                              # maximise contention on finish
+        r.finish(key, f"DONE-{i}")
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(n)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    out = s.getvalue()
+    for i in range(n):
+        assert f"DONE-{i}" in out                 # no finished line lost to a torn write
+    assert r._rows == {} and r._order == []       # every row settled, none orphaned

--- a/tests/test_preprocess_batch.py
+++ b/tests/test_preprocess_batch.py
@@ -1,11 +1,14 @@
 """Tests for preprocess_batch helpers (find_files + preprocess_one paths)."""
 
+import io
 import json
 import subprocess
 import sys
 from pathlib import Path
 
 import pytest
+
+from watchdog.cmd.live import LiveRegion
 
 from watchdog.pipeline.preprocess_batch import (
     find_files,
@@ -511,6 +514,34 @@ def test_garbled_doc_still_queued(tmp_path, monkeypatch, capsys):
     assert (queue / "gg00.json").exists()
     assert not (incoming / "_SKIPPED").exists()
     assert not (incoming / "_FAILED").exists()
+
+
+# ── live status region (#158) ───────────────────────────────────────────────────
+
+def test_tty_run_shows_inflight_row_and_progress(tmp_path, monkeypatch):
+    """On a TTY the batch draws an in-flight 'chewing…' row per file plus a progress/ETA row,
+    and the file's result scrolls above when it settles."""
+    vault, incoming, queue, staging = _make_vault(tmp_path)
+    f = incoming / "report.pdf"
+    f.write_bytes(b"")
+
+    monkeypatch.setattr(ppb, "preprocess_one", lambda path, *a, **kw: {
+        "sha256": "feed01", "pages": [{"markdown": "hi"}], "char_count": 2,
+        "page_count": 1, "source_path": str(path),
+    })
+
+    buf = io.StringIO()
+    # Inject a TTY-enabled region over a capture buffer (the test process is not a real TTY).
+    monkeypatch.setattr(ppb, "LiveRegion", lambda *a, **kw: LiveRegion(buf, enabled=True))
+
+    _run_ingest_inner(vault, incoming, queue, staging, workers=1, chunk_workers=None, files=[f])
+
+    out = buf.getvalue()
+    assert "chewing…" in out              # in-flight row appeared while the worker ran
+    assert "report.pdf" in out            # settled result line scrolled above
+    assert "1/1" in out                   # progress row rendered
+    assert "\x1b[" in out                 # cursor escapes used (TTY path, not append-only)
+    assert (queue / "feed01.json").exists()
 
 
 def test_skipped_subdir_excluded_from_find_files(tmp_path):


### PR DESCRIPTION
Closes #158 (chew + watch sites).

## What

Replaces `watchdog chew`'s single carriage-return progress bar with the reusable `LiveRegion` from #156:

- one in-place row per in-flight file (`→ file  chewing…`),
- a persistent progress/ETA row above them,
- finished/failed results scroll into the scrollback above as each file settles.

`watchdog watch` inherits this for free — it drives the same `run_ingest` batch path, so each detection's chew now renders through the live region with no extra wiring.

## Thread-safety

`LiveRegion` gains an internal `threading.Lock`, since chew runs files on a `ThreadPoolExecutor` (worker threads mark a file in-flight; the main thread settles it). Single-threaded callers (ingest's asyncio loop) only pay an uncontended acquire. The issue flagged this as the main new consideration; an internal lock keeps the abstraction self-contained and reusable.

## Non-TTY fallback

Off a TTY the region stays append-only — only the finished lines + summary print — so CI/piped/`tee` logs keep the prior output. The in-flight rows and the progress row are gated on `live.enabled`.

## Tests

- a contended 50-thread `LiveRegion` finish test (no torn writes, no orphaned rows),
- a TTY chew-batch test asserting in-flight rows + progress + scrollback + cursor escapes.

Docs (INSTALL.md, GETTING_STARTED.md) updated to describe the live rows instead of the old progress bar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)