### PR TITLE
Auto-load hot.md into sessions via SessionStart hook (#187)

### DIFF
--- a/src/watchdog/cmd/vault.py
+++ b/src/watchdog/cmd/vault.py
@@ -343,6 +343,22 @@ def cmd_new(args) -> None:
                     "allow": _VAULT_PERMISSIONS,
                 },
                 "hooks": {
+                    # Load hot.md into context at the start of a session — and again
+                    # after compaction, which drops hook-injected context. The `compact`
+                    # matcher fires once compaction completes, so this one hook covers a
+                    # fresh start, a resume, and a post-compaction reload. SessionStart
+                    # stdout is added to Claude's context, so `cat` is all it takes.
+                    "SessionStart": [
+                        {
+                            "matcher": "startup|resume|compact",
+                            "hooks": [
+                                {
+                                    "type": "command",
+                                    "command": "[ -f hot.md ] && cat hot.md || true",
+                                }
+                            ],
+                        }
+                    ],
                     "UserPromptSubmit": [
                         {
                             "matcher": "",
@@ -360,7 +376,7 @@ def cmd_new(args) -> None:
                                 }
                             ],
                         }
-                    ]
+                    ],
                 },
             },
             indent=2,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -213,6 +213,21 @@ def test_cmd_new_creates_bases_dashboard(configured):
     assert "dashboard" in index.lower()
 
 
+def test_cmd_new_session_start_hook_loads_hot_md(configured):
+    cli.cmd_new(args(name="City Hall Probe", dir=str(configured)))
+    settings = json.loads(
+        (configured / "city-hall-probe" / ".claude" / "settings.json").read_text()
+    )
+    hooks = settings["hooks"]["SessionStart"]
+    matcher = hooks[0]["matcher"]
+    # one hook covers fresh start, resume, and post-compaction reload
+    assert "startup" in matcher and "resume" in matcher and "compact" in matcher
+    cmd = hooks[0]["hooks"][0]["command"]
+    assert "hot.md" in cmd
+    # the queue-reminder hook is preserved alongside it
+    assert "UserPromptSubmit" in settings["hooks"]
+
+
 def test_cmd_new_registers_project(configured, wdg_home):
     cli.cmd_new(args(name="My Story", dir=str(configured)))
     projects = json.loads((wdg_home / "projects.json").read_text())


### PR DESCRIPTION
Closes #187.

## What

The vault's `.claude/settings.json` now ships a `SessionStart` hook (matcher `startup|resume|compact`) that `cat`s `hot.md`. SessionStart stdout is injected into context, so a new investigation session opens with the case summary already loaded.

## Why one hook covers everything

The `compact` matcher fires *after* compaction completes (verified against the current Claude Code hooks docs), and compaction is exactly when hook-injected context is otherwise dropped. So a single `startup|resume|compact` hook covers a fresh start, a resume, **and** a post-compaction reload — cleaner than the separate `SessionStart` + `PostCompact` pair claude-obsidian uses. This serves watchdog's "close the ingest session, open a fresh one to investigate; it reads hot.md/briefings/registry" workflow without the user (or skill) having to remember to read it.

Per #181 review, the `Stop`-hook auto-rewrite of `hot.md` was deliberately **not** adopted — `hot.md` is a pipeline output and a read-mostly investigation session shouldn't clobber the briefing.

## Scope

- Adds the `SessionStart` hook to the settings block in `cmd/vault.py`; the existing `UserPromptSubmit` queue-reminder hook is preserved.
- `cat` is guarded (`[ -f hot.md ] && … || true`) so a vault without `hot.md` yet is a clean no-op.
- No CLI flag / command / workflow-step change, so no README/INSTALL/GETTING_STARTED or DECISIONS update needed.

## Tests

Full suite **673 passed**. New `test_cmd_new_session_start_hook_loads_hot_md` asserts the hook is scaffolded with the three-source matcher, runs `hot.md`, and leaves the queue-reminder hook in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)