### PR TITLE
Docs: Claude Code is required; only ingestion is backend-flexible

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -37,6 +37,20 @@ These run through every decision below.
   (semaphore-bounded); all registry and note writes funnel through a single serialized,
   lock-guarded path (`write_vault`), so concurrency is safe without the model reasoning
   about it.
+- **Two runtimes, one boundary — Claude Code is required.** Watchdog runs in two places, and
+  the line between them is a governing constraint. The **document pipeline** (`watchdog chew` /
+  `ingest`) is a terminal program whose bounded reasoning calls go through a provider-agnostic
+  `model_client`: Claude by default, but offloadable to OpenAI/DeepSeek per stage (D37) because
+  a single-shot, schema-bound extraction call tolerates a cheaper model. The **investigation**
+  (`/watchdog-query`, `-surface`, `-wiki`, `-context`, `-health`) runs *inside Claude Code* as
+  agentic, multi-turn, user-in-the-loop sessions — and is deliberately **not** offloadable:
+  Claude Code is a hard requirement, and these stay on Claude. The split tracks capability, not
+  preference — open-ended exploration that asks the user questions and follows links across the
+  vault is where model and harness quality are hardest to substitute. The practical rule this
+  sets: "make it backend-portable" applies only to pipeline steps; collapsing an interactive
+  command into the single-shot pipeline pattern to gain portability would forfeit the iteration
+  that makes it useful (see D18 for the one move that *was* worth it — ingest, which is batch,
+  not interactive).
 
 ---
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -12,12 +12,12 @@ This guide assumes you have never used a terminal before. Read through it once b
 |------|-----|-------|
 | A computer running macOS, Linux, or Windows | Watchdog runs on your computer, not in the cloud | n/a |
 | [Obsidian](https://obsidian.md) | The app where you'll read and explore your documents | Free |
-| [Claude Code](https://claude.ai/download) | The AI assistant that reads and connects your documents | Free to install |
+| [Claude Code](https://claude.ai/download) | The AI assistant you ask questions, surface connections, and build your investigation in — **required** | Free to install |
 | Claude access | Powers the AI — required for document processing | Pro/Max subscription, or Anthropic API key |
 
 **Obsidian** is a note-taking app that Watchdog uses to organize and display your research. You don't need to know how to use it before starting — Watchdog sets it up for you.
 
-**Claude Code** is the AI assistant that does the document processing. It's made by Anthropic, the same company that makes Claude. You install it once on your computer.
+**Claude Code** is the AI assistant where you do your investigative work — asking questions of your documents, surfacing connections, and building up wiki threads. It's made by Anthropic, the same company that makes Claude, and you install it once on your computer. It is required: the interactive investigation commands run inside it. (If you want to cut cost, the separate document-*ingestion* step can be pointed at other AI providers like OpenAI or DeepSeek — see the README's Model backends section — but Claude Code itself is still needed for everything else.)
 
 **Claude access** is required because processing documents requires AI. A Pro subscription ($20/month) is enough for most journalism work. If you're ingesting hundreds of documents at a time, Max (from $100/month) gives you higher limits. If you have an Anthropic API key, you can use that instead — see Step 2.
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Every document Watchdog processes is read by an AI. There is no way to take that
 
 ## How it works
 
-The pipeline has two stages — a CLI stage you run in your terminal, and an extraction stage that runs inside Claude Code.
+Watchdog runs in two places: a **document pipeline** you run in your terminal (`watchdog chew`, then `watchdog ingest` — a Python orchestrator that calls a model only for the bounded reasoning steps, and can be pointed at Claude, OpenAI, or DeepSeek), and your **investigation**, which you run inside Claude Code (`/watchdog-query`, `/watchdog-surface`, `/watchdog-wiki`, and the other commands — interactive, multi-turn, always on Claude). The diagram below covers the terminal pipeline.
 
 ```
 Drop files into _INCOMING/
@@ -122,13 +122,15 @@ Because the model that extracts the document is the one that classifies it — r
 
 - **macOS, Linux, or Windows**
 - **[Obsidian](https://obsidian.md) v1.6+** — free
-- **[Claude Code](https://claude.ai/download)** — free to install
+- **[Claude Code](https://claude.ai/download)** — free to install; **required**
 - **Claude access** — a Claude.ai Pro or Max subscription, or an Anthropic API key
 - **Python 3.10+**
 - **qpdf + Ghostscript** — PDF decryption and repair
 - **Tesseract OCR** — Linux/Windows only (macOS uses Apple Vision)
 
 A Claude.ai Pro or Max subscription is the simplest starting point — no API key setup, no per-token billing. If you have an Anthropic API key, run `claude login` in your terminal after installing Claude Code and authenticate that way instead.
+
+**Claude Code is required and is not optional.** The investigation commands — `/watchdog-query`, `/watchdog-surface`, `/watchdog-wiki`, `/watchdog-context`, `/watchdog-health` — are agentic, multi-turn sessions (they read across the vault, follow links, and ask you questions), and they run inside Claude Code on Claude. What *is* flexible is the **document-ingestion pipeline**: its reasoning steps (classification, extraction, post-ingest synthesis) can be offloaded to other model providers — OpenAI or DeepSeek — to cut cost, while the interactive analysis stays on Claude. See [Model backends](#model-backends).
 
 ---
 
@@ -507,7 +509,9 @@ watchdog configure extract_concurrency 2
 
 ### Model backends
 
-Watchdog is designed around Claude and uses it by default, but each stage — classification, extraction, post-ingest — can run on a different model provider. A stage's model knob takes either a **Claude tier** (`haiku`/`sonnet`/`opus`, routed by your `watchdog auth` mode) or a **`backend:model`** value naming the provider and its model:
+Backend choice applies **only to the `watchdog ingest` pipeline** — the batch reasoning steps that run in your terminal. The interactive investigation commands (`/watchdog-query`, `/watchdog-surface`, `/watchdog-wiki`, `/watchdog-context`, `/watchdog-health`) are not affected: they run inside Claude Code, on Claude, always. (Those commands are open-ended, multi-turn agent sessions, where model capability is hardest to substitute; the ingest stages are bounded single-shot calls, which tolerate a cheaper provider far better.)
+
+Within ingest, Watchdog is designed around Claude and uses it by default, but each stage — classification, extraction, post-ingest — can run on a different model provider. A stage's model knob takes either a **Claude tier** (`haiku`/`sonnet`/`opus`, routed by your `watchdog auth` mode) or a **`backend:model`** value naming the provider and its model:
 
 | Value | Runs on |
 |---|---|


### PR DESCRIPTION
Clarifies the boundary we landed on in discussion: **Claude Code is a hard requirement**, and only the **ingestion pipeline** is backend-flexible. Promotes it from a doc footnote to a governing architecture principle.

## Why

The interactive investigation commands (`/watchdog-query`, `/watchdog-surface`, `/watchdog-wiki`, `/watchdog-context`, `/watchdog-health`) are agentic, multi-turn sessions — they read across the vault, follow links, and ask the user questions — and they run inside Claude Code on Claude. That iteration is a property of the harness, and model/harness capability is hardest to substitute there. The `watchdog ingest` pipeline, by contrast, is bounded single-shot reasoning calls, which tolerate a cheaper provider — so its classify/extract/post-ingest stages can be routed to OpenAI or DeepSeek.

## Changes

- **ARCHITECTURE §1 (Design principles)** — new "Two runtimes, one boundary — Claude Code is required" principle. States the governing rule: only pipeline steps are candidates for backend portability; don't flatten an interactive command into the single-shot pattern to gain it (with D18 — ingest — as the one batch case where the move was right).
- **README Requirements** — mark Claude Code **required**; explain the interactive-vs-ingestion split.
- **README Model backends** — scope the section to `watchdog ingest`; state the interactive commands always run on Claude.
- **README How it works** — fix a stale line claiming extraction "runs inside Claude Code." Post-#118/D18, ingest is a terminal Python orchestrator; the line also contradicted its own diagram.
- **INSTALL "What you need"** — same framing for a lay audience.

Docs-only; no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)