### PR TITLE
Validate model-emitted morgue_entity_id and key_facts.date before filesystem use

### DIFF
--- a/src/watchdog/pipeline/orchestrate.py
+++ b/src/watchdog/pipeline/orchestrate.py
@@ -244,6 +244,10 @@ def _stamp_document(extraction: dict, *, sha: str, pf: dict, skill_label: str, v
     # morgue_document_type is just the slug form of document_type — derive it deterministically
     # rather than asking the model for the same fact twice (it names the morgue folder).
     extraction["morgue_document_type"] = slugify(doc.get("document_type") or "") or "document"
+    # morgue_entity_id is used raw as a morgue path segment (write_vault) — slugify the model's
+    # value here too, so a value with spaces or an embedded path separator (e.g. "Acme Corp" or
+    # "acme/subsidiary") can't produce a broken morgue directory layout or wikilinks.
+    extraction["morgue_entity_id"] = slugify(extraction.get("morgue_entity_id") or "")
 
 
 async def _classify(doc_excerpt: str, model: str, backend: str | None = None,

--- a/src/watchdog/pipeline/postflight.py
+++ b/src/watchdog/pipeline/postflight.py
@@ -11,10 +11,12 @@ Handles everything after Claude produces the extraction JSON:
 """
 
 import json
+import re
 import sys
 from pathlib import Path
 
 _VALID_BASIS = {"stated", "inferred"}
+_DATE_RE = re.compile(r"^\d{4}(-\d{2}(-\d{2})?)?$")
 
 
 def _validate(data: dict) -> list[str]:
@@ -79,6 +81,24 @@ def _apply_match_ids(extraction: dict) -> dict:
     return extraction
 
 
+def _sanitize_dates(extraction: dict) -> list[str]:
+    """Drop ``key_facts.date`` values that aren't ISO-shaped (``YYYY``, ``YYYY-MM``, or
+    ``YYYY-MM-DD``) before they can reach timeline.py's ``{date}_{sha7}.ndjson`` filename
+    construction — a value like ``"2024/03"`` or free text would otherwise produce a broken or
+    nested file write. Mutates ``key_facts`` in place; returns a warning per dropped date so the
+    loss is visible rather than silent."""
+    warnings: list[str] = []
+    for i, fact in enumerate(extraction.get("document", {}).get("key_facts", [])):
+        date = fact.get("date")
+        if date and not _DATE_RE.match(date):
+            warnings.append(
+                f"document.key_facts[{i}].date '{date}' is not ISO-shaped (YYYY, YYYY-MM, or "
+                "YYYY-MM-DD) — dropped from timeline placement"
+            )
+            fact["date"] = ""
+    return warnings
+
+
 def explode_key_facts(extraction: dict) -> None:
     """Reconstruct the per-entity views from the unified `key_facts` primitive (#140).
 
@@ -133,6 +153,12 @@ def run(vault: Path, extraction_path: Path, quiet: bool = False) -> dict:
         return {"errors": errors}
 
     extraction = _apply_match_ids(extraction)
+
+    # Drop non-ISO-shaped key_facts dates before they can reach explode_key_facts or
+    # timeline.py's filename construction — a malformed date is a visible warning, not a
+    # silent event loss.
+    for warning in _sanitize_dates(extraction):
+        print(f"Warning: {warning}", file=sys.stderr)
 
     # Fan the unified key_facts out into the per-entity evidence_fragments / timeline_events that
     # write_vault and timeline staging consume (#140).

--- a/tests/test_orchestrate.py
+++ b/tests/test_orchestrate.py
@@ -213,6 +213,26 @@ def test_stamp_document_morgue_type_falls_back_when_no_type(tmp_path):
     assert ext["morgue_document_type"] == "document"
 
 
+def test_stamp_document_slugifies_morgue_entity_id_with_spaces(tmp_path):
+    """morgue_entity_id is used raw as a morgue path segment (write_vault) — a model value with
+    spaces must be slugified so it doesn't produce a broken morgue directory (#262)."""
+    vault = make_vault(tmp_path)
+    pf = {"filename": "f.pdf", "original_path": None, "page_count": 1, "pages": [{}]}
+    ext = {"document": {}, "morgue_entity_id": "Acme Corp"}
+    orchestrate._stamp_document(ext, sha="s", pf=pf, skill_label="general-records", vault=vault)
+    assert ext["morgue_entity_id"] == "acme-corp"
+
+
+def test_stamp_document_slugifies_morgue_entity_id_with_embedded_slash(tmp_path):
+    """An embedded path separator (e.g. from the model nesting a subsidiary name) must not
+    survive into the morgue path segment (#262)."""
+    vault = make_vault(tmp_path)
+    pf = {"filename": "f.pdf", "original_path": None, "page_count": 1, "pages": [{}]}
+    ext = {"document": {}, "morgue_entity_id": "acme/subsidiary"}
+    orchestrate._stamp_document(ext, sha="s", pf=pf, skill_label="general-records", vault=vault)
+    assert "/" not in ext["morgue_entity_id"]
+
+
 def test_sidecar_provenance_parsed_in_python(tmp_path):
     """source/obtained come from the .yml sidecar (parsed in Python), not the model — and an
     unquoted ISO date is coerced back to a string rather than a date object."""

--- a/tests/test_postflight.py
+++ b/tests/test_postflight.py
@@ -1,7 +1,7 @@
 import json
 from pathlib import Path
 
-from watchdog.pipeline.postflight import _apply_match_ids, explode_key_facts
+from watchdog.pipeline.postflight import _apply_match_ids, _sanitize_dates, explode_key_facts
 from watchdog.pipeline.postflight import run as postflight_run
 
 
@@ -53,6 +53,39 @@ def test_explode_ignores_unknown_tags():
                   "entities": [{"id": "real", "name": "R", "type": "Person"}]}
     explode_key_facts(extraction)
     assert "evidence_fragments" not in extraction["entities"][0]
+
+
+# ── _sanitize_dates (#262: non-ISO dates must not reach timeline.py's filenames) ────────────
+
+def test_sanitize_dates_drops_non_iso_date_and_warns():
+    extraction = {"document": {"key_facts": [
+        {"fact": "x", "date": "2024/03", "entities": ["a"]},
+    ]}}
+    warnings = _sanitize_dates(extraction)
+    assert extraction["document"]["key_facts"][0]["date"] == ""
+    assert len(warnings) == 1
+    assert "2024/03" in warnings[0]
+
+
+def test_sanitize_dates_drops_free_text_date():
+    extraction = {"document": {"key_facts": [
+        {"fact": "x", "date": "sometime last year", "entities": ["a"]},
+    ]}}
+    warnings = _sanitize_dates(extraction)
+    assert extraction["document"]["key_facts"][0]["date"] == ""
+    assert len(warnings) == 1
+
+
+def test_sanitize_dates_keeps_valid_iso_shapes():
+    extraction = {"document": {"key_facts": [
+        {"fact": "a", "date": "2021", "entities": []},
+        {"fact": "b", "date": "2021-03", "entities": []},
+        {"fact": "c", "date": "2021-03-30", "entities": []},
+        {"fact": "d", "entities": []},   # no date at all — untouched
+    ]}}
+    assert _sanitize_dates(extraction) == []
+    dates = [f.get("date") for f in extraction["document"]["key_facts"]]
+    assert dates == ["2021", "2021-03", "2021-03-30", None]
 
 
 def test_apply_match_ids_remaps_key_fact_tags():
@@ -119,6 +152,27 @@ def test_postflight_builds_entity_analysis_from_tagged_facts(tmp_path):
     pbgf_note = (vault / "entities" / "fund" / "pbgf.md").read_text(encoding="utf-8")
     assert "Stayed a $842,018.34 payment." in pbgf_note
     assert "Transfer ratio set at 65.8%." not in pbgf_note  # not tagged to pbgf
+
+
+def test_postflight_run_drops_malformed_date_before_timeline_write(tmp_path, capsys):
+    """A non-ISO-shaped key_facts.date (#262) must not reach timeline.py's
+    {date}_{sha7}.ndjson filename construction — it's dropped with a visible warning instead."""
+    vault = _full_vault(tmp_path)
+    (vault / "_INCOMING" / "doc.pdf").write_text("pdf")
+    ext = _extraction()
+    ext["document"]["key_facts"][1]["date"] = "2024/03"   # bad shape: contains a slash
+    ext_path = vault / ".watchdog" / "tmp" / "wdg_ex_sha777aaa.json"
+    ext_path.write_text(json.dumps(ext), encoding="utf-8")
+
+    result = postflight_run(vault, ext_path)
+    assert result.get("ok"), result   # doesn't crash the whole extraction
+
+    timeline_dir = vault / ".watchdog" / "timeline"
+    ndjson_files = list(timeline_dir.glob("*.ndjson")) if timeline_dir.exists() else []
+    assert not any("2024" in f.name for f in ndjson_files)   # no file written for the bad date
+
+    err = capsys.readouterr().err
+    assert "Warning" in err and "2024/03" in err
 
 
 def test_postflight_writes_morgue_markdown(tmp_path):


### PR DESCRIPTION
Fixes #262

## Summary
Two model-emitted strings were used raw as filesystem path components with no shape validation:

- `morgue_entity_id` had no shape check and became a morgue path segment directly — a model emitting `"Acme Corp"` or `"acme/subsidiary"` would break the morgue layout and wikilinks. Now slugified in `orchestrate._stamp_document`, mirroring the existing treatment of its sibling field `morgue_document_type`.
- `key_facts.date` became a timeline filename (`{date}_{sha7}.ndjson`) with no validation — a value like `"2024/03"` or free text produced a nested/failed write, silently swallowed by post-flight's warning wrapper. Now validated against `^\d{4}(-\d{2}(-\d{2})?)?$` in `postflight.py`; a non-conforming date is dropped before it reaches the timeline, with a visible stderr warning rather than silent loss.

## Test plan
- [x] `tests/test_orchestrate.py` — `morgue_entity_id` with spaces/embedded slash comes out slugified
- [x] `tests/test_postflight.py` — `_sanitize_dates` unit tests, plus an end-to-end `postflight.run()` test confirming a malformed date never produces a timeline file and surfaces a warning
- [x] Full suite: `pytest -q` → 1002 passed