### PR TITLE
Pricing fidelity: OpenAI rates + DeepSeek cache-hit (#170 item 2)

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -602,3 +602,11 @@ Resolved by deriving both defaults from the extraction model context window inst
 Removed the key, its Docling toggle (export is now always `PLACEHOLDER` → `[image]`), the guided-setup membership, the docs row/prose, and the test reference. Image-as-evidence is handled properly by #183's on-demand page rasterization to a vision model, which sends a real image block — the approach that embedding-everything-as-text could never be.
 
 **Tradeoff:** a user who had turned `embed_images` on loses a setting, but it was delivering no vision to begin with, so there is no capability regression — only a smaller, honest config surface and lower token cost. The one real image-as-evidence path is deferred to #183.
+
+### D91 — Non-Claude pricing fidelity: OpenAI rates populated and cache-hit input modelled (issue #170)
+
+`_OPENAI_PRICING` was output-approximate: it held only DeepSeek's cache-*miss* input rate (so a cache hit was over-charged) and no OpenAI rates at all (so cost reported `None` for every OpenAI run). Both are needed before a non-Claude backend can be defaulted to with honest cost reporting.
+
+Widened the table entries from `(input, output)` to `(input, output, cached_input)` and added the GPT-5 family standard rates alongside DeepSeek V4. `_openai_cost` now splits `prompt_tokens` into cached vs uncached from the provider's usage fields — OpenAI nests the count under `prompt_tokens_details.cached_tokens`, DeepSeek reports `prompt_cache_hit_tokens` (with `prompt_tokens` = hit + miss) — and prices each portion at its own rate. A model with no published cache rate repeats its input rate (no discount), so the split is always safe to apply.
+
+**Tradeoff:** the hard-coded rate tables now cover two vendors' fast-moving model lineups and will drift as prices change — accepted as a small, centrally-commented table with source links, matching the existing Claude `_PRICING` approach; an unlisted id still degrades to `None` cost rather than raising, so drift is a stale figure, never a crash.

--- a/src/watchdog/model_client.py
+++ b/src/watchdog/model_client.py
@@ -370,22 +370,50 @@ async def _api_complete_async(prompt: str | list[dict], model_id: str, schema: d
     return {"text": text, "usage": usage_dict, "cost_usd": _api_cost(model_id, usage)}
 
 
-# OpenAI-compatible (Chat Completions) pricing: model id → (input $/tok, output $/tok).
-# DeepSeek figures are the cache-miss input rate; cache-hit input discounts are not modelled yet
-# (a v1 simplification), so cost is a slight over-estimate when prompts hit cache. Verify against
-# the provider before relying on absolute figures: https://api-docs.deepseek.com/quick_start/pricing
+# OpenAI-compatible (Chat Completions) pricing: model id → (input, output, cached_input) $/tok.
+# `input` is the cache-MISS input rate; `cached_input` is the discounted rate applied to the part
+# of the prompt served from the provider's context cache. `_openai_cost` splits prompt tokens into
+# cached vs uncached from the provider's usage fields (OpenAI nests the count under
+# `prompt_tokens_details.cached_tokens`; DeepSeek reports `prompt_cache_hit_tokens`), so a cache hit
+# is priced at the lower rate rather than over-charged. Models with no published cache rate repeat
+# the input rate (no discount). Verify against the providers before relying on absolute figures:
+#   OpenAI:   https://developers.openai.com/api/docs/pricing
+#   DeepSeek: https://api-docs.deepseek.com/quick_start/pricing
 _OPENAI_PRICING = {
-    "deepseek-v4-flash": (0.14e-6,  0.28e-6),
-    "deepseek-v4-pro":   (0.435e-6, 0.87e-6),
+    # DeepSeek V4 (1M-token window; cache-hit input is a ~50x discount on the miss rate)
+    "deepseek-v4-flash": (0.14e-6,  0.28e-6,  0.0028e-6),
+    "deepseek-v4-pro":   (0.435e-6, 0.87e-6,  0.003625e-6),
+    # OpenAI GPT-5 family, standard tier (the -pro models publish no cache rate → no discount)
+    "gpt-5.5":           (5e-6,     30e-6,    0.50e-6),
+    "gpt-5.5-pro":       (30e-6,    180e-6,   30e-6),
+    "gpt-5.4":           (2.5e-6,   15e-6,    0.25e-6),
+    "gpt-5.4-mini":      (0.75e-6,  4.5e-6,   0.075e-6),
+    "gpt-5.4-nano":      (0.20e-6,  1.25e-6,  0.02e-6),
+    "gpt-5.4-pro":       (30e-6,    180e-6,   30e-6),
 }
+
+
+def _cached_input_tokens(usage: dict) -> int:
+    """Prompt tokens served from the provider's context cache, normalised across usage shapes.
+    OpenAI nests the count under `prompt_tokens_details.cached_tokens`; DeepSeek reports it as
+    `prompt_cache_hit_tokens` (with `prompt_tokens` = hit + miss). Absent either field, treat it
+    as no cache hit."""
+    details = usage.get("prompt_tokens_details") or {}
+    cached = details.get("cached_tokens")
+    if cached is None:
+        cached = usage.get("prompt_cache_hit_tokens")
+    return cached or 0
 
 
 def _openai_cost(model_id: str, usage: dict | None) -> float | None:
     rates = _OPENAI_PRICING.get(model_id)
     if not rates or not usage:
         return None
-    inp, outp = rates
-    return ((usage.get("prompt_tokens", 0) or 0) * inp
+    inp, outp, cached_rate = rates
+    prompt = usage.get("prompt_tokens", 0) or 0
+    cached = min(_cached_input_tokens(usage), prompt)   # cache hits are a subset of prompt tokens
+    return ((prompt - cached) * inp
+            + cached * cached_rate
             + (usage.get("completion_tokens", 0) or 0) * outp)
 
 

--- a/tests/test_model_client.py
+++ b/tests/test_model_client.py
@@ -249,6 +249,29 @@ def test_openai_cost():
     assert mc._openai_cost("deepseek-v4-flash", None) is None
 
 
+def test_openai_cost_prices_openai_models():
+    # gpt-5.4 standard: $2.50/1M input, $15/1M output.
+    assert mc._openai_cost("gpt-5.4",
+                           {"prompt_tokens": 1_000_000, "completion_tokens": 1_000_000}) \
+        == pytest.approx(2.5 + 15)
+
+
+def test_openai_cost_deepseek_cache_hit():
+    # DeepSeek reports prompt_tokens = hit + miss; the hit portion is priced at the cheap rate.
+    cost = mc._openai_cost("deepseek-v4-flash",
+                           {"prompt_tokens": 1_000_000, "completion_tokens": 0,
+                            "prompt_cache_hit_tokens": 900_000, "prompt_cache_miss_tokens": 100_000})
+    assert cost == pytest.approx(100_000 * 0.14e-6 + 900_000 * 0.0028e-6)
+
+
+def test_openai_cost_openai_cache_hit():
+    # OpenAI nests the cached count under prompt_tokens_details; it is a subset of prompt_tokens.
+    cost = mc._openai_cost("gpt-5.4",
+                           {"prompt_tokens": 1_000_000, "completion_tokens": 0,
+                            "prompt_tokens_details": {"cached_tokens": 400_000}})
+    assert cost == pytest.approx(600_000 * 2.5e-6 + 400_000 * 0.25e-6)
+
+
 def test_openai_backend_request_shape(monkeypatch):
     import httpx
     captured = {}


### PR DESCRIPTION
Item 2 of #170. Makes non-Claude cost reporting honest before a non-Claude backend can be defaulted to.

**Before**
- `_OPENAI_PRICING` held only DeepSeek's cache-*miss* input rate → cache hits over-charged.
- No OpenAI rates → `cost_usd` was `None` for every OpenAI run.

**Change**
- Widened entries `(input, output)` → `(input, output, cached_input)`.
- Added GPT-5 family standard rates (gpt-5.5, gpt-5.5-pro, gpt-5.4, -mini, -nano, -pro) from the [official pricing page](https://developers.openai.com/api/docs/pricing).
- Refreshed DeepSeek V4-flash/pro cache-hit rates from [DeepSeek pricing](https://api-docs.deepseek.com/quick_start/pricing).
- `_openai_cost` splits `prompt_tokens` into cached vs uncached from each provider's usage fields (OpenAI `prompt_tokens_details.cached_tokens`; DeepSeek `prompt_cache_hit_tokens`) and prices each portion separately. Models with no cache rate repeat the input rate (no discount).

Unlisted ids still return `None` cost (unchanged, graceful). DECISIONS D91. Full suite: 1182 passed.

Remaining #170 item 3 (request-shape: reasoning-capability table + `max_completion_tokens`) ships separately. Item 1 (Claude fallback) is being dropped by decision — re-routing a flaky provider is a one-line config change and a fallback risks masking quality problems.