### PR TITLE
Clean up stale /watchdog-ingest strings that survived the D18 migration

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -562,7 +562,7 @@ Registry/
   usage-<ts>.json           per-run model-call token/cost telemetry (D50)
   batch-pending.json        pending claude-batch extraction state (D52)
   .ingest-lock / .write-lock  run lock / write serialization
-ingest-state.json           handoff from `watchdog ingest` to the skill
+ingest-state.json           present while a run is in progress; stale ⇒ interrupted ingest, resume with `watchdog ingest`
 ```
 
 **Why a manifest separate from `entities.json`.** Pre-flight needs only a small

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -377,7 +377,7 @@ After the first ingest, the typical workflow is:
 
 1. **Drop new documents** into `_INCOMING/`
 2. **`watchdog chew`** from the vault directory (or `watchdog watch <name>` to chew automatically as files arrive)
-3. **`watchdog ingest`** — opens Claude Code with extraction pre-loaded; Claude starts immediately
+3. **`watchdog ingest`** — extracts the queued documents in your terminal
 4. **Read the briefing** — pay particular attention to connections with entities already in the vault
 5. **`/watchdog-surface`** if the new batch was substantial
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -153,7 +153,7 @@ For a complete walkthrough of a first investigation from start to finish, see [G
 
 ## How to ingest documents
 
-Ingestion happens in two steps: chewing in your terminal, then extraction in Claude Code.
+Ingestion happens in two steps, both run from your terminal: chewing, then extraction.
 
 **Step 1 — Drop files and chew**
 

--- a/src/watchdog/cmd/base.py
+++ b/src/watchdog/cmd/base.py
@@ -597,7 +597,7 @@ def _print_banner() -> None:
         ("Document processing", [
             ("fetch",            "Download a batch of URLs into _INCOMING/"),
             ("chew",             "Process documents in _INCOMING/"),
-            ("ingest",           "Set up extraction session and open in Claude Code"),
+            ("ingest",           "Extract queued documents into the vault"),
             ("context",          "Seed investigation context from _CONTEXT/"),
             ("watch",            "Watch _INCOMING/ and chew files automatically"),
             ("log",              "Show ingest history"),

--- a/src/watchdog/cmd/vault.py
+++ b/src/watchdog/cmd/vault.py
@@ -372,7 +372,7 @@ def cmd_new(args) -> None:
                                         "from pathlib import Path; "
                                         "p = list(Path('.watchdog/queue').glob('*.json')) "
                                         "if Path('.watchdog/queue').exists() else []; "
-                                        "print('WATCHDOG: ' + str(len(p)) + ' file(s) ready for extraction — run /watchdog-ingest') if p else None"
+                                        "print('WATCHDOG: ' + str(len(p)) + ' file(s) ready for extraction — run watchdog ingest in your terminal') if p else None"
                                         "\""
                                     ),
                                 }
@@ -412,7 +412,7 @@ def cmd_new(args) -> None:
     print(f"    1. {_DIM}(optional){_RESET} Drop background material into {_CYAN}{vault}/_CONTEXT/{_RESET} and run {_CYAN}watchdog context{_RESET}")
     print(f"    2. Drop documents into {_CYAN}{vault}/_INCOMING/{_RESET}")
     print(f"    3. Run {_CYAN}watchdog chew{_RESET} to process documents")
-    print(f"    4. Run {_CYAN}watchdog ingest{_RESET} to set up extraction and open Claude Code")
+    print(f"    4. Run {_CYAN}watchdog ingest{_RESET} to extract the queued documents")
     print(f"    5. Run {_CYAN}watchdog obsidian {slug}{_RESET} to open the vault in Obsidian")
     print()
 
@@ -823,7 +823,7 @@ def cmd_watch(args) -> None:
                 if new_queued > 0:
                     _notify(
                         f"Watchdog — {info['name']}",
-                        f"Chewed {label}. {new_queued} file{'s' if new_queued != 1 else ''} ready for /watchdog-ingest.",
+                        f"Chewed {label}. {new_queued} file{'s' if new_queued != 1 else ''} ready — run watchdog ingest.",
                     )
                 known = set()
             else:
@@ -940,7 +940,7 @@ def cmd_status(args) -> None:
         if info.get("description"):
             print(f"  {_DIM}{info['description']}{_RESET}")
         print(f"  {_DIM}Created {_fmt_date(info.get('created_at', ''))}{_RESET}")
-        print(f"\n  {_DIM}No registry found — open this vault in Claude Code to begin ingesting.{_RESET}\n")
+        print(f"\n  {_DIM}No registry found — run {_RESET}{_CYAN}watchdog chew{_RESET}{_DIM} then {_RESET}{_CYAN}watchdog ingest{_RESET}{_DIM} to begin.{_RESET}\n")
         return
 
     docs_file = vault / ".watchdog" / "Registry" / "documents.json"
@@ -981,7 +981,7 @@ def cmd_status(args) -> None:
     if incoming_n:
         print(f"  {_YELLOW}{incoming_n} file{'s' if incoming_n != 1 else ''}{_RESET} in {_CYAN}_INCOMING/{_RESET} {_DIM}— run{_RESET} {_CYAN}watchdog chew{_RESET}")
     if queued_n:
-        print(f"  {_YELLOW}{queued_n} file{'s' if queued_n != 1 else ''}{_RESET} chewed and waiting for {_CYAN}/watchdog-ingest{_RESET}")
+        print(f"  {_YELLOW}{queued_n} file{'s' if queued_n != 1 else ''}{_RESET} chewed and waiting for {_CYAN}watchdog ingest{_RESET}")
     _warn_pending_research(vault)
 
     if orchestrate.has_pending_finalization(vault):

--- a/src/watchdog/pipeline/ingest_setup.py
+++ b/src/watchdog/pipeline/ingest_setup.py
@@ -1,19 +1,19 @@
 """
-watchdog ingest — human-facing setup step for the /watchdog-ingest skill.
+watchdog ingest — setup step for the Python ingest orchestrator (`pipeline/orchestrate.py`).
 
-Run from the vault root before opening Claude Code. Handles:
+Called from `cmd/ingest.py` before extraction runs. Handles:
   1. Stale lock detection (>30 min) and re-acquisition
   2. Queue directory scan
-  3. Writes .watchdog/ingest-state.json for the skill to read
+  3. Writes .watchdog/ingest-state.json (present for the run's duration; a stale one
+     signals an interrupted ingest to resume with `watchdog ingest`)
 
 Human workflow:
-  watchdog chew    →  watchdog ingest    →  open Claude Code  →  /watchdog-ingest
-  (OCR/docling)       (lock + queue)        (skill reads state file)
+  watchdog chew    →  watchdog ingest
+  (OCR/docling)       (lock + queue + extract, all in-terminal)
 """
 
 import json
 import shutil
-import sys
 import time
 from datetime import datetime, timezone
 from pathlib import Path
@@ -121,23 +121,3 @@ def run(vault: Path, extractor_model: str = "sonnet", finalizer_model: str = "so
     }
     state_file.write_text(json.dumps(state, ensure_ascii=False, indent=2), encoding="utf-8")
     return state
-
-
-def main() -> None:
-    vault = Path(".").resolve()
-    if not (vault / ".watchdog").is_dir():
-        sys.exit("Error: must be run from inside a Watchdog vault directory")
-    result = run(vault)
-    if "error" in result:
-        sys.exit(f"Error: {result['error']}")
-    if result["total"] == 0:
-        print("\n  Queue is empty — nothing to ingest.")
-        print("  Run watchdog chew to process documents in _INCOMING/ first.\n")
-        return
-    q = len(result["queue_files"])
-    print(f"\n  {q} document{'s' if q != 1 else ''} ready for extraction")
-    print("\n  Open Claude Code and run:  /watchdog-ingest\n")
-
-
-if __name__ == "__main__":
-    main()

--- a/src/watchdog/templates/vault/CLAUDE.md
+++ b/src/watchdog/templates/vault/CLAUDE.md
@@ -1,6 +1,6 @@
 # {name} — Watchdog
 
-At the start of every session: (1) read `hot.md` for a summary of recent activity and open questions; (2) read `context.md` to understand what this investigation is about; (3) check `.watchdog/ingest-state.json` — if it exists, files are queued and ready to extract; run `/watchdog-ingest` before doing anything else.
+At the start of every session: (1) read `hot.md` for a summary of recent activity and open questions; (2) read `context.md` to understand what this investigation is about; (3) check `.watchdog/ingest-state.json` — if it exists, an ingest is running or was interrupted; tell the user to run `watchdog ingest` in their terminal to resume it before doing anything else.
 
 
 ## Vault layout
@@ -65,8 +65,6 @@ The following are auto-allowed in `.claude/settings.json` — never ask for conf
 | Command | Action |
 |---------|--------|
 | `/watchdog-context` | Seed context.md from background files in `_CONTEXT/` |
-| `/watchdog-ingest` | Extract all preprocessed files in `.watchdog/queue/` |
-| `/watchdog-ingest [file]` | Preprocess and extract a specific file |
 | `/watchdog-query [question]` | Answer a question from the vault; file substantive answers to `queries/` |
 | `/watchdog-surface` | Find connections and anomalies across the vault |
 | `/watchdog-wiki` | Create or update investigation thread pages |


### PR DESCRIPTION
Fixes #256

## Summary
D18 moved ingest from a Claude Code skill (`/watchdog-ingest`) to a Python orchestrator, but a family of user-facing strings still described the old flow. The behavior-affecting one: `templates/vault/CLAUDE.md` told Claude, as a standing per-session instruction, to run `/watchdog-ingest` if an ingest looked interrupted — a command that no longer exists. Fixed that plus the accompanying copy in `cmd/base.py`, `cmd/vault.py`, `INSTALL.md`, `GETTING_STARTED.md`, and `ARCHITECTURE.md` §12.

Also removed the dead `ingest_setup.main()` code path (confirmed via grep it's never called — not by `cli.py`, not registered in `pyproject.toml`'s `[project.scripts]`, not referenced by any test) which still printed the same stale instruction.

Flagged but not touched (out of scope / owned by other in-flight fixes): `watchdog-health.md` and `watchdog-context.md` skill files also reference `/watchdog-ingest`; this repo's own top-level CLAUDE.md "Ingest workflow" section has the same drift.

## Test plan
- [x] Grepped `tests/` for the old strings before/after — zero hits either way, no test assertions needed updating
- [x] Full suite: `pytest -q` → 996 passed