### PR TITLE
Small batch: finalizer default, _SKIPPED status count, wasted section summary, watch mid-copy race

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -592,9 +592,9 @@ anything no longer in the registry.
 
 ## 13. Models & skills
 
-- **Models** (configurable via `watchdog configure`, default sonnet): `extractor_model`
-  (extraction, whole-doc + section) and `finalizer_model` (post-ingest synthesis +
-  timeline + briefing, §8–§9); classification runs on haiku. `extract_concurrency`
+- **Models** (configurable via `watchdog configure`): `extractor_model` (default sonnet;
+  extraction, whole-doc + section) and `finalizer_model` (default haiku; post-ingest
+  synthesis + timeline + briefing, §8–§9); classification runs on haiku. `extract_concurrency`
   (default 5) bounds parallel extraction. Each is overridable per run via the matching
   `watchdog ingest` flag (`--extractor-model` / `--finalizer-model` / `--concurrency`).
 - **Reasoning effort** (per-stage, default `high` ≡ the model default): `extractor_effort`

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -172,7 +172,7 @@ watchdog ingest
 
 This runs the extraction pipeline **in your terminal** — there's no Claude Code session to open. Watchdog scans the queue, confirms, and processes documents in parallel. The model is called only for the reasoning steps; everything mechanical runs in Python. (Authentication is set during `watchdog setup` — your Claude subscription or an API key; see INSTALL.)
 
