### PR TITLE
Upgrade index.md dashboard queries; document the Dataview requirement

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -243,6 +243,9 @@ The vault now contains:
 - **`hot.md`** — a current-state summary of the investigation, rewritten after every ingest
 - **`log.md`** — a running record of every ingest session
 - **`watchlist.md`** — terms to watch for in new documents; matches are written to `briefings/alerts-<date>.md`
+- **`index.md`** — a dashboard of live tables (most-mentioned entities, recent documents, people, companies, possible duplicates) that refresh as you ingest
+
+The `index.md` dashboard is built on Obsidian's **Dataview** community plugin, so you have to add it once per vault: open **Settings → Community plugins**, turn on community plugins (a new vault starts in restricted mode), then **Browse → Dataview → Install → Enable**. Until you do, `index.md` shows the raw query blocks rather than rendered tables.
 
 Each entity note has the same structure:
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -144,6 +144,8 @@ watchdog obsidian shell-company-investigation
 
 You can also run `watchdog obsidian` with no arguments from inside the vault directory. If Obsidian opens and the vault isn't visible, go to **Open folder as vault** in Obsidian, navigate to the investigation folder, and click Open. Once you've done that once, `watchdog obsidian` will open it directly in future.
 
+**Optional — turn on the dashboard.** The vault's `index.md` is a dashboard of live tables (most-mentioned entities, recent documents, possible duplicates) powered by Obsidian's **Dataview** plugin. To make it render, go to **Settings → Community plugins** in the vault, turn on community plugins (a new vault starts in restricted mode), then **Browse → Dataview → Install → Enable**. Until then, `index.md` shows raw query blocks instead of tables.
+
 For a complete walkthrough of a first investigation from start to finish, see [GETTING_STARTED.md](GETTING_STARTED.md).
 
 ---

--- a/README.md
+++ b/README.md
@@ -304,8 +304,10 @@ my-investigation/
 ├── log.md                 ← Append-only human-readable ingest history
 ├── context.md             ← Your investigation intent and key questions
 ├── watchlist.md           ← Terms to watch for in new documents (one per line)
-└── index.md               ← Dataview index
+└── index.md               ← Dashboard of live tables (requires the Dataview plugin — see below)
 ```
+
+`index.md` is a dashboard of live tables — most-mentioned entities, recent documents, people, companies, and possible duplicates — that refresh as you ingest. The tables are [Dataview](https://github.com/blacksmithgu/obsidian-dataview) queries, so they only render if you install and enable Obsidian's **Dataview** community plugin: in the vault, go to **Settings → Community plugins**, turn on community plugins (a fresh vault starts in restricted mode), then **Browse → Dataview → Install → Enable**. Without the plugin you'll just see the raw query blocks.
 
 ### Supported file types
 

--- a/src/watchdog/templates/vault/index.md
+++ b/src/watchdog/templates/vault/index.md
@@ -2,19 +2,50 @@
 
 *Watchdog investigation vault — created {today}.*
 
+> The tables below are live [Dataview](https://github.com/blacksmithgu/obsidian-dataview) queries. Install and enable the **Dataview** community plugin (Settings → Community plugins → turn on community plugins, then Browse → Dataview → Install → Enable) to render them; without it you'll see the raw query blocks. The tables refresh themselves as you ingest.
+
+## Most-mentioned entities
+
+The people, companies, and addresses appearing in the most documents — a quick read on who is central to the investigation.
+
+```dataview
+TABLE type AS "Type", length(appears_in) AS "Documents", date_last_updated AS "Updated"
+FROM "entities"
+SORT length(appears_in) DESC
+LIMIT 20
+```
+
 ## Recent documents
 
 ```dataview
-TABLE document_type, date_of_document
+TABLE document_type AS "Type", date_of_document AS "Dated", page_count AS "Pages"
 FROM "documents"
 SORT date_ingested DESC
 LIMIT 10
 ```
 
-## Entities
+## People
 
 ```dataview
-TABLE type, aliases
-FROM "entities"
-SORT date_last_updated DESC
+TABLE aliases AS "Also known as", length(appears_in) AS "Documents"
+FROM "entities/person"
+SORT length(appears_in) DESC
+```
+
+## Companies
+
+```dataview
+TABLE aliases AS "Also known as", length(appears_in) AS "Documents"
+FROM "entities/company"
+SORT length(appears_in) DESC
+```
+
+## Possible duplicates
+
+Documents flagged during chew as near-duplicates of an earlier one.
+
+```dataview
+TABLE near_duplicate_of AS "Near-duplicate of"
+FROM "documents"
+WHERE near_duplicate_of
 ```


### PR DESCRIPTION
The vault's `index.md` shipped two Dataview tables but never said they require the **Dataview** community plugin to render. Without it the file shows raw query blocks — which reads as "empty/useless." This makes `index.md` a genuinely useful dashboard and documents the dependency.

## Changes

- **Expanded `index.md`** into a real dashboard:
  - **Most-mentioned entities** — `length(appears_in)` ranks who's central (lead triage).
  - **Recent documents**, **People**, **Companies**, **Possible duplicates**.
  - Entity-kind tables filter by folder (`FROM "entities/person"`) rather than the `type` frontmatter field, since the directory is deterministically lowercased while the field's case isn't guaranteed.
- **Documented the Dataview requirement** in the file itself and in **README**, **GETTING_STARTED**, and **INSTALL** — including turning off a fresh vault's restricted mode, then Browse → Dataview → Install → Enable.

## Notes

- Static template + doc change; full suite green (658). Template render verified (placeholders substitute, 5 tables).
- Affects newly created vaults; existing vaults keep their `index.md` (users can paste the new queries in).

🤖 Generated with [Claude Code](https://claude.com/claude-code)