### PR TITLE
Surface per-ingest token/cost usage in watchdog status and log.md

### DIFF
--- a/src/watchdog/cmd/vault.py
+++ b/src/watchdog/cmd/vault.py
@@ -971,13 +971,19 @@ def cmd_status(args) -> None:
     pages_note = f" {_DIM}({total_pages} pages){_RESET}" if total_pages else ""
     print(f"  {_BOLD}{reg['document_count']}{_RESET} documents{pages_note} · {_BOLD}{reg['entity_count']}{_RESET} entities · {_DIM}last updated {_fmt_date(reg['last_updated'])}{_RESET}")
 
+    from watchdog.pipeline import orchestrate
+    last_usage = orchestrate.latest_usage(vault)
+    if last_usage:
+        cost = f" · ~${last_usage['cost_usd']:.4f}" if last_usage.get("cost_usd") else ""
+        print(f"  {_DIM}Last ingest: {last_usage['input_tokens']:,} in / "
+              f"{last_usage['output_tokens']:,} out tokens{cost}{_RESET}")
+
     if incoming_n:
         print(f"  {_YELLOW}{incoming_n} file{'s' if incoming_n != 1 else ''}{_RESET} in {_CYAN}_INCOMING/{_RESET} {_DIM}— run{_RESET} {_CYAN}watchdog chew{_RESET}")
     if queued_n:
         print(f"  {_YELLOW}{queued_n} file{'s' if queued_n != 1 else ''}{_RESET} chewed and waiting for {_CYAN}/watchdog-ingest{_RESET}")
     _warn_pending_research(vault)
 
-    from watchdog.pipeline import orchestrate
     if orchestrate.has_pending_finalization(vault):
         p = orchestrate.pending_finalization(vault)
         bits = []

--- a/src/watchdog/pipeline/orchestrate.py
+++ b/src/watchdog/pipeline/orchestrate.py
@@ -119,6 +119,22 @@ def _write_usage(vault: Path, records: list[dict]) -> str | None:
     return relpath
 
 
