### PR TITLE
Sweep doc/code mismatches from the 2026-07-05 production review

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Architecture
 
-Two files, split by how often they're read. **[ARCHITECTURE.md](ARCHITECTURE.md)** is the current-state map — how the pipeline is built, plus §14's **Invariants** (I1–I4), the canonical governing rules. Read it to orient; it's kept lean so it stays loadable every session. **[DECISIONS.md](DECISIONS.md)** is the dated, numbered history of specific decisions (D1, D2, …) — the rationale and tradeoff for each — read on demand when you need the *why* behind a past choice.
+Two files, split by how often they're read. **[ARCHITECTURE.md](ARCHITECTURE.md)** is the current-state map — how the pipeline is built, plus §15's **Invariants** (I1–I5), the canonical governing rules. Read it to orient; it's kept lean so it stays loadable every session. **[DECISIONS.md](DECISIONS.md)** is the dated, numbered history of specific decisions (D1, D2, …) — the rationale and tradeoff for each — read on demand when you need the *why* behind a past choice.
 
 **When a change alters the pipeline's structure, the split between deterministic code and the model, or the vault/registry layout, update `ARCHITECTURE.md` in the same change**, and append a `### D<n>` entry to `DECISIONS.md` (ascending order, newest last). If the change establishes or revises a governing rule, update the Invariants section in `ARCHITECTURE.md` too. **Keep decision entries concise** — a few sentences of rationale, then the tradeoff; the full record is in git and the PR, not the log. A decision earns an entry only if it forecloses a future option or would read as a bug without the rationale; pure refactors belong in the commit message. Treat both as part of the definition of done, like tests.
 

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -100,7 +100,7 @@ notes: Check the director change on page 12.
 
 This context is merged into the document record and preserved through ingest.
 
