### PR TITLE
Offer to install Playwright/Chromium during watchdog setup

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -107,9 +107,10 @@ This will:
 - Verify that qpdf and Ghostscript are installed
 - Ask where you want to store your investigation projects
 - Enable tab completion in your shell automatically
+- Offer to install the optional capture browser for full page snapshots (see [Full page snapshots](#full-page-snapshots-optional) below)
 - Download the ML models for document conversion and semantic search (one-time, may take a few minutes on a slow connection)
 
-It will ask one question: where to store your projects. Press Return to accept the default (`~/Investigations`), or type a different path.
+It will ask two questions: where to store your projects, and whether to install the optional capture browser. Press Return to accept the projects default (`~/Investigations`), or type a different path; the capture browser defaults to no (type `y` to install it, an extra ~150 MB).
 
 When setup finishes, reload your shell so the tab completion takes effect:
 
@@ -355,6 +356,8 @@ pipx install "watchdog-intel[asr]" --force
 ## Full page snapshots (optional)
 
 By default, `watchdog research` and `watchdog fetch` save HTML pages with a plain, sanitized fetch — no JavaScript runs, so client-rendered pages (single-page apps) can deposit as an empty shell, and images/styling aren't captured. Installing the optional capture browser renders every HTML page in headless Chromium instead and saves a faithful, self-contained snapshot (images, fonts, and stylesheets inlined; all scripts stripped) — worth it if the sources you're pulling in are often JavaScript-heavy or you want the visual layout preserved.
+
+`watchdog setup` asks whether to install it (see [Step 6](#step-6-run-setup) above). To install it later, or if you said no the first time:
 
 ```
 pipx inject watchdog-intel playwright

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ pipx install watchdog-intel
 watchdog setup
 ```
 
-`watchdog setup` verifies system dependencies (qpdf, Ghostscript, Tesseract on Linux), configures your projects directory, and downloads the ML models used for document conversion and semantic search (one-time). Expect the model download step to take a few minutes on a slow connection.
+`watchdog setup` verifies system dependencies (qpdf, Ghostscript, Tesseract on Linux), configures your projects directory, offers to install the optional Playwright/Chromium capture browser (~150 MB — declines by default), and downloads the ML models used for document conversion and semantic search (one-time). Expect the model download step to take a few minutes on a slow connection.
 
 Shell tab completion is enabled automatically by `watchdog setup` — it writes the activation line to your shell profile (`~/.zshrc`, `~/.bashrc`, or equivalent) and prompts you to reload.
 

--- a/src/watchdog/setup_cmd.py
+++ b/src/watchdog/setup_cmd.py
@@ -64,6 +64,49 @@ def install_skills(commands_dir: Path) -> None:
             (commands_dir / item.name).write_bytes(item.read_bytes())
 
 
+def _check_playwright() -> None:
+    """Check for Playwright + Chromium (the optional, higher-fidelity capture path `watchdog
+    research`/`fetch` use — see #200/D61) and offer to install both if missing. Everything else
+    works without it; a missing/declined install just means plain-fetch captures instead of
+    full-fidelity ones."""
+    from watchdog.pipeline import capture
+
+    print()
+    print("  Checking web-capture support...")
+    if capture.render_available():
+        _ok("Playwright + Chromium — faithful web captures ready")
+        return
+
+    print(f"  {_DIM}Used by `watchdog research`/`watchdog fetch` to save full-fidelity page\n"
+          f"  snapshots (images, styles, client-rendered pages) instead of a plain fetch.\n"
+          f"  Optional — everything else works without it. Adds ~150 MB (Chromium browser).{_RESET}")
+    answer = input("  Install web-capture support now? [y/N] ").strip().lower()
+    if answer not in ("y", "yes"):
+        print(f"  {_DIM}Skipped. Install later with:{_RESET}")
+        print(f"    {_CYAN}pipx inject watchdog-intel playwright{_RESET}")
+        print(f"    {_CYAN}~/.local/pipx/venvs/watchdog-intel/bin/playwright install chromium{_RESET}")
+        return
+
+    print(f"\n  {_DIM}Installing playwright...{_RESET}")
+    result = subprocess.run(
+        [sys.executable, "-m", "pip", "install", "playwright"],
+        capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        _warn(f"could not install playwright: {result.stderr.strip()[:300]}")
+        return
+
+    print(f"  {_DIM}Downloading Chromium (one-time, ~150 MB)...{_RESET}")
+    result = subprocess.run(
+        [sys.executable, "-m", "playwright", "install", "chromium"],
+        capture_output=True, text=True,
+    )
+    if result.returncode == 0:
+        _ok("Playwright + Chromium installed")
+    else:
+        _warn(f"Chromium download failed: {result.stderr.strip()[:300]}")
+
+
 def _ask_projects_dir() -> Path:
     default = Path.home() / "Investigations"
     default_exists = default.exists()
@@ -211,7 +254,10 @@ def run(force: bool = False) -> None:
             _warn("tesserocr not importable — OCR will fall back to EasyOCR"
                   " (install Tesseract system package first, then: pip install tesserocr)")
 
-    # 6. Download ML models
+    # 6. Web capture (Playwright/Chromium)
+    _check_playwright()
+
+    # 7. Download ML models
     # Pin fastembed cache to ~/.cache/fastembed so it survives reboots.
     # Fastembed 0.8+ defaults to tempfile.gettempdir()/fastembed_cache which is ephemeral.
     _FASTEMBED_MODEL = "BAAI/bge-small-en-v1.5"
@@ -255,7 +301,7 @@ def run(force: bool = False) -> None:
         except Exception as e:
             _warn(f"Docling model download failed: {e}")
 
-    # 7. Write config
+    # 8. Write config
     WATCHDOG_HOME.mkdir(parents=True, exist_ok=True)
     CONFIG_FILE.write_text(
         json.dumps(
@@ -264,11 +310,11 @@ def run(force: bool = False) -> None:
         ) + "\n"
     )
 
-    # 8. Authentication
+    # 9. Authentication
     from watchdog.cmd.auth import setup_auth_interactive
     setup_auth_interactive()
 
-    # 9. Done
+    # 10. Done
     reload_hint = f"{_CYAN}source {profile}{_RESET}" if profile else "reload your shell"
     print()
     print(f"{_GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━{_RESET}")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1284,6 +1284,7 @@ def test_setup_writes_auto_for_worker_keys(tmp_path, monkeypatch):
     monkeypatch.setattr(sc, "_check_deps",       lambda: [])
     monkeypatch.setattr(sc, "_ask_projects_dir", lambda: investigations)
     monkeypatch.setattr(sc, "_detect_shell",     lambda: (None, None))
+    monkeypatch.setattr(sc, "_check_playwright", lambda: None)
 
     sc.run()
 

--- a/tests/test_setup_playwright.py
+++ b/tests/test_setup_playwright.py
@@ -1,0 +1,77 @@
+"""Tests for the Playwright/Chromium check in `watchdog setup` (#246)."""
+
+import watchdog.setup_cmd as sc
+
+
+def test_playwright_already_available_skips_prompt(monkeypatch, capsys):
+    monkeypatch.setattr("watchdog.pipeline.capture.render_available", lambda: True)
+
+    def _boom(*a):
+        raise AssertionError("should not prompt when already available")
+    monkeypatch.setattr("builtins.input", _boom)
+
+    sc._check_playwright()
+    out = capsys.readouterr().out
+    assert "faithful web captures ready" in out
+
+
+def test_playwright_missing_declined_prints_manual_hint(monkeypatch, capsys):
+    monkeypatch.setattr("watchdog.pipeline.capture.render_available", lambda: False)
+    monkeypatch.setattr("builtins.input", lambda prompt="": "n")
+
+    def _boom(*a, **k):
+        raise AssertionError("should not install when declined")
+    monkeypatch.setattr(sc.subprocess, "run", _boom)
+
+    sc._check_playwright()
+    out = capsys.readouterr().out
+    assert "Skipped" in out
+    assert "pipx inject watchdog-intel playwright" in out
+    assert "playwright install chromium" in out
+
+
+def test_playwright_missing_accepted_installs_both(monkeypatch, capsys):
+    monkeypatch.setattr("watchdog.pipeline.capture.render_available", lambda: False)
+    monkeypatch.setattr("builtins.input", lambda prompt="": "y")
+
+    calls = []
+
+    class _Result:
+        def __init__(self, returncode):
+            self.returncode = returncode
+            self.stderr = ""
+
+    def _fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        return _Result(0)
+
+    monkeypatch.setattr(sc.subprocess, "run", _fake_run)
+
+    sc._check_playwright()
+    out = capsys.readouterr().out
+    assert "Playwright + Chromium installed" in out
+    assert calls[0][-1] == "playwright"        # pip install playwright
+    assert calls[1][-2:] == ["install", "chromium"]  # playwright install chromium
+
+
+def test_playwright_pip_install_failure_warns_and_stops(monkeypatch, capsys):
+    monkeypatch.setattr("watchdog.pipeline.capture.render_available", lambda: False)
+    monkeypatch.setattr("builtins.input", lambda prompt="": "y")
+
+    calls = []
+
+    class _Result:
+        def __init__(self, returncode, stderr=""):
+            self.returncode = returncode
+            self.stderr = stderr
+
+    def _fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        return _Result(1, "network unreachable")
+
+    monkeypatch.setattr(sc.subprocess, "run", _fake_run)
+
+    sc._check_playwright()
+    out = capsys.readouterr().out
+    assert "could not install playwright" in out
+    assert len(calls) == 1  # never attempted the chromium download after pip failed


### PR DESCRIPTION
Closes #246.

## What

`watchdog setup` now checks `capture.render_available()` and, if the optional web-capture browser (Playwright + Chromium) is missing, explains what it's for and prompts to install it:

> Used by `watchdog research`/`watchdog fetch` to save full-fidelity page snapshots (images, styles, client-rendered pages) instead of a plain fetch.
> Optional — everything else works without it. Adds ~150 MB (Chromium browser).
> Install web-capture support now? [y/N]

Defaults to no, given it's a ~150 MB download only needed for the web-research feature (not every investigation touches it). Accepting runs `pip install playwright` then `playwright install chromium` inline, reusing the same install-during-setup pattern already used for OCR engines (`_ensure_ocr_engine`). Declining prints the existing manual install command (`pipx inject watchdog-intel playwright` + `playwright install chromium`).

If already installed (already true for most dev setups after #242), setup just confirms it's ready and skips the prompt entirely.

## Docs

- README.md: `watchdog setup` description now mentions the new prompt.
- INSTALL.md: Step 6 list and the "Full page snapshots" section now reference the setup-time prompt.

## Tests

- `tests/test_setup_playwright.py`: already-available (no prompt), declined (manual hint, no subprocess calls), accepted (both installs run, right args), pip-install failure (warns, never attempts the Chromium download).
- Updated `test_setup_writes_auto_for_worker_keys` to mock the new step for determinism.
- Full suite: 952 passed. Mutation-verified the decline path (weakening the condition check turned the test red).

🤖 Generated with [Claude Code](https://claude.com/claude-code)