-By default Watchdog uses Sonnet for extraction and for the post-ingest step (synthesis + timeline + briefing), and Haiku for the quick document classification. Set persistent defaults with `watchdog configure`, or override per run:
+By default Watchdog uses Sonnet for extraction, and Haiku for the post-ingest step (synthesis + timeline + briefing) and the quick document classification. Set persistent defaults with `watchdog configure`, or override per run:
 
 ```bash
 watchdog ingest --extractor-model haiku             # faster, cheaper extraction

--- a/src/watchdog/cmd/base.py
+++ b/src/watchdog/cmd/base.py
@@ -450,7 +450,7 @@ def _count_incoming(vault: Path) -> int:
     count = 0
     for root, dirs, files in os.walk(incoming):
         rel_parts = Path(root).relative_to(incoming).parts
-        if any(p in ("_FAILED", "_failed") for p in rel_parts):
+        if any(p in ("_FAILED", "_failed", "_SKIPPED", "_skipped") for p in rel_parts):
             dirs.clear()
             continue
         count += sum(1 for f in files if not f.startswith(".") and not f.endswith(".yml"))

--- a/src/watchdog/cmd/ingest.py
+++ b/src/watchdog/cmd/ingest.py
@@ -202,7 +202,7 @@ def cmd_ingest(args, *, confirm: bool = True) -> None:
     extract_backend, extract_model = _resolve_stage(
         getattr(args, "extractor_model", None), config.get("extractor_model"))
     post_backend, post_model = _resolve_stage(
-        getattr(args, "finalizer_model", None), config.get("finalizer_model"))
+        getattr(args, "finalizer_model", None), config.get("finalizer_model"), default="haiku")
     classify_backend, classify_model = _resolve_stage(
         getattr(args, "classifier_model", None), config.get("classifier_model"), default="haiku")
     extract_effort = _effort(getattr(args, "extractor_effort", None), config.get("extractor_effort"))

--- a/src/watchdog/cmd/vault.py
+++ b/src/watchdog/cmd/vault.py
@@ -784,6 +784,25 @@ def cmd_log(args) -> None:
     print()
 
 
+def _poll_stable_files(candidates: set, pending_sizes: dict) -> tuple:
+    """Split newly-seen files into size-stable (safe to chew) vs. still-growing.
+
+    A file mid-copy (Finder, a network share) must not be chewed until its size holds
+    steady across two polls — otherwise chew hashes/OCRs truncated bytes (#261).
+    """
+    ready, new_pending = [], {}
+    for f in candidates:
+        try:
+            size = f.stat().st_size
+        except OSError:
+            continue
+        if pending_sizes.get(f) == size:
+            ready.append(f)          # unchanged since the last poll — copy finished
+        else:
+            new_pending[f] = size    # still growing (or first sighting) — wait
+    return ready, new_pending
+
+
 def cmd_watch(args) -> None:
     if not args.name:
         cwd = Path(".").resolve()
@@ -807,18 +826,19 @@ def cmd_watch(args) -> None:
     print(f"\n  {_BOLD}{info['name']}{_RESET}  watching {_CYAN}_INCOMING/{_RESET} — press Ctrl+C to stop.\n")
 
     known: set = set(find_files([incoming]))
+    pending_sizes: dict = {}   # file -> size at the previous poll, until it stops growing (#261)
 
     try:
         while True:
             _time.sleep(3)
             current: set = set(find_files([incoming]))
-            new_files = current - known
-            if new_files:
-                n = len(new_files)
+            ready, pending_sizes = _poll_stable_files(current - known, pending_sizes)
+            if ready:
+                n = len(ready)
                 label = f"{n} file{'s' if n != 1 else ''}"
                 print(f"  {_BOLD}{label}{_RESET} detected — chewing...\n")
                 queued_before = _count_queued(vault)
-                run_ingest(vault)
+                run_ingest(vault, files=ready)
                 new_queued = _count_queued(vault) - queued_before
                 if new_queued > 0:
                     _notify(
@@ -827,7 +847,7 @@ def cmd_watch(args) -> None:
                     )
                 known = set()
             else:
-                known = current
+                known = current - set(pending_sizes)
     except KeyboardInterrupt:
         print(f"\n  {_DIM}Stopped watching.{_RESET}\n")
 

--- a/src/watchdog/pipeline/prompts.py
+++ b/src/watchdog/pipeline/prompts.py
@@ -112,8 +112,9 @@ def build_section_prompt(*, pages_text: str, existing_entities: list, skill_text
                         "date_of_document) and the morgue_entity_id field.")
         volatile.append(_known_types_block(known_document_types))
     else:
-        volatile.append("This is a LATER section: omit document metadata and morgue fields; supply "
-                        "entities + document.key_facts + document.summary for this section only.")
+        volatile.append("This is a LATER section: omit document metadata, morgue fields, and "
+                        "document.summary (only section 1's summary is kept); supply entities + "
+                        "document.key_facts for this section only.")
     volatile.append("Put only forward-looking reporting notes for the briefing in `observations` — "
                     "leads to chase, open questions, missing documents, threads to other sections or "
                     "documents. Do NOT restate figures, dates, chronology, or contradictions (those "

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -124,6 +124,34 @@ def test_count_incoming_not_fooled_by_failed_in_vault_path(tmp_path):
     assert cli._count_incoming(vault) == 1
 
 
+def test_count_incoming_excludes_skipped(tmp_path):
+    # A duplicate chew moves files to _SKIPPED/ — status must not count them as pending,
+    # or the user is sent in a status -> chew -> status loop chasing files chew already
+    # decided to skip (#255).
+    incoming = tmp_path / "_INCOMING"
+    skipped = incoming / "_SKIPPED"
+    skipped.mkdir(parents=True)
+    (incoming / "pending.pdf").write_text("")
+    (skipped / "duplicate.pdf").write_text("")
+    assert cli._count_incoming(tmp_path) == 1
+
+
+def test_count_incoming_matches_find_files_exclusions(tmp_path):
+    # _count_incoming (status) and find_files (chew) must exclude the same directories,
+    # or a file can be simultaneously "pending" per status and invisible to chew (#255).
+    from watchdog.pipeline.preprocess_batch import find_files, SKIP_DIRS
+
+    incoming = tmp_path / "_INCOMING"
+    for d in SKIP_DIRS:
+        skip_dir = incoming / d
+        skip_dir.mkdir(parents=True, exist_ok=True)  # case-insensitive filesystems collide _FAILED/_failed
+        (skip_dir / "file.pdf").write_text("")
+    (incoming / "pending.pdf").write_text("")
+
+    assert cli._count_incoming(tmp_path) == 1
+    assert len(find_files([incoming])) == 1
+
+
 # ── _load_registry ────────────────────────────────────────────────────────────
 
 def test_load_registry_missing(tmp_path):
@@ -1776,6 +1804,51 @@ def test_cmd_ingest_rejects_claude_batch_for_classifier_or_finalizer(wdg_home, t
         cmd_ingest(args(), confirm=False)
 
 
+def test_cmd_ingest_and_cmd_finalize_agree_on_finalizer_default(wdg_home, tmp_path, monkeypatch):
+    """An unconfigured vault must finalize on the same model whether ingest finishes the
+    batch itself or a separate `watchdog finalize` completes it (#253)."""
+    from watchdog.cmd import auth as auth_module
+    from watchdog.cmd import ingest as ing
+    from watchdog.pipeline import orchestrate as orch_module
+
+    vault = _vault_with_queued_doc(tmp_path)
+    monkeypatch.chdir(vault)
+    monkeypatch.setattr(auth_module, "resolve_auth", lambda: {"mode": "api-key", "key": "sk-x"})
+
+    finalizer_defaults = {}
+    orig_resolve = ing._resolve_stage
+
+    class _Stop(Exception):
+        pass
+
+    def _boom(*a, **k):
+        raise _Stop()
+
+    # cmd_ingest: skip past the pending-finalization prompt, stop right after model
+    # resolution (before the heavy ingest_setup/orchestrate pipeline runs).
+    monkeypatch.setattr(orch_module, "has_pending_finalization", lambda v: False)
+    calls = []
+    monkeypatch.setattr(ing, "_resolve_stage",
+                         lambda *a, **k: (calls.append((a, k)), orig_resolve(*a, **k))[1])
+    monkeypatch.setattr("watchdog.pipeline.ingest_setup.run", _boom)
+    with pytest.raises(_Stop):
+        ing.cmd_ingest(args(), confirm=False)
+    # Call order in cmd_ingest is extractor, finalizer, classifier.
+    _, finalizer_kwargs = calls[1]
+    finalizer_defaults["ingest"] = finalizer_kwargs.get("default")
+
+    # cmd_finalize: needs a pending finalization to proceed past its early-return guard.
+    calls.clear()
+    monkeypatch.setattr(orch_module, "has_pending_finalization", lambda v: True)
+    monkeypatch.setattr(ing, "_run_finalize", _boom)
+    with pytest.raises(_Stop):
+        ing.cmd_finalize(args())
+    _, finalizer_kwargs = calls[0]
+    finalizer_defaults["finalize"] = finalizer_kwargs.get("default")
+
+    assert finalizer_defaults["ingest"] == finalizer_defaults["finalize"] == "haiku"
+
+
 # ── configure sections + default_skill ────────────────────────────────────────
 
 def test_configure_sections_cover_every_key_exactly_once():
@@ -2308,6 +2381,45 @@ def test_read_batch_terms_skips_blank_lines_and_comments(tmp_path):
 def test_read_batch_terms_missing_file_exits(tmp_path):
     with pytest.raises(SystemExit):
         _vault._read_batch_terms(tmp_path / "missing.txt")
+
+
+# ── _poll_stable_files (watchdog watch mid-copy guard, #261) ───────────────────
+
+def test_poll_stable_files_holds_growing_file(tmp_path):
+    f = tmp_path / "big.pdf"
+    f.write_bytes(b"a" * 10)
+    ready, pending = _vault._poll_stable_files({f}, {})
+    assert ready == []
+    assert pending == {f: 10}
+
+
+def test_poll_stable_files_releases_file_once_size_holds(tmp_path):
+    f = tmp_path / "big.pdf"
+    f.write_bytes(b"a" * 10)
+    # First poll: no prior size recorded — held.
+    ready, pending = _vault._poll_stable_files({f}, {})
+    assert ready == []
+    # Second poll: same size as last time — copy finished.
+    ready, pending = _vault._poll_stable_files({f}, pending)
+    assert ready == [f]
+    assert pending == {}
+
+
+def test_poll_stable_files_keeps_holding_a_still_growing_file(tmp_path):
+    f = tmp_path / "big.pdf"
+    f.write_bytes(b"a" * 10)
+    ready, pending = _vault._poll_stable_files({f}, {})
+    f.write_bytes(b"a" * 20)   # more bytes copied in between polls
+    ready, pending = _vault._poll_stable_files({f}, pending)
+    assert ready == []
+    assert pending == {f: 20}
+
+
+def test_poll_stable_files_skips_file_removed_before_stat(tmp_path):
+    f = tmp_path / "gone.pdf"   # never created — simulates a race with deletion
+    ready, pending = _vault._poll_stable_files({f}, {})
+    assert ready == []
+    assert pending == {}
 
 
 def test_search_batch_reports_hits_and_no_hits(configured, monkeypatch, tmp_path, capsys):

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -58,6 +58,28 @@ def test_section_prompt_renders_label():
     assert "pp.1-10" in _flat(p) and "{{" not in _flat(p)
 
 
+def test_later_section_prompt_does_not_ask_for_summary():
+    # Only section 1's document.summary survives merge.merge_extractions (merge.py:69), so
+    # explicitly asking later sections for one pays for model output that's thrown away (#260).
+    # The shared instructions block still documents the field generically (also used by the
+    # first-section/whole-doc path) — what must be gone is the later-section instruction
+    # explicitly telling the model to supply one for that section.
+    p = prompts.build_section_prompt(
+        pages_text="x", existing_entities=[], skill_text="", carry_forward="",
+        section_label="pp.11-20", is_first=False, known_document_types=[])
+    text = _flat(p)
+    assert "document.summary for this section only" not in text
+    assert "LATER section" in text
+
+
+def test_first_section_prompt_still_fills_metadata():
+    p = prompts.build_section_prompt(
+        pages_text="x", existing_entities=[], skill_text="", carry_forward="",
+        section_label="pp.1-10", is_first=True, known_document_types=[])
+    text = _flat(p)
+    assert "morgue_entity_id" in text
+
+
 def test_extract_prompt_includes_instructions_and_data():
     p = prompts.build_extract_prompt(
         pages_text="DOCBODY", existing_entities=[{"id": "x"}], skill_text="SKILL",


### PR DESCRIPTION
Fixes #253, Fixes #255, Fixes #260, Fixes #261

Four small, independent production-review fixes bundled together since each is a one-to-few-line change:

- **#253**: `watchdog ingest` resolved `finalizer_model` with the wrong default (sonnet instead of haiku), diverging from `watchdog finalize` and from documented behavior. One-word fix, plus ARCHITECTURE/GETTING_STARTED doc corrections and a test asserting both commands agree on the default.
- **#255**: `watchdog status` counted files in `_INCOMING/_SKIPPED/` as pending, sending the user in a status → chew → status loop chasing files chew already decided to skip. `_count_incoming` now excludes `_SKIPPED` like `find_files` already does, plus a parity test between the two.
- **#260**: later sections of a sectioned extraction were asked for a `document.summary` that `merge.merge_extractions` always discards (only section 1's survives) — paid-for, wasted model output. Dropped the ask. Filed #279 as a follow-up: compose the summary once after merge instead of relying on section 1 alone, so it actually covers the whole document.
- **#261**: `watchdog watch` chewed files that were still being copied into `_INCOMING/`, risking a truncated-file hash/OCR. Newly-seen files now wait for their size to hold steady across two 3s polls before chewing (extracted into a small testable `_poll_stable_files` helper).

## Test plan
- [x] New/updated tests for all four fixes, each mutation-tested (broke the fix, confirmed red, restored)
- [x] Full suite: `pytest -q` → 1005 passed