-**Near-duplicate detection is automatic.** Watchdog fingerprints every document using a hash of its content. If you drop in a document that's already been ingested — even renamed — it will be flagged as a duplicate and skipped.
+**Exact-duplicate detection is automatic.** Watchdog fingerprints every document using a hash of its content. If you drop in a document that's byte-identical to one already ingested — even renamed — it's set aside in `_INCOMING/_SKIPPED/` rather than processed again. A separate near-duplicate check (fuzzy content similarity, for documents that are similar but not byte-identical — a redlined revision, say) only flags a match for your review; it never skips the file.
 
 ---
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -110,8 +110,9 @@ This will:
 - Enable tab completion in your shell automatically
 - Offer to install the optional capture browser for full page snapshots (see [Full page snapshots](#full-page-snapshots-optional) below)
 - Download the ML models for document conversion and semantic search (one-time, may take a few minutes on a slow connection)
+- Ask how you want to authenticate with Claude
 
-It will ask two questions: where to store your projects, and whether to install the optional capture browser. Press Return to accept the projects default (`~/Investigations`), or type a different path; the capture browser defaults to no (type `y` to install it, an extra ~150 MB).
+It will ask three questions: where to store your projects, whether to install the optional capture browser, and how to authenticate with Claude. Press Return to accept the projects default (`~/Investigations`), or type a different path; the capture browser defaults to no (type `y` to install it, an extra ~150 MB); for authentication, choose your existing Claude Code subscription login (press Return) or a metered Claude API key.
 
 When setup finishes, reload your shell so the tab completion takes effect:
 

--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ For a full end-to-end walkthrough of a first investigation, see [GETTING_STARTED
 | `watchdog archive <name>` | Mark an investigation complete — hidden from `watchdog list` |
 | `watchdog unarchive <name>` | Restore an archived investigation |
 | `watchdog rename <name> <new-name>` | Rename an investigation — updates the folder, registry, and Obsidian entry |
+| `watchdog describe <name> ["text"]` | Set or update an investigation's description; omit text to be prompted |
 | `watchdog move <name> <path>` | Move vault to a new path and update the registry; if files are already at the new path, just updates the registry |
 | `watchdog delete <name>` | Remove from registry (vault files are left on disk); `--purge` also permanently deletes all vault files |
 | `watchdog register [path]` | Register an existing vault with watchdog; omit path when inside the vault directory |
@@ -243,6 +244,7 @@ Every ingest finalizes automatically at the end (entity synthesis + timeline + b
 | `watchdog resolve <id…>` | Acknowledge one or more leads, watch-word alerts, or contradiction callouts so the deterministic reports stop re-surfacing them. Run from inside the vault. Each report prints a copyable resolution id next to every item (e.g. `lead:isolated:acme`, `alert:ab12c34:…`, `contradiction:…`); pass those ids here. `--sync` instead imports any `- [x]` checkboxes you've ticked in the `briefings/` files; `--list` shows what's currently acknowledged. Pure Python, no model call — the acknowledgments live in `.watchdog/Registry/resolutions.json` and follow an entity through `watchdog merge-entities` |
 | `watchdog unresolve <id…>` | Bring acknowledged items back into the active list — the inverse of `watchdog resolve`. Run from inside the vault |
 | `watchdog merge-entities <keep-id> <merge-id>` | Fold a duplicate entity into another — fully deterministic, no model call. Run from inside the vault. Unions aliases, `appears_in`, roles, and timeline events onto `keep-id`; remaps every relationship anywhere in the registry that targeted `merge-id` (not just the two entities involved); concatenates the losing entity's `## Analysis` into the survivor's with provenance intact; and redirects the losing note to a short stub linking to the survivor. Prints both entities (name, type, document/relationship counts) and asks for confirmation before doing anything, since this is irreversible — anything other than `y`/`yes` cancels with no changes made; pass `--force` to skip the prompt. This is the fix for what the dashboard's "Possible duplicates" view and `/watchdog-health`'s near-duplicate check can only ever flag — run `watchdog reindex` afterward to drop the merged entity's stale search-index entries |
+| `watchdog timeline [name]` | Rebuild `timeline.md` from the canonical `.watchdog/timeline/` event files — fully deterministic, no model call. Omit the name when inside the project folder |
 | `watchdog reindex [name]` | Rebuild `.embeddings/` **and** `.fulltext/` from disk — no OCR re-run, no model calls. Reads the document/entity registries and the morgue's page-marked full text to rebuild every corpus passage/note vector and every full-text index row from scratch. Run it after changing `embed_model` in `watchdog configure`, instead of re-ingesting — the previous model's vectors aren't comparable to the new one's. (`rerank_model` needs no reindex: reranking runs fresh at query time and nothing about it is persisted, so a change takes effect on the next `watchdog search`.) Documents ingested before D26 (no morgue text on disk) are skipped and reported; their notes still reindex. Omit the name when inside the project folder |
 | `watchdog research [name]` | Open Claude Code to research the vault's open questions on the web. Seeded by the vault's entities, leads, and gaps, Claude conducts bounded web research and **queues the sources it finds**; when the session ends, watchdog downloads them into `_INCOMING/` (with egress hygiene — full rendered snapshots for HTML when Playwright is installed, sanitized plain fetch otherwise), so findings flow through the normal `chew → ingest` pipeline. Claude never writes vault notes directly, and skips sources the vault already has. `--question "<q>"` (or `-q`) seeds a question (omit to be prompted); `--model M` overrides the model. After download, run `watchdog chew` then `watchdog ingest`. If a session is interrupted before the download runs, the queued URLs are held durably and `watchdog`, `watchdog chew`, and `watchdog status` warn that they're still pending. Omit the name when inside the project folder |
 | `watchdog watchlist [name]` | Sweep **every already-ingested document** in the vault against the current `watchlist.md` — fully deterministic, no model call. The scan that runs automatically at the end of `watchdog ingest` only ever sees that run's documents, so a term added to the watchlist afterward never gets checked against the existing corpus; this command builds the same scan over the whole vault instead. Writes to the same `briefings/alerts-<date>.md` as the per-run scan (appending a new dated section if one exists). A term you've acknowledged for a document with `watchdog resolve` no longer re-reports on later scans. Omit the name when inside the project folder |
@@ -294,20 +296,25 @@ Each investigation is an independent Obsidian vault:
 ```
 my-investigation/
 ├── _INCOMING/              ← Drop public records here
-│   └── _FAILED/           ← Files that could not be processed
+│   ├── _FAILED/           ← Files that could not be processed
+│   └── _SKIPPED/          ← Exact duplicates and empty-text files, set aside
 ├── _CONTEXT/               ← Background material (prior stories, notes)
 ├── morgue/                 ← Original files after successful ingest, each beside
 │   └── <entity>/             a <name>.md of its full extracted text (greppable)
 │       └── <doc-type>/
 ├── .watchdog/
 │   ├── queue/             ← Extracted data awaiting ingest (.json per file)
+│   │   └── _failed/       ← Documents that failed extraction, held for `watchdog requeue`
 │   ├── staging/           ← Originals held during processing
+│   ├── research/          ← Queued web-research sources awaiting download into _INCOMING/
 │   └── Registry/          ← Internal state — do not edit manually
 │       ├── entities.json
 │       ├── documents.json
 │       ├── manifest.json  ← Lightweight entity lookup index
 │       ├── registry.json
-│       └── ingest.log
+│       ├── ingest.log
+│       ├── usage-<ts>.json    ← Per-run token/cost telemetry, kept for the last few runs
+│       └── batch-pending.json ← State for a batch left unfinalized by an interrupted ingest
 ├── entities/
 │   ├── person/            ← One note per person
 │   ├── company/           ← One note per company
@@ -316,8 +323,10 @@ my-investigation/
 ├── briefings/             ← Post-ingest briefing notes + watch-word alerts (alerts-<date>.md)
 ├── wiki/                  ← Investigation thread pages (matured angles)
 ├── queries/               ← Saved answers to questions you've asked (filed by /watchdog-query)
+├── .fulltext/             ← Full-text search index (index.db) — rebuild with `watchdog reindex`
 ├── hot.md                 ← Current session state — rewritten after every ingest
 ├── log.md                 ← Append-only human-readable ingest history
+├── timeline.md            ← Chronological event log, rebuilt from canonical timeline files
 ├── context.md             ← Your investigation intent and key questions
 ├── watchlist.md           ← Terms to watch for in new documents (one per line)
 ├── index.md               ← Landing page linking to the dashboard

--- a/src/watchdog/pipeline/abort.py
+++ b/src/watchdog/pipeline/abort.py
@@ -17,7 +17,7 @@ whose registry entry was rolled back. Those are self-healing — re-ingesting th
 document replaces its note and fragment contribution idempotently (keyed by doc-note /
 sha), and `watchdog reindex` rebuilds the indexes from the registry — so this command
 leaves them in place rather than half-deleting a note a journalist may have annotated.
-The source file stays in `_INCOMING/` (post-flight never moved it).
+The source file stays wherever `watchdog chew` already put it, in `.watchdog/staging/<sha256>/` — this command never touches it.
 
 Re-ingest later: move the queue file back —
   mv .watchdog/queue/_failed/<sha>.json .watchdog/queue/

--- a/src/watchdog/pipeline/entity_norm.py
+++ b/src/watchdog/pipeline/entity_norm.py
@@ -3,7 +3,7 @@ Canonical entity-name normalization.
 
 Shared by both duplicate-reconciliation paths so they collapse the same spelling
 variants to the same comparison key:
-  * write_vault — reconciling near-duplicate slugs coined by parallel subagents
+  * write_vault — reconciling near-duplicate slugs coined by concurrent extraction tasks
   * merge      — folding id drift across sections of one large document
 """
 

--- a/src/watchdog/pipeline/finalize_entity.py
+++ b/src/watchdog/pipeline/finalize_entity.py
@@ -2,19 +2,21 @@
 """
 Write a finalizer's synthesized prose into an entity note.
 
-Used by the post-ingest subagent after it reconciles an entity's per-document
-fragments. The shared ``apply_one`` writer replaces *only* the prose sections —
-## Summary and ## Analysis — leaving the append-only ## Contradictions log, the
+Used by post-ingest after it reconciles an entity's per-document fragments. The
+shared ``apply_one`` writer replaces *only* the prose sections — ## Summary and
+## Analysis — leaving the append-only ## Contradictions log, the
 deterministically-merged ## Timeline, ## Relationships, and the journalist
-## Notes untouched. It backs both the single-entity ``write-entity-synthesis``
-command (here) and the bulk ``apply-syntheses`` path (``synthesis_bundle.py``).
+## Notes untouched. It backs the bulk synthesis path (``synthesis_bundle.py``'s
+``apply_bundle``, called from `orchestrate.py`); this module's own ``main()``
+below is a standalone single-entity entry point (not wired into the `watchdog`
+CLI), runnable as ``python -m watchdog.pipeline.finalize_entity``.
 
 Unlike watchdog-write-entity (the /watchdog-entity full refresh, which also
 re-synthesizes the Timeline), this is a narrow prose-only write — it never reads
 or rewrites structured sections.
 
 Usage:
-    watchdog write-entity-synthesis --entity-id alice-smith --extraction .watchdog/tmp/wdg_synth-alice-smith.json [--vault .]
+    python -m watchdog.pipeline.finalize_entity --entity-id alice-smith --extraction .watchdog/tmp/wdg_synth-alice-smith.json [--vault .]
 
 Extraction JSON schema:
 {
@@ -54,8 +56,8 @@ def apply_one(
     registry once after applying every entity. Returns False if the entity is
     unknown (caller decides whether that is an error or a skip).
 
-    Shared by the single-entity write-entity-synthesis command and the bulk
-    apply-syntheses path.
+    Shared by this module's standalone single-entity entry point and the bulk
+    synthesis_bundle.apply_bundle path.
     """
     if entity_id not in entities_reg:
         return False

--- a/src/watchdog/pipeline/postflight.py
+++ b/src/watchdog/pipeline/postflight.py
@@ -194,8 +194,8 @@ def run(vault: Path, extraction_path: Path, quiet: bool = False) -> dict:
     except Exception as e:
         return {"errors": [str(e)]}
 
-    # Stage raw timeline NDJSON files (replaces the subagent's manual per-date
-    # writes). The vault is already written at this point, so a staging failure
+    # Stage raw timeline NDJSON files (replaces the pre-D18 subagent's manual
+    # per-date writes). The vault is already written at this point, so a staging failure
     # is reported as a warning rather than failing the whole extraction —
     # erroring here would trigger a retry and double-write the vault.
     try:

--- a/src/watchdog/pipeline/preflight.py
+++ b/src/watchdog/pipeline/preflight.py
@@ -1,9 +1,10 @@
 """
-Watchdog pre-flight — packages everything a subagent needs to extract a document.
+Watchdog pre-flight — packages everything the model needs to extract a document.
 
 Reads the queue file, runs entity candidate lookup against the manifest (substring
-match — no ML), and returns a single JSON blob. The subagent reads this output,
-does extraction reasoning, writes the extraction JSON, then calls post-flight.
+match — no ML), and returns a single JSON blob. The orchestrator sends this output
+to the model, which does extraction reasoning and returns the extraction JSON; the
+orchestrator then calls post-flight.
 """
 
 import json
@@ -73,7 +74,7 @@ def _digest_roles(roles: list[dict]) -> list[dict]:
 def _existing_analysis(vault: Path, note_path: str) -> str:
     """Return the existing '## Analysis' section of an entity note.
 
-    Supplied alongside the entity's prior contradictions so the subagent can run
+    Supplied alongside the entity's prior contradictions so the model can run
     the contradiction check without reading note files. Returns '' if the note or
     the section is absent.
     """
@@ -110,7 +111,7 @@ def run(vault: Path, sha256: str, *, alias_min_length: int | None = None) -> dic
     ).lower()
 
     # Full registry, read once — supplies each candidate's timeline/roles digest so
-    # the subagent can run the contradiction check without reading note files.
+    # the model can run the contradiction check without reading note files.
     entities_reg: dict = {}
     entities_file = vault / ".watchdog" / "Registry" / "entities.json"
     if entities_file.exists():
@@ -139,7 +140,7 @@ def run(vault: Path, sha256: str, *, alias_min_length: int | None = None) -> dic
                     "type": entry.get("type", ""),
                     "aliases": entry.get("aliases", []),
                     "note_path": note_path,
-                    # Carried forward so the subagent revises rather than clobbers.
+                    # Carried forward so the model revises rather than clobbers.
                     "summary": _extract_summary(vault / f"{note_path}.md") if note_path else None,
                     "timeline_events": _digest_events(reg.get("timeline_events", [])),
                     "roles": _digest_roles(reg.get("roles", [])),

--- a/src/watchdog/pipeline/section.py
+++ b/src/watchdog/pipeline/section.py
@@ -2,7 +2,7 @@
 Watchdog section planner — split a large queued document into sections for
 sectioned (sequential) extraction.
 
-Large documents don't fit comfortably in one extraction subagent's context, and
+Large documents don't fit comfortably in one extraction call's context, and
 the cost of a single huge context grows with its size. This splits a document
 into overlapping sections of roughly `section_token_budget` estimated tokens
 each. The orchestrator extracts the sections in reading order, carrying a

--- a/src/watchdog/pipeline/synthesis_bundle.py
+++ b/src/watchdog/pipeline/synthesis_bundle.py
@@ -2,21 +2,14 @@
 """
 Build the entity-synthesis bundle and bulk-apply synthesized prose.
 
-Phase-1 cost reduction (issue #87/#80 follow-up): instead of launching one
-subagent per multi-mention entity — each re-reading its fragment file and note,
-paying startup + preamble cache-write overhead — Python gathers every
-``count >= 2`` entity's fragments and current prose into a single bundle for one
-post-ingest model call, then bulk-applies the returned prose deterministically.
-
-Commands:
-    watchdog build-synthesis-bundle [--vault .] [--out PATH]
-        Reads .watchdog/tmp/entity-fragments/_queue.json and writes one bundle
-        JSON describing the entities to synthesize. Prints the entity count.
-
-    watchdog apply-syntheses --bundle PATH [--vault .]
-        Reads the model's synthesis result JSON and writes ## Summary / ## Analysis
-        for each entity, leaving all other sections untouched. Unknown entity ids
-        and empty summaries are skipped, never written.
+Phase-1 cost reduction (issue #87/#80 follow-up, superseded by #140/D26's
+recurrence-gated synthesis): instead of one model call per multi-mention entity —
+each re-reading its fragment file and note, paying startup + preamble cache-write
+overhead — Python gathers every entity that recurs project-wide (``appears_in``
+count in the registry meets ``min_docs``, not this batch's mention count) into a
+single bundle for one post-ingest model call, then bulk-applies the returned prose
+deterministically. Called from `orchestrate.py` as library functions
+(`build_bundle` / `apply_bundle`); there is no standalone `watchdog` subcommand.
 """
 
 import json

--- a/src/watchdog/pipeline/timeline.py
+++ b/src/watchdog/pipeline/timeline.py
@@ -6,7 +6,7 @@ rebuild-timeline     Read all canonical {date}.ndjson files; render timeline.md.
 
 File naming convention in .watchdog/timeline/:
   {date}.ndjson             — canonical (orchestrator-maintained, deduplicated)
-  {date}_{sha256[:7]}.ndjson — raw subagent output; always written by subagents
+  {date}_{sha256[:7]}.ndjson — raw per-document output; always written by the extraction task
 
 Canonical files have no underscore in the stem (dates use hyphens only).
 """

--- a/src/watchdog/pipeline/write_vault.py
+++ b/src/watchdog/pipeline/write_vault.py
@@ -109,11 +109,11 @@ def _reconcile_entity_ids(incoming_entities: list[dict], entities_reg: dict) -> 
     """
     Remap incoming entities that name an existing entity under a different slug.
 
-    Subagents extract in parallel from a pre-flight snapshot taken at launch, so two
+    Documents extract in parallel from a pre-flight snapshot taken at launch, so two
     documents referencing the same real-world entity can coin different ids (e.g.
     'ernst-and-young-inc' vs 'ernst-young-inc'). write_vault runs inside the registry
     lock with a fresh read of entities_reg — the one place that sees entities written
-    by sibling subagents earlier in the batch — so we reconcile here: any incoming
+    by concurrent extraction tasks earlier in the batch — so we reconcile here: any incoming
     *new* entity whose normalized (name, type) matches an existing one is remapped to
     that existing id, routing it through the merge path instead of creating a duplicate.
     """
@@ -816,7 +816,7 @@ def run(extraction_path: Path, vault_path: Path, neardup_file: Path | None = Non
 
         # ── 1. Update entity registry ─────────────────────────────────────────
 
-        # Reconcile near-duplicate slugs coined by parallel subagents before merging.
+        # Reconcile near-duplicate slugs coined by concurrent extraction tasks before merging.
         _reconcile_entity_ids(incoming_entities, entities_reg)
         # Roles arrive as target_id only; re-inflate target_name/target_type deterministically.
         _resolve_role_targets(incoming_entities, entities_reg)


### PR DESCRIPTION
## Summary
Closes #264 — the remaining doc/code mismatch items not already covered by their own issue (#253/#254/#256/#258/#259, all now merged):

- `CLAUDE.md`: "§14's Invariants (I1–I4)" → "§15's Invariants (I1–I5)"
- `INSTALL.md`: setup asks **three** questions (projects dir, capture browser, auth mode), not two
- `README.md` vault-structure tree: added `_INCOMING/_SKIPPED/`, `.watchdog/queue/_failed/`, `.watchdog/research/`, `.fulltext/`, `timeline.md`, `Registry/usage-<ts>.json`, `Registry/batch-pending.json`
- `README.md`: documented previously-undocumented `watchdog describe` and `watchdog timeline` commands
- `GETTING_STARTED.md`: separated the exact-duplicate skip (sha match → `_SKIPPED/`) from the near-duplicate MinHash check (flag-only, never skipped) — the original wording conflated the two
- Pre-D18 "subagent" vocabulary and stale/nonexistent `watchdog` subcommand references cleaned up in `abort.py`, `preflight.py`, `write_vault.py`, `timeline.py`, `postflight.py`, `section.py`, `finalize_entity.py`, `entity_norm.py`, `synthesis_bundle.py` — these are all comments/docstrings, no behavior change

**Checked and left as-is** (recorded here so #264 doesn't get re-litigated):
- `base.py` vs `model_client.py`'s two different Haiku model ids — not a duplication bug. `base.py`'s `_MODEL_IDS` feeds `claude --model <id>` (the Claude Code CLI, introduced deliberately as "full-id" per the original commit), while `model_client.py`'s feeds the direct Anthropic API client and is pinned by an existing test (`test_model_client.py`). Different consumers, different valid id formats — unifying them risked breaking one call site for no benefit.
- README's Windows Requirements vs. Alpha-limitations tension — already reconciled by #258's merged PR.

## Test plan
- [x] `~/.local/pipx/venvs/watchdog-intel/bin/pytest` — 1072 passed (docstring/comment/doc-only changes, no behavior touched)