### PR TITLE
Fail the whole document when any chunk of a large PDF fails

### DIFF
--- a/src/watchdog/pipeline/preprocess.py
+++ b/src/watchdog/pipeline/preprocess.py
@@ -319,7 +319,8 @@ def process_large_pdf(path: Path, force_ocr: bool, total_pages: int) -> dict:
             start, result = future.result()
             chunk_results[start] = result
 
-    # Merge in page order; skip failed chunks but note them
+    # Merge in page order; any failed chunk fails the whole document — a silent
+    # page gap is worse than a failed file, since a failed file gets retried (#251).
     all_pages = []
     failed_chunks = []
     garbled_detected = False
@@ -337,7 +338,10 @@ def process_large_pdf(path: Path, force_ocr: bool, total_pages: int) -> dict:
         if r.get("metadata", {}).get("ocr_used"):
             ocr_used = True
 
-    result = {
+    if failed_chunks:
+        return {"error": f"Chunk(s) failed: {'; '.join(failed_chunks)}"}
+
+    return {
         "filename": path.name,
         "sha256": sha256_file(path),
         "page_count": total_pages,
@@ -350,14 +354,6 @@ def process_large_pdf(path: Path, force_ocr: bool, total_pages: int) -> dict:
             "chunk_count": len(chunks),
         },
     }
-
-    if failed_chunks:
-        result["metadata"]["failed_chunks"] = failed_chunks
-
-    if not all_pages:
-        return {"error": f"All chunks failed: {'; '.join(failed_chunks)}"}
-
-    return result
 
 
 _PAGE_BREAK = "\n\n<!-- page-break -->\n\n"

--- a/tests/test_preprocess.py
+++ b/tests/test_preprocess.py
@@ -117,8 +117,8 @@ def test_process_large_pdf_all_chunks_fail_returns_error(tmp_path, monkeypatch):
     assert "failed" in result["error"].lower()
 
 
-def test_process_large_pdf_partial_failure_still_returns_pages(tmp_path, monkeypatch):
-    """When only some chunks fail, return the pages from successful chunks."""
+def test_process_large_pdf_partial_failure_returns_error(tmp_path, monkeypatch):
+    """A single failed chunk must fail the whole document, not queue it with a silent page gap (#251)."""
     from pathlib import Path as _Path
     import watchdog.pipeline.preprocess as preprocess_mod
 
@@ -138,9 +138,8 @@ def test_process_large_pdf_partial_failure_still_returns_pages(tmp_path, monkeyp
     monkeypatch.setattr(preprocess_mod, "sha256_file", lambda p: "abc123")
 
     result = process_large_pdf(_Path("/fake/doc.pdf"), force_ocr=False, total_pages=80)
-    assert "error" not in result
-    assert result["pages"]
-    assert result["metadata"]["failed_chunks"]
+    assert "error" in result
+    assert "chunk 1 failed" in result["error"]
 
 
 # ── process_with_docling large-PDF fallback ───────────────────────────────────


### PR DESCRIPTION
Fixes #251

## Summary
`process_large_pdf` silently dropped failed chunks' page ranges and queued the document as OK, so a journalist could get entities and a briefing from a document silently missing pages. A partial chunk failure now returns an error, routing the file to `_INCOMING/_FAILED/` (retry-friendly) — the same path already used for the all-chunks-failed and small-PDF failure cases.

## Test plan
- [x] Updated `test_process_large_pdf_partial_failure_still_returns_pages` (renamed to `_returns_error`) to assert the new behavior
- [x] `pytest tests/test_preprocess.py` — 15 passed
- [x] Mutation-tested: reverted the fix, confirmed the test goes red, restored