### PR TITLE
Make timeline-sort tests actually exercise sorting

### DIFF
--- a/tests/test_write_entity.py
+++ b/tests/test_write_entity.py
@@ -57,11 +57,13 @@ def make_extraction(tmp_path: Path, entity_id: str = "alice-smith") -> Path:
     data = {
         "entity_id": entity_id,
         "summary": "Alice Smith is a key figure appearing across 2 documents.",
+        # Out of chronological order on purpose so test_timeline_sorted_in_note
+        # actually exercises the sort instead of pre-ordered input.
         "timeline_events": [
-            {"date": "2015-11-03", "event": "Transferred shares with no equity received",
-             "source_sha256": "sha-doc1", "page": 1, "basis": "stated"},
             {"date": "2019-01-15", "event": "Listed as director in annual report",
              "source_sha256": "sha-doc2", "page": 4, "basis": "stated"},
+            {"date": "2015-11-03", "event": "Transferred shares with no equity received",
+             "source_sha256": "sha-doc1", "page": 1, "basis": "stated"},
         ],
     }
     path = tmp_path / "entity-refresh.json"

--- a/tests/test_write_vault.py
+++ b/tests/test_write_vault.py
@@ -62,9 +62,11 @@ def make_extraction(tmp_path: Path, overrides: dict | None = None) -> Path:
                      "page": 2, "basis": "stated", "reason": "establishes control of Acme",
                      "quote": "Ms. Smith holds 4,200,000 common shares of Acme Corp."},
                 ],
+                # Deliberately out of chronological order so the sort test exercises
+                # the sort rather than asserting on already-ordered input.
                 "timeline_events": [
-                    {"date": "2020-03-15", "event": "Appointed director of Acme Corp", "page": 2, "basis": "stated"},
                     {"date": "2024", "event": "Continued as director", "page": 2, "basis": "inferred"},
+                    {"date": "2020-03-15", "event": "Appointed director of Acme Corp", "page": 2, "basis": "stated"},
                 ],
                 "roles": [
                     {


### PR DESCRIPTION
## Problem

`test_timeline_sorted_chronologically` (test_write_vault.py) and `test_timeline_sorted_in_note` (test_write_entity.py) asserted on fixtures whose timeline events were **already in chronological order**. So the assertions held whether or not the sort ran — deleting the timeline sort entirely left both tests green. They could not detect broken sorting.

This surfaced via mutation testing: removing the sort from the render path was a surviving mutant for both tests.

## Fix

Reorder the fixture events to be deliberately out of chronological order, so each assertion (`pos_earlier < pos_later`) only holds if the sort actually runs.

## Verification

- Both tests pass normally.
- Both tests **fail** when the timeline sort is deleted (confirmed against the real source).
- Full suite: 671 passed.

No source changes — fixtures only.