### PR TITLE
watchdog-health: tally unresolved contradictions + unreviewed near-dups (#188)

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ Extraction is **not** a slash command — run `watchdog ingest` in your terminal
 | `/watchdog-entity [id ...]` | Refresh entity Summary and Timeline from all source documents |
 | `/watchdog-wiki` | Create or update investigation thread pages |
 | `/watchdog-context` | Seed `context.md` from background files in `_CONTEXT/` |
-| `/watchdog-health` | Check vault integrity — orphaned notes, broken links, registry mismatches |
+| `/watchdog-health` | Check vault integrity — orphaned notes, broken links, registry mismatches, unresolved contradictions, unreviewed near-duplicates |
 
 **Query examples:**
 

--- a/src/watchdog/skills/watchdog-health.md
+++ b/src/watchdog/skills/watchdog-health.md
@@ -113,7 +113,29 @@ Find all entities in `entities.json` where `roles` is an empty list or absent. T
 
 ---
 
-## 8. Report
+## 8. Unresolved contradictions
+
+The pipeline flags conflicts between sources as `> [!contradiction]` callouts in an entity's `## Contradictions` section, verified at extraction time and never auto-removed. They sit there until a journalist resolves them — but nothing surfaces the full list in one place. Find them:
+
+```bash
+grep -rn '\[!contradiction\]' entities/ --include="*.md"
+```
+
+For each callout, report: `CONTRADICTION: entities/<type>/<id>.md — <first line of the callout>`. These are conflicting claims a journalist should resolve (confirm which source is right; check dates and primary sources). Count them for the summary. They are append-only by design, so a callout the journalist has already worked through may still appear — treat the list as "conflicts on record," highest-value first.
+
+---
+
+## 9. Unreviewed near-duplicates
+
+During chew, MinHash flags a document that closely matches an earlier one by writing `near_duplicate_of` into its registry entry — detection only, never auto-discarded, so the journalist decides whether they are the same document. Read `.watchdog/Registry/documents.json`; for every entry with a non-empty `near_duplicate_of`, report:
+
+`NEAR-DUPLICATE: documents/<slug>.md ~ <near_duplicate_of> — confirm same or different`
+
+Count them for the summary. A flagged pair stays flagged until the journalist acts (delete one, or annotate the document note's `## Notes`), so this list is everything still awaiting that judgement.
+
+---
+
+## 10. Report
 
 Print a health summary to the terminal:
 
@@ -124,11 +146,13 @@ Documents:   <n> registered, <n> notes found
 Entities:    <n> registered, <n> notes found
 Dead links:  <n>
 Missing fields: <n>
+Contradictions: <n> unresolved
+Near-duplicates: <n> unreviewed
 
 Issues:
   CRITICAL  (<n>): missing notes, orphaned notes, stale lock
-  WARNING   (<n>): missing frontmatter fields, dead links, count mismatches
-  INFO      (<n>): isolated entities
+  WARNING   (<n>): missing frontmatter fields, dead links, count mismatches, unresolved contradictions
+  INFO      (<n>): isolated entities, unreviewed near-duplicates
 
 <list of issues>
 

--- a/tests/test_setup_skills.py
+++ b/tests/test_setup_skills.py
@@ -16,3 +16,13 @@ def test_install_skills_does_not_copy_records(tmp_path):
     install_skills(tmp_path)
     # Domain/record skills live globally now and are not seeded into the vault.
     assert not (tmp_path / "records").exists()
+
+
+def test_health_skill_covers_contradictions_and_near_dups(tmp_path):
+    install_skills(tmp_path)
+    health = (tmp_path / "watchdog-health.md").read_text()
+    # the two checks added in #188 must survive in the installed skill
+    assert "Unresolved contradictions" in health
+    assert "[!contradiction]" in health
+    assert "Unreviewed near-duplicates" in health
+    assert "near_duplicate_of" in health


### PR DESCRIPTION
Closes #188.

## What

Adds the two checks the #181 review found missing in `watchdog-health` versus claude-obsidian's `wiki-lint` (health was otherwise already ahead on registry integrity):

- **§8 Unresolved contradictions** — greps entity notes for `[!contradiction]` callouts and lists them, so the conflicts the pipeline flagged at extraction surface in one place for a journalist to resolve.
- **§9 Unreviewed near-duplicates** — reads `documents.json` for entries with `near_duplicate_of` set and lists the pairs still awaiting a same/different judgement (chew flags these, never auto-discards).

Both feed the §10 report summary (contradictions → WARNING, near-dups → INFO).

## Scope

Skill-prose change to `watchdog-health.md` plus the README command description. No pipeline/layout/invariant change, so no ARCHITECTURE/DECISIONS entry. A structural test asserts the installed skill retains both checks (guards against accidental deletion).

## Tests

Full suite **674 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)