### PR TITLE
OpenAI request-shape: capability table + max_completion_tokens (#170 item 3)

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -610,3 +610,11 @@ Removed the key, its Docling toggle (export is now always `PLACEHOLDER` → `[im
 Widened the table entries from `(input, output)` to `(input, output, cached_input)` and added the GPT-5 family standard rates alongside DeepSeek V4. `_openai_cost` now splits `prompt_tokens` into cached vs uncached from the provider's usage fields — OpenAI nests the count under `prompt_tokens_details.cached_tokens`, DeepSeek reports `prompt_cache_hit_tokens` (with `prompt_tokens` = hit + miss) — and prices each portion at its own rate. A model with no published cache rate repeats its input rate (no discount), so the split is always safe to apply.
 
 **Tradeoff:** the hard-coded rate tables now cover two vendors' fast-moving model lineups and will drift as prices change — accepted as a small, centrally-commented table with source links, matching the existing Claude `_PRICING` approach; an unlisted id still degrades to `None` cost rather than raising, so drift is a stale figure, never a crash.
+
+### D92 — OpenAI request-shape: explicit capability table replaces the substring reasoning heuristic (issue #170)
+
+Reasoning-model detection was a substring tuple (`gpt-5`/`o1`/`o3`/`o4`/`reasoner`) consulted only to decide whether to send `reasoning_effort`. It was fragile (a coincidental substring, not an intent) and, worse, it did not govern the token field: the client always sent `max_tokens`, which OpenAI *reasoning* models reject — they require `max_completion_tokens`.
+
+Replaced it with a single explicit `_OPENAI_MODEL_CAPS` prefix table (`gpt-5`/`o1`/`o3`/`o4` reason; `gpt-4`/`chatgpt` chat) behind `_openai_is_reasoning`, and routed **both** decisions through it: reasoning models get `reasoning_effort` **and** `max_completion_tokens`; chat models and DeepSeek (classic wire format) get `max_tokens`. The two can no longer drift apart. An id matching nothing is treated as a chat model.
+
+**Tradeoff:** an unlisted id defaults to chat, so a brand-new OpenAI reasoning model is silently denied effort until it is added to the table. Chosen over the reverse (guess reasoning) because the failure modes are asymmetric: a denied effort is a quality/perf miss, while sending `reasoning_effort`/`max_completion_tokens` to a chat model — or `max_tokens` to a reasoning model — is a hard 400. Correctness-safe by default; effort is opt-in per known family.

--- a/src/watchdog/model_client.py
+++ b/src/watchdog/model_client.py
@@ -76,9 +76,34 @@ _SYSTEM_PROMPT = (
 _EFFORT_LEVELS = ("low", "medium", "high")
 # Claude models that reject `output_config.effort` with a 400 (Haiku-tier).
 _EFFORT_UNSUPPORTED = {"claude-haiku-4-5"}
-# OpenAI-compatible models that accept `reasoning_effort` (substring match on the id). A chat
-# model 400s on it, so the knob is dropped for anything not matching.
-_OPENAI_REASONING_MARKERS = ("reasoner", "gpt-5", "o1", "o3", "o4")
+# OpenAI-provider model capabilities (#170). A *reasoning* model accepts `reasoning_effort` and
+# requires the newer `max_completion_tokens` field — it 400s on `max_tokens`; a *chat* model is the
+# exact reverse. Both decisions flow from this one table so they can't drift apart. Keyed by model-id
+# prefix, most specific first: declare a family once (`gpt-5`, `o3`) and put any chat exception above
+# its family. An id matching nothing is treated as a chat model — the correctness-safe default that
+# never sends an unsupported param; a genuinely new reasoning model is added here to earn effort,
+# rather than being guessed at from a substring. (DeepSeek is not consulted here: its thinking is a
+# separate per-request toggle, and it uses the classic `max_tokens` field — see `_openai_complete_async`.)
+_OPENAI_MODEL_CAPS: tuple[tuple[str, bool], ...] = (
+    ("gpt-4",   False),   # gpt-4o / gpt-4.1 / gpt-4-turbo — chat
+    ("chatgpt", False),   # chat-latest — chat
+    ("gpt-5",   True),    # entire GPT-5 family reasons
+    ("o1",      True),
+    ("o3",      True),
+    ("o4",      True),
+)
+
+
+def _openai_is_reasoning(model_id: str) -> bool:
+    """Whether an OpenAI model is a reasoning model — accepts `reasoning_effort` and needs
+    `max_completion_tokens` (rejecting `max_tokens`). Chat models are the reverse. Resolved from the
+    explicit `_OPENAI_MODEL_CAPS` table (most-specific prefix first); an unlisted id is treated as a
+    chat model, the safe default that never sends an unsupported param."""
+    mid = model_id.lower()
+    for prefix, reasoning in _OPENAI_MODEL_CAPS:
+        if mid.startswith(prefix):
+            return reasoning
+    return False
 
 
 def _claude_effort(model_id: str, effort: str) -> str | None:
@@ -91,8 +116,7 @@ def _claude_effort(model_id: str, effort: str) -> str | None:
 def _openai_effort(model_id: str, effort: str) -> str | None:
     """OpenAI-compatible: `reasoning_effort` is accepted only by reasoning models — drop it
     elsewhere. Unlike Claude, `high` is not the default, so it is passed through."""
-    mid = model_id.lower()
-    return effort if any(m in mid for m in _OPENAI_REASONING_MARKERS) else None
+    return effort if _openai_is_reasoning(model_id) else None
 
 
 def _no_effort(model_id: str, effort: str) -> str | None:
@@ -460,7 +484,6 @@ async def _openai_complete_async(prompt: str | list[dict], model_id: str, schema
 
     body = {
         "model": model_id,
-        "max_tokens": max_tokens,
         "response_format": {"type": "json_object"},   # "JSON" must appear in the prompt below
         "messages": [
             {"role": "system", "content": _SYSTEM_PROMPT},
@@ -468,6 +491,12 @@ async def _openai_complete_async(prompt: str | list[dict], model_id: str, schema
              "content": f"{_flatten_prompt(prompt)}\n\nReturn JSON matching this schema:\n{json.dumps(schema)}"},
         ],
     }
+    # OpenAI reasoning models reject `max_tokens` and require `max_completion_tokens`; chat models
+    # and DeepSeek (classic wire format) take `max_tokens`. Driven by the one capability table.
+    if not is_deepseek and _openai_is_reasoning(model_id):
+        body["max_completion_tokens"] = max_tokens
+    else:
+        body["max_tokens"] = max_tokens
     if effort:
         body["reasoning_effort"] = effort
     if thinking is not None:   # DeepSeek: pin the mode explicitly (provider defaults to enabled)

--- a/tests/test_model_client.py
+++ b/tests/test_model_client.py
@@ -363,6 +363,46 @@ def test_openai_backend_no_thinking_param(monkeypatch):
     assert "thinking" not in captured["body"]
 
 
+@pytest.mark.parametrize("model_id, reasoning", [
+    ("gpt-5", True), ("gpt-5-mini", True), ("gpt-5.4", True), ("gpt-5.5-pro", True),
+    ("o1", True), ("o3-mini", True), ("o4-mini", True),
+    ("gpt-4o", False), ("gpt-4.1", False), ("chatgpt-4o-latest", False),
+    ("some-new-model", False),   # unlisted → chat, the safe default (never sends an unsupported param)
+])
+def test_openai_is_reasoning(model_id, reasoning):
+    assert mc._openai_is_reasoning(model_id) is reasoning
+
+
+def test_openai_reasoning_model_uses_max_completion_tokens(monkeypatch):
+    # OpenAI reasoning models reject max_tokens → send max_completion_tokens instead.
+    captured = {}
+    _fake_httpx(monkeypatch, captured)
+    asyncio.run(mc._openai_complete_async("p", "gpt-5-mini", SCHEMA, "sk-o", 8000,
+                                          base_url="https://api.openai.com/v1"))
+    assert captured["body"]["max_completion_tokens"] == 8000
+    assert "max_tokens" not in captured["body"]
+
+
+def test_openai_chat_model_uses_max_tokens(monkeypatch):
+    # A chat model takes the classic max_tokens field.
+    captured = {}
+    _fake_httpx(monkeypatch, captured)
+    asyncio.run(mc._openai_complete_async("p", "gpt-4o", SCHEMA, "sk-o", 8000,
+                                          base_url="https://api.openai.com/v1"))
+    assert captured["body"]["max_tokens"] == 8000
+    assert "max_completion_tokens" not in captured["body"]
+
+
+def test_deepseek_uses_max_tokens(monkeypatch):
+    # DeepSeek speaks the classic wire format regardless of thinking mode → max_tokens.
+    captured = {}
+    _fake_httpx(monkeypatch, captured)
+    asyncio.run(mc._openai_complete_async("p", "deepseek-v4-flash", SCHEMA, "sk-ds", 8000,
+                                          base_url="https://api.deepseek.com"))
+    assert captured["body"]["max_tokens"] == 8000
+    assert "max_completion_tokens" not in captured["body"]
+
+
 # ── JSON extraction ───────────────────────────────────────────────────────────
 
 @pytest.mark.parametrize("text,expected", [


### PR DESCRIPTION
Item 3 of #170 (from PR #169 review notes).

**Two coupled gaps**
1. Reasoning-model detection was a substring tuple (`gpt-5`/`o1`/`o3`/`o4`/`reasoner`) — fragile, and it gated only `reasoning_effort`.
2. The client always sent `max_tokens`. Fine for DeepSeek and OpenAI *chat* models, but OpenAI *reasoning* models reject it — they require `max_completion_tokens`.

**Change**
- New explicit `_OPENAI_MODEL_CAPS` prefix table behind `_openai_is_reasoning` (`gpt-5`/`o1`/`o3`/`o4` reason; `gpt-4`/`chatgpt` chat).
- **Both** the effort knob and the token-field choice now flow from that one table, so they can't drift: reasoning → `reasoning_effort` + `max_completion_tokens`; chat + DeepSeek → `max_tokens`.
- An unlisted id defaults to chat — the correctness-safe side (a wrong guess is a hard 400, a denied effort is only a perf miss).

DECISIONS D92. Full suite: 1193 passed.

This is the last remaining implementable item of #170. Item 1 (Claude fallback) is being dropped by decision (see PR #326 description).