### PR TITLE
usage: show full model name next to stage header

### DIFF
--- a/src/watchdog/cmd/usage.py
+++ b/src/watchdog/cmd/usage.py
@@ -39,12 +39,19 @@ def _fmt_secs(s: float) -> str:
     return f"{s:.1f}s" if s < 60 else f"{s / 60:.1f}m"
 
 
-def _short_model(m: str | None) -> str:
-    """e.g. 'claude-sonnet-4-6' -> 'sonnet', 'claude-haiku-4-5' -> 'haiku'."""
-    if not m:
-        return "?"
-    parts = m.split("-")
-    return parts[1] if len(parts) > 1 else m
+def _stage_models(calls: list[dict]) -> str:
+    """Distinct full model names used across `calls`, in first-seen order — printed once next
+    to the stage header rather than truncated into a per-row column (a per-row abbreviation like
+    `_short_model`'s old 'claude-sonnet-4-6' -> 'sonnet' silently mangled non-Claude ids, e.g.
+    'gemini-3.1-flash-lite' -> '3.1'). Calls within one stage share a model in the overwhelming
+    majority of runs (one `--classifier-model`/etc. per invocation), but joining distinct values
+    keeps this correct if that ever changes mid-run."""
+    seen = []
+    for c in calls:
+        m = c.get("model") or "?"
+        if m not in seen:
+            seen.append(m)
+    return ", ".join(seen)
 
 
 def _short_auth(mode: str | None) -> str:
@@ -101,11 +108,10 @@ def _print_stage(calls: list[dict]) -> dict:
     rather than leaving an inflated cost/latency unexplained."""
     name_w = max(min(28, max(len(c.get("filename") or c["task"]) for c in calls)), len("Filename"))
     detail_w = max(min(24, max(len(c.get("detail") or "—") for c in calls)), len("Detail"))
-    model_w = max(max(len(_short_model(c.get("model"))) for c in calls), len("Model"))
     effort_w = max(max(len(c.get("effort") or "—") for c in calls), len("Effort"))
     auth_w = max(max(len(_short_auth(c.get("auth_mode"))) for c in calls), len("Auth"))
 
-    hdr = (f"  {'Filename':<{name_w}}  {'Detail':<{detail_w}}  {'Model':<{model_w}}  {'Effort':<{effort_w}}  "
+    hdr = (f"  {'Filename':<{name_w}}  {'Detail':<{detail_w}}  {'Effort':<{effort_w}}  "
            f"{'Auth':<{auth_w}}  "
            f"{'Input':>8}  {'C.read':>8}  {'C.write':>8}  {'Output':>7}  {'Latency':>8}  {'Cost':>8}")
     print(hdr)
@@ -124,7 +130,7 @@ def _print_stage(calls: list[dict]) -> dict:
         trunc_detail = (detail[:detail_w - 1] + "…") if len(detail) > detail_w else detail
         retry_note = f"  ×{attempts}" if attempts > 1 else ""
         print(
-            f"  {trunc_name:<{name_w}}  {trunc_detail:<{detail_w}}  {_short_model(c.get('model')):<{model_w}}  "
+            f"  {trunc_name:<{name_w}}  {trunc_detail:<{detail_w}}  "
             f"{effort:<{effort_w}}  {auth:<{auth_w}}  "
             f"{_fmt(c['input_tokens']):>8}  {_fmt(c['cache_read_tokens']):>8}  {_fmt(c['cache_write_tokens']):>8}  "
             f"{_fmt(c['output_tokens']):>7}  {_fmt_secs(latency):>8}  ${cost:>6.4f}{retry_note}"
@@ -137,7 +143,7 @@ def _print_stage(calls: list[dict]) -> dict:
         totals["latency_s"] += latency
 
     print(
-        f"  {'Subtotal':<{name_w}}  {'':<{detail_w}}  {'':<{model_w}}  {'':<{effort_w}}  {'':<{auth_w}}  "
+        f"  {'Subtotal':<{name_w}}  {'':<{detail_w}}  {'':<{effort_w}}  {'':<{auth_w}}  "
         f"{_fmt(totals['input_tokens']):>8}  {_fmt(totals['cache_read_tokens']):>8}  "
         f"{_fmt(totals['cache_write_tokens']):>8}  {_fmt(totals['output_tokens']):>7}  "
         f"{_fmt_secs(totals['latency_s']):>8}  ${totals['cost_usd']:>7.4f}"
@@ -170,7 +176,8 @@ def _analyze_run(usage_file: Path, vault: Path) -> None:
               [s for s in by_stage if s not in _STAGE_ORDER]
     for stage in ordered:
         stage_calls = by_stage[stage]
-        print(f"\n  {stage.upper()}  ({len(stage_calls)} call{'s' if len(stage_calls) != 1 else ''})")
+        print(f"\n  {stage.upper()}  ({len(stage_calls)} call{'s' if len(stage_calls) != 1 else ''})"
+              f"  ·  model: {_stage_models(stage_calls)}")
         totals = _print_stage(stage_calls)
         _accumulate(grand, totals)
         n_calls += len(stage_calls)

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -113,6 +113,25 @@ def test_cmd_usage_run_flag_picks_specific_run(tmp_path, monkeypatch, capsys):
     assert "feb.pdf" not in out
 
 
+def test_cmd_usage_shows_full_model_name_next_to_stage(tmp_path, monkeypatch, capsys):
+    """The model column used to abbreviate by splitting on '-' and taking the second segment,
+    which worked for 'claude-sonnet-4-6' -> 'sonnet' but mangled non-Claude ids like
+    'gemini-3.1-flash-lite' into '3.1'. The full model name is now printed once next to the
+    stage header instead, and there's no more per-row Model column."""
+    vault = _build_vault(tmp_path, runs={
+        "usage-2026-01-01T00-00-00": [
+            _call(task="classify", model="gemini-3.1-flash-lite", cost_usd=0.001),
+        ],
+    })
+    monkeypatch.chdir(vault)
+
+    cmd_usage(_args())
+
+    out = capsys.readouterr().out
+    assert "CLASSIFIER" in out and "model: gemini-3.1-flash-lite" in out
+    assert "  Model  " not in out   # no more per-row Model column
+
+
 def test_cmd_usage_run_flag_no_match(tmp_path, monkeypatch):
     vault = _build_vault(tmp_path, runs={"usage-2026-01-01T00-00-00": [_call()]})
     monkeypatch.chdir(vault)


### PR DESCRIPTION
Fixes a display bug reported after an ingest run on Gemini 3.1 Flash Lite: `watchdog usage` showed the model as just `3.1`.

## Root cause

`_short_model()` abbreviated by splitting the model id on `-` and taking the second segment — works for Claude ids (`claude-sonnet-4-6` -> `sonnet`) but silently mangles others, e.g. `gemini-3.1-flash-lite` -> `3.1`. The actually-configured model name was invisible in the report.

## Fix

Calls within one stage share a model in the overwhelming majority of runs (one `--classifier-model`/`--extractor-model`/`--finalizer-model` per invocation), so a per-row abbreviated column was the wrong shape to begin with. Instead:

- Print the full model name(s) once next to each stage header, e.g. `CLASSIFIER  (3 calls)  ·  model: gemini-3.1-flash-lite`.
- Drop the now-redundant per-row `Model` column from the per-call table.
- `_stage_models()` joins distinct model names (first-seen order) in the rare case a stage's calls used more than one.

## Tests

New `test_cmd_usage_shows_full_model_name_next_to_stage`; full suite passes (1223).