### PR TITLE
Persist entity contradictions to the registry

### DIFF
--- a/src/watchdog/pipeline/write_vault.py
+++ b/src/watchdog/pipeline/write_vault.py
@@ -410,6 +410,7 @@ def _new_entity(entity: dict, doc_sha256: str) -> dict:
         "note_path":        f"entities/{_type_dir(entity['type'])}/{entity['id']}",
         "roles":            roles,
         "timeline_events":  events,
+        "contradictions":   [c.strip() for c in entity.get("contradictions") or [] if c.strip()],
         "date_first_seen":  _today(),
         "date_last_updated": _today(),
     }
@@ -443,6 +444,12 @@ def _merge_entity(existing: dict, incoming: dict, doc_sha256: str) -> None:
         incoming.get("timeline_events", []),
         doc_sha256,
     )
+
+    existing_contradictions = existing.setdefault("contradictions", [])
+    for callout in incoming.get("contradictions") or []:
+        callout = callout.strip()
+        if callout and callout not in existing_contradictions:
+            existing_contradictions.append(callout)
 
     existing["date_last_updated"] = _today()
 

--- a/tests/test_leads.py
+++ b/tests/test_leads.py
@@ -119,6 +119,34 @@ def test_total_and_empty():
     assert leads.total(leads.find_leads({})) == 0
 
 
+# ── writer -> sweep contract (#252) ──────────────────────────────────────────
+#
+# The tests above fabricate a registry entry with a hand-built "contradictions" key.
+# That masked a real bug: nothing in write_vault ever persisted that key, so the signal
+# could never fire against a real vault. This test drives the actual writer instead, to
+# prove entities.json really ends up in the shape find_leads expects.
+
+def test_write_vault_persists_contradictions_findable_by_leads(tmp_path):
+    from watchdog.pipeline import write_vault
+    from tests.test_write_vault import make_vault, make_extraction
+
+    vault = make_vault(tmp_path)
+    (vault / "_INCOMING" / "test-doc.pdf").write_text("dummy")
+    callout = "> [!contradiction] Address differs from prior filing"
+    overrides = {"entities": [{"id": "alice-smith", "name": "Alice Smith", "type": "Person",
+                               "contradictions": [callout]}]}
+
+    write_vault.run(make_extraction(tmp_path, overrides), vault)
+
+    entities_reg = json.loads(
+        (vault / ".watchdog" / "Registry" / "entities.json").read_text()
+    )
+    data = leads.find_leads(entities_reg)
+    assert len(data["contradictions"]) == 1
+    assert data["contradictions"][0]["id"] == "alice-smith"
+    assert data["contradictions"][0]["count"] == 1
+
+
 def test_dangling_without_target_name_falls_back_to_id():
     reg = {"x": {"id": "x", "name": "X", "type": "person", "appears_in": ["d1"],
                  "roles": [{"relationship": "Linked", "target_id": "ghost-123",

--- a/tests/test_write_vault.py
+++ b/tests/test_write_vault.py
@@ -480,6 +480,57 @@ def test_merge_deduplicates_roles(tmp_path):
     assert len(director_roles) == 1
 
 
+def test_new_entity_persists_contradictions_to_registry(tmp_path):
+    # #252: the registry entry must carry the contradiction callouts so leads.find_leads
+    # (which reads them straight from entities.json) isn't a structurally dead signal.
+    vault = make_vault(tmp_path)
+    (vault / "_INCOMING" / "test-doc.pdf").write_text("dummy")
+    callout = "> [!contradiction] Address differs from prior filing"
+    overrides = {"entities": [{"id": "alice-smith", "name": "Alice Smith", "type": "Person",
+                               "contradictions": [callout]}]}
+
+    run(make_extraction(tmp_path, overrides), vault)
+
+    entities = json.loads(
+        (vault / ".watchdog" / "Registry" / "entities.json").read_text()
+    )
+    assert entities["alice-smith"]["contradictions"] == [callout]
+
+
+def test_merge_deduplicates_contradictions(tmp_path):
+    vault = make_vault(tmp_path)
+    (vault / "_INCOMING" / "test-doc.pdf").write_text("dummy")
+
+    callout = "> [!contradiction] Address differs from prior filing"
+    existing_entities = {
+        "alice-smith": {
+            "id": "alice-smith",
+            "name": "Alice Smith",
+            "type": "Person",
+            "aliases": [],
+            "appears_in": ["prior-sha"],
+            "note_path": "entities/person/alice-smith",
+            "roles": [],
+            "contradictions": [callout],
+            "date_first_seen": "2024-01-01",
+            "date_last_updated": "2024-01-01",
+        }
+    }
+    (vault / ".watchdog" / "Registry" / "entities.json").write_text(
+        json.dumps(existing_entities)
+    )
+
+    new_callout = "> [!contradiction] Director count differs from prior filing"
+    overrides = {"entities": [{"id": "alice-smith", "name": "Alice Smith", "type": "Person",
+                               "contradictions": [callout, new_callout]}]}
+    run(make_extraction(tmp_path, overrides), vault)
+
+    entities = json.loads(
+        (vault / ".watchdog" / "Registry" / "entities.json").read_text()
+    )
+    assert entities["alice-smith"]["contradictions"] == [callout, new_callout]
+
+
 # ── Reverse relationship ──────────────────────────────────────────────────────
 
 def test_reverse_relationship_written_to_target(tmp_path):


### PR DESCRIPTION
Fixes #252

## Summary
`leads.find_leads` reads `ent.get("contradictions")` from the entity registry to power the "unresolved contradictions" lead signal, but nothing in `write_vault._new_entity`/`_merge_entity` ever wrote that key onto `entities.json` — contradiction callouts only ever landed in the note body's `## Contradictions` section, so this lead signal could structurally never fire.

`_new_entity`/`_merge_entity` now persist/dedupe the callouts onto the registry entry, matching the shape `find_leads` already expects.

## Test plan
- [x] `test_new_entity_persists_contradictions_to_registry`, `test_merge_deduplicates_contradictions` in `tests/test_write_vault.py`
- [x] `test_write_vault_persists_contradictions_findable_by_leads` in `tests/test_leads.py` — drives the real writer → sweep contract instead of a hand-fabricated fixture
- [x] Full suite: `pytest -q` → 999 passed
- [x] Mutation-tested: reverted the fix, confirmed all 3 new tests go red, restored