### PR TITLE
Faceted query filters: entity type / document type / date range (#111)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -672,7 +672,10 @@ completed purge, and the CLI hint says so.
   `watchdog-wiki`, `watchdog-health`, `watchdog-research` (§14). Ingest is the Python
   orchestrator (§5); it uses no Claude Code skill. `watchdog-query` reads the manifest/notes
   first but can shell out to `watchdog search --json` as a **semantic lane** for
-  conceptual/passage-level questions (§11, D44).
+  conceptual/passage-level questions (§11, D44). It also narrows by **facet** (entity type,
+  document type, date range) before reading notes, driven entirely off metadata already
+  captured at ingest — manifest `type`, document-note `document_type`/`date_of_document`
+  frontmatter, and `timeline.md`'s year grouping — no new index (#111).
 - **`claude-batch` — bulk extraction via the Message Batches API** (`pipeline/batch_extract.py`,
   D52): a fundamentally different flow from the other backends — submit-many/poll/collect over
   minutes-to-24h rather than one call per document — so it isn't in `model_client._ABACKENDS`

--- a/src/watchdog/skills/watchdog-query.md
+++ b/src/watchdog/skills/watchdog-query.md
@@ -15,8 +15,20 @@ Identify:
 - What time period, if any?
 - What kind of relationship or fact is being asked about?
 - Is this a lookup ("who is the director of X?"), a comparison ("which companies share address Y?"), a timeline ("when did Z first appear?"), or an analysis ("what's unusual about this transaction?")?
+- Does it name a **facet** to filter by: an entity type ("companies", "people"), a document type ("court filings", "annual reports"), or a date range ("in 2021")? See step 2 for how to apply these.
 
 ### 2. Gather evidence
+
+**Facets — narrow before you read.** If the question names a filter — an entity type ("which companies…"), a document type ("court filings", "annual reports"), or a date range ("in 2021", "between 2019 and 2022") — apply it before opening individual notes, using metadata already captured at ingest. No new lookups are needed, and facets combine (e.g. "companies named in court filings from 2021" narrows on all three):
+
+- **Entity type** — `Registry/manifest.json`'s `type` field (`Person`, `Company`, `Fund`, `Address`, …). Keep only matching entries before matching on name/alias in the manifest step below.
+- **Document type** — each document note's `document_type` frontmatter field. Grep across notes rather than opening each one:
+  ```bash
+  grep -l "^document_type: <type>" documents/*.md
+  ```
+- **Date range** — `timeline.md` is grouped under `## <year>` headings and already sorted chronologically; jump straight to the years in range instead of scanning the whole file. For a *document's* own date (as opposed to when the events in it took place), grep `date_of_document:` in document note frontmatter — the value is a quoted ISO date (e.g. `date_of_document: '2021-06-15'`) — and keep the notes whose date falls in the range.
+
+A facet narrows which notes you read, not what you conclude from them — read the narrowed set in full, and if you reach for the semantic lane below, restrict attention to hits whose `filename`/note falls in that narrowed set rather than re-filtering by hand.
 
 Read the relevant vault files. Prioritise in this order:
 


### PR DESCRIPTION
## Summary
- Adds facet-narrowing guidance to `/watchdog-query`: entity type, document type, and date range, driven entirely off metadata already captured at ingest — no new index or CLI flags for this first cut, matching the issue's own framing ("relatively cheap... mostly exposing metadata we already capture").
  - **Entity type** — filter `Registry/manifest.json`'s `type` field before matching name/alias.
  - **Document type** — grep each document note's `document_type` frontmatter (verified the YAML dump renders it unquoted, so `grep -l "^document_type: <type>"` works reliably).
  - **Date range** — `timeline.md`'s existing `## <year>` grouping for "when did X happen in the vault" questions, or `date_of_document` frontmatter (quoted ISO string) for a document's own date.
  - Facets compose with each other and with the existing natural-language/semantic-search flow.
- `ARCHITECTURE.md` §13 updated with a one-line mention of the new facet capability on `watchdog-query`.

No pipeline/code changes — this is a skill (prompt) file update, so there's nothing for `pytest` to newly cover; full suite (1072 tests) still passes to confirm no regressions.

Closes #111.

## Test plan
- [x] Verified `write_vault._frontmatter`'s YAML dump renders `document_type` unquoted and `date_of_document` as a quoted ISO string, matching the grep patterns the skill now documents
- [x] `PYTHONPATH=src pytest` — full suite passes (unaffected, no code changed)
- [ ] Manual: run `/watchdog-query` with a faceted question against a real vault (not done here — no live vault/model access in this session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)