+def latest_usage(vault: Path) -> dict | None:
+    """The most recent ingest run's token/cost totals (F5, #222), or None if none exist yet —
+    `watchdog status` surfaces this so a subscription user can see what a dump cost before
+    deciding whether to kick off another one. Filenames sort chronologically (the timestamp
+    format is lexicographically ordered), so the last one is the most recent."""
+    reg_dir = vault / ".watchdog" / "Registry"
+    files = sorted(reg_dir.glob("usage-*.json")) if reg_dir.exists() else []
+    if not files:
+        return None
+    try:
+        data = json.loads(files[-1].read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return data.get("totals")
+
+
 DEFAULT_CLASSIFY_PAGES = 5
 # Per-section input budget when falling back to sectioning after a whole-doc extraction
 # overruns the output ceiling. Small, so each section's output stays well under the cap;
@@ -740,6 +756,11 @@ def _write_briefing(vault: Path, b: dict, results: list, neardup_alerts: list,
              f"- **Briefing:** [[briefings/{slug}|{slug}]]\n")
     if contradiction_flags:
         entry += f"- **Contradictions flagged:** {len(contradiction_flags)}\n"
+    if _usage:   # (F5, #222) — _post_ingest's own calls (synthesis/timeline-dedup/briefing)
+        totals = _usage_totals(_usage)   # are already recorded by the time this runs
+        cost = f" · ~${totals['cost_usd']:.4f}" if totals.get("cost_usd") else ""
+        entry += (f"- **Usage:** {totals['input_tokens']:,} in / "
+                 f"{totals['output_tokens']:,} out tokens{cost}\n")
     with open(vault / "log.md", "a", encoding="utf-8") as f:
         f.write(entry)
     return f"briefings/{slug}.md"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -589,6 +589,29 @@ def test_cmd_status_no_batch_line_when_none_pending(configured, capsys):
     assert "Batch extraction pending" not in _strip_ansi(capsys.readouterr().out)
 
 
+def test_cmd_status_shows_last_ingest_usage(configured, capsys):
+    """#222: the user-facing half of A2's telemetry — watchdog status shows what the last
+    ingest cost, without having to go spelunking in .watchdog/Registry/."""
+    cli.cmd_new(args(name="Test Proj", dir=str(configured)))
+    vault = configured / "test-proj"
+    reg = vault / ".watchdog" / "Registry"
+    (reg / "usage-20260101T000000Z.json").write_text(json.dumps({
+        "calls": [], "totals": {"input_tokens": 41200, "output_tokens": 9600,
+                                "cache_read_tokens": 0, "cache_write_tokens": 0, "cost_usd": 1.87},
+    }))
+    cli.cmd_status(args(name="Test Proj"))
+    out = _strip_ansi(capsys.readouterr().out)
+    assert "Last ingest" in out
+    assert "41,200 in" in out and "9,600 out" in out
+    assert "$1.87" in out
+
+
+def test_cmd_status_no_usage_line_before_any_ingest(configured, capsys):
+    cli.cmd_new(args(name="Test Proj", dir=str(configured)))
+    cli.cmd_status(args(name="Test Proj"))
+    assert "Last ingest" not in _strip_ansi(capsys.readouterr().out)
+
+
 def test_cmd_guided_warns_pending_research(configured, capsys, monkeypatch):
     cli.cmd_new(args(name="Test Proj", dir=str(configured)))
     vault = configured / "test-proj"

--- a/tests/test_orchestrate.py
+++ b/tests/test_orchestrate.py
@@ -579,6 +579,50 @@ def test_usage_telemetry_persisted_after_ingest(tmp_path, monkeypatch):
     assert round(summary["usage"]["cost_usd"], 4) == round(0.01 * n_calls, 4)
 
 
+def test_log_md_ingest_entry_includes_usage_line(tmp_path, monkeypatch):
+    """F5/#222: the log.md entry for an ingest carries the run's token/cost totals, the
+    user-facing half of A2's telemetry."""
+    vault = make_vault(tmp_path)
+    _queue_doc(vault)
+
+    async def fake(*, task, prompt, schema, model=None, backend=None, max_retries=1, effort=None):
+        parsed = {
+            "classify": {"skill": "general-records.md"},
+            "extract": _extraction(),
+            "briefing": {"investigation_status": "x", "what_was_ingested": []},
+        }.get(task, {"entity_syntheses": []} if task == "entity-synthesis" else {"keep": []})
+        return model_client.ModelResult(
+            parsed=parsed, text="", model="claude-sonnet-4-6", backend="claude-api",
+            auth_mode="api-key", cost_usd=0.01, usage={"input_tokens": 100, "output_tokens": 20})
+    monkeypatch.setattr(orchestrate.model_client, "acomplete_json", fake)
+
+    asyncio.run(orchestrate.run(vault))
+    log = (vault / "log.md").read_text()
+    assert "**Usage:**" in log
+    assert "in /" in log and "out tokens" in log
+    assert "$0.0" in log   # non-zero cost rendered
+
+
+def test_latest_usage_none_before_any_ingest(tmp_path):
+    vault = make_vault(tmp_path)
+    assert orchestrate.latest_usage(vault) is None
+
+
+def test_latest_usage_returns_the_most_recent_run(tmp_path):
+    vault = make_vault(tmp_path)
+    reg = vault / ".watchdog" / "Registry"
+    (reg / "usage-20260101T000000Z.json").write_text(
+        json.dumps({"calls": [], "totals": {"input_tokens": 1, "output_tokens": 1,
+                                            "cache_read_tokens": 0, "cache_write_tokens": 0,
+                                            "cost_usd": 0.001}}))
+    (reg / "usage-20260102T000000Z.json").write_text(
+        json.dumps({"calls": [], "totals": {"input_tokens": 999, "output_tokens": 999,
+                                            "cache_read_tokens": 0, "cache_write_tokens": 0,
+                                            "cost_usd": 0.05}}))
+    totals = orchestrate.latest_usage(vault)
+    assert totals["input_tokens"] == 999
+
+
 def test_orchestrator_cancels_gracefully_on_sigint(tmp_path, monkeypatch):
     """Ctrl+C during extraction → cancelled summary, no traceback, unfinished docs keep
     their queue file, and post-ingest is skipped."""


### PR DESCRIPTION
Closes #222

## Summary

The user-facing half of #207's usage telemetry — until now, `usage-<ts>.json` files were written per ingest but nothing ever read them back. For a subscription user, the only way to learn what a dump cost was to hit the session limit mid-batch; this makes it visible upfront.

- `orchestrate.latest_usage(vault)` — reads the most recent `usage-<ts>.json`'s totals (filenames sort chronologically, so the last one is the newest).
- `watchdog status` prints a `Last ingest: X in / Y out tokens · ~$Z` line when usage data exists (silent before the first ingest).
- Each ingest's `log.md` entry gets a `- **Usage:** X in / Y out tokens · ~$Z` bullet, computed from the same run-scoped `_usage` accumulator `_write_briefing` already has in scope by the time it runs (all of `_post_ingest`'s own calls — synthesis, timeline-dedup, briefing — are already recorded).

No README/GETTING_STARTED changes — this is additive display data, not a format change, and neither doc reproduces `watchdog status`'s literal output.

## Test plan

- [x] `~/.local/pipx/venvs/watchdog-intel/bin/pytest` — 810 passed
- [x] `latest_usage`: None before any ingest, picks the most recent of several usage files
- [x] `log.md` entry includes the usage line with real numbers from a mocked ingest run
- [x] `watchdog status`: shows the line when a usage file exists, omits it when none exists yet

🤖 Generated with [Claude Code](https://claude.com/claude-code)