### PR TITLE
cli: clearer `watchdog -h` section headings

### DIFF
--- a/src/watchdog/cmd/base.py
+++ b/src/watchdog/cmd/base.py
@@ -495,7 +495,7 @@ def _print_banner() -> None:
     print(f"  {_DIM}Usage:  watchdog <command> [options]{_RESET}")
     print()
     groups = [
-        ("Investigation", [
+        ("Manage investigations", [
             ("new",        "Create a new investigation vault"),
             ("register",   "Register an existing vault folder"),
             ("obsidian",   "Open in Obsidian"),
@@ -506,7 +506,7 @@ def _print_banner() -> None:
             ("move",       "Move vault to a new path"),
             ("delete",     "Remove an investigation from registry"),
         ]),
-        ("Processing", [
+        ("Document processing", [
             ("chew",             "Process documents in _INCOMING/"),
             ("ingest",           "Set up extraction session and open in Claude Code"),
             ("context",          "Seed investigation context from _CONTEXT/"),


### PR DESCRIPTION
Renames two `watchdog -h` banner section headings that read ambiguously:

- **Investigation → Manage investigations.** That group is the vault *lifecycle* (new, register, obsidian, open, archive, unarchive, rename, move, delete), not investigative work — "Investigation" implied the latter.
- **Processing → Document processing.** Clearer that it's the document pipeline (chew, ingest, watch, log, timeline, context).

Presentation only — no command behaviour changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)