### PR TITLE
Fix ingest progress-region rendering and post-flight warning visibility

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -645,4 +645,20 @@ That bug was a symptom of a wider mismatch: setup and the `watchdog auth` status
 
 **Tradeoff:** the setup wizard is longer for a subscription user who accepts the metered offer (provider pick → key → three model picks) — accepted because it replaces what would otherwise be three separate manual `watchdog configure` edits plus a `watchdog auth` key add, and it is fully skippable (declining leaves subscription-for-everything, the prior default). The api-key branch's original "other providers?" offer is unchanged, since that path was never the source of confusion.
 
+### D96 — `LiveRegion` queries the terminal width straight from the OS, not `shutil.get_terminal_size()`
+
+A user reported the live progress region leaving stale duplicate "extracting…" rows on screen during a real ingest run. Root cause: `_render()` sized live rows with `shutil.get_terminal_size((80, 24)).columns`, which checks the `COLUMNS`/`LINES` env vars *before* asking the OS — in a terminal where those vars are stale or absent-but-cached, it can report a width wider than the real screen. A live row that then wraps onto a second physical line isn't accounted for by `LiveRegion`'s own rendered-line count, so the next redraw's cursor-up-N/erase undercounts and leaves the previous frame's text behind. Confirmed with a `pyte` VT100-emulator reproduction: an intentionally-wrong reported width reproduced the exact stale-duplicate-row symptom; the same scenario with a correct width stayed clean even with long lines that wrap.
+
+Fixed with a small `_terminal_width(stream)` helper that calls `os.get_terminal_size(stream.fileno())` first (a direct OS ioctl query, immune to stale env vars) and only falls back to `shutil.get_terminal_size((80, 24))` on `OSError`/`ValueError`/`AttributeError` (non-tty stream, no real fd — the case `shutil`'s own fallback exists for).
+
+**Tradeoff:** none identified — this is a strict correctness fix over the same fallback behavior `shutil.get_terminal_size()` already provided for non-tty streams.
+
+### D97 — Post-flight validation warnings (quote-verify, entity-id/date sanitization) route through the live region and the ingest log instead of a raw stderr print
+
+The same user-reported screenshot showed a quote-verification warning ("`document.key_facts[3].quote not found...`") appear once in the terminal and then vanish, and it was absent from `ingest.log` entirely. Root cause: `postflight.run()` printed these three warning classes directly with `print(f"Warning: {msg}", file=sys.stderr)`, bypassing `orchestrate.py`'s `_say`/`_log`/`LiveRegion` machinery completely. A raw print like this sits outside the live region's own line-count bookkeeping, so it can be erased by the next redraw's cursor-up/erase (D96's mechanism, but here the trigger is a second, uncoordinated writer rather than a wrong width) — and since it never went through `_log()`, it also never reached `ingest.log`, silently dropping a real signal a journalist would want on record.
+
+Gave `postflight.run()` an optional `warn` callback parameter: when provided, each warning is handed to it instead of the raw print; when omitted, the exact original stderr behavior is preserved (needed by `watchdog postflight`'s standalone CLI path, `cmd/ingest.py`'s `cmd_postflight`, which has no live region to route through). `orchestrate.py`'s `_write_postflight` now passes a `warn` callback that prints through `_say()` (so `LiveRegion` knows about the line and won't erase it) and writes the same message to `ingest.log` via `_log()`.
+
+**Tradeoff:** none identified — the default (no `warn` given) behavior is byte-for-byte the same as before, so only the orchestrator's own call site changes behavior.
+
 

--- a/src/watchdog/cmd/ingest.py
+++ b/src/watchdog/cmd/ingest.py
@@ -102,6 +102,50 @@ def _effective_extract_backend(extract_backend: str | None, auth_mode: str) -> s
     return extract_backend or ("claude-agent-sdk" if auth_mode == "subscription" else "claude-api")
 
 
+def _format_models_line(classify_backend, classify_model, extract_backend, extract_model,
+                        post_backend, post_model) -> str:
+    """Which model runs each ingest stage — printed alongside the cost estimate before an
+    ingest starts, so a run under a non-default provider (#325) is obvious up front instead of
+    the older generic 'Using the configured provider(s).' notice."""
+    def label(backend, model):
+        return f"{backend}:{model}" if backend else model
+    stages = (("classifier", classify_backend, classify_model),
+              ("extractor", extract_backend, extract_model),
+              ("finalizer", post_backend, post_model))
+    bits = " · ".join(f"{_DIM}{name}{_RESET} {_CYAN}{label(b, m)}{_RESET}" for name, b, m in stages)
+    return f"  {bits}"
+
+
+def _preview_ingest(vault: Path, args) -> tuple[str, str] | None:
+    """Read-only preview of what an ingest run would do — the doc/page/token cost estimate and
+    which models would run each stage — shown before any ingest confirm prompt, mirroring
+    `--estimate`'s lock-free scan (#269, #325). None when the queue is empty."""
+    from watchdog.pipeline.ingest_setup import scan_queue, cost_estimate
+    from watchdog.cmd.auth import resolve_auth
+    from watchdog.cmd.base import CONFIG_FILE
+    queue_files = scan_queue(vault)
+    if not queue_files:
+        return None
+    config: dict = {}
+    if CONFIG_FILE.exists():
+        try:
+            config = json.loads(CONFIG_FILE.read_text())
+        except Exception:
+            pass
+    extract_backend, extract_model = _resolve_stage(
+        getattr(args, "extractor_model", None), config.get("extractor_model"))
+    post_backend, post_model = _resolve_stage(
+        getattr(args, "finalizer_model", None), config.get("finalizer_model"), default="haiku")
+    classify_backend, classify_model = _resolve_stage(
+        getattr(args, "classifier_model", None), config.get("classifier_model"), default="haiku")
+
+    auth_mode = resolve_auth()["mode"] if extract_backend is None else None
+    est = cost_estimate(vault, queue_files, _effective_extract_backend(extract_backend, auth_mode))
+    models_line = _format_models_line(classify_backend, classify_model,
+                                      extract_backend, extract_model, post_backend, post_model)
+    return _format_cost_estimate(est), models_line
+
+
 def _pick_skill_interactive() -> str | None:
     """Numbered picker for `watchdog ingest --skill` (no value), drawn from the global
     skill catalog. Returns the chosen skill's file path; Enter → classify per doc."""
@@ -206,10 +250,13 @@ def cmd_chew(args) -> None:
 
 def _offer_ingest(args, vault: Path) -> None:
     """After chew, offer to run ingest right away; print the command hint if declined."""
-    total = _count_queued(vault)
-    label = f"{total} document{'s' if total != 1 else ''}"
-    if interactive.confirm(f"\n  {_BOLD}{label}{_RESET} ready. Ingest now?", default=True):
-        cmd_ingest(args, confirm=False)
+    preview = _preview_ingest(vault, args)
+    if preview:
+        estimate_line, models_line = preview
+        print(f"\n{estimate_line}")
+        print(models_line)
+    if interactive.pick(["Ingest now", "Not now"], 0, title="Ingest now?") == 0:
+        cmd_ingest(args, confirm=False, skip_preview=True)
     else:
         print(f"\n  Run:  {_CYAN}watchdog ingest{_RESET}\n")
 
@@ -269,7 +316,7 @@ def _merge_summary(base: dict | None, new: dict) -> dict:
     return merged
 
 
-def cmd_ingest(args, *, confirm: bool = True) -> None:
+def cmd_ingest(args, *, confirm: bool = True, skip_preview: bool = False) -> None:
     vault = Path(".").resolve()
     if not (vault / ".watchdog").is_dir():
         sys.exit("Error: must be run from inside a Watchdog vault directory")
@@ -392,10 +439,12 @@ def cmd_ingest(args, *, confirm: bool = True) -> None:
         return
 
     q = len(result["queue_files"])
-    if q:
+    if q and not skip_preview:
         from watchdog.pipeline.ingest_setup import cost_estimate
         est = cost_estimate(vault, result["queue_files"], _effective_extract_backend(extract_backend, a["mode"]))
         print(f"\n{_format_cost_estimate(est)}")
+        print(_format_models_line(classify_backend, classify_model, extract_backend, extract_model,
+                                  post_backend, post_model))
     elif batch_pending:
         print(f"\n  {_DIM}Checking on a pending batch extraction…{_RESET}")
 
@@ -428,14 +477,11 @@ def cmd_ingest(args, *, confirm: bool = True) -> None:
         (vault / ".watchdog" / "Registry" / ".ingest-lock").unlink(missing_ok=True)
         (vault / ".watchdog" / "ingest-state.json").unlink(missing_ok=True)
 
-    auth_note = f"your {_BOLD}{a['mode']}{_RESET} auth" if a["mode"] else "the configured provider(s)"
     if confirm:
-        if not interactive.confirm(f"\n  Ingest now with {auth_note}?", default=True):
+        if interactive.pick(["Ingest now", "Not now"], 0, title="Ingest now?") != 0:
             _release_lock()
             print(f"\n  When ready, run:  {_CYAN}watchdog ingest{_RESET}\n")
             return
-    else:
-        print(f"\n  {_DIM}Using {auth_note}{_DIM}.{_RESET}")
 
     import asyncio
     from watchdog.pipeline import orchestrate

--- a/src/watchdog/cmd/live.py
+++ b/src/watchdog/cmd/live.py
@@ -13,6 +13,7 @@ pass fully-formatted lines (including the 2-space indent and colour codes); the 
 truncates live rows to the terminal width so the redraw math stays one physical line per row.
 """
 
+import os
 import re
 import shutil
 import sys
@@ -20,6 +21,18 @@ import threading
 
 _ANSI = re.compile(r"\033\[[0-9;]*m")
 _RESET = "\033[0m"
+
+
+def _terminal_width(stream) -> int:
+    """Physical column count for `stream`'s real fd, queried straight from the OS. Deliberately
+    NOT `shutil.get_terminal_size()`, which checks the `COLUMNS` env var first — that can go
+    stale (e.g. after a resize) and silently disagree with the real terminal, which corrupts the
+    live region's redraw math: a row that wraps onto an extra physical line the region didn't
+    account for leaves stale duplicate text on screen after the next redraw."""
+    try:
+        return os.get_terminal_size(stream.fileno()).columns
+    except (OSError, ValueError, AttributeError):
+        return shutil.get_terminal_size((80, 24)).columns
 
 
 def _truncate(line: str, width: int) -> str:
@@ -116,7 +129,7 @@ class LiveRegion:
 
     def _render(self) -> None:
         self._clear()
-        width = shutil.get_terminal_size((80, 24)).columns
+        width = _terminal_width(self.stream)
         for key in self._order:
             self.stream.write(_truncate(self._rows[key], width) + "\n")
         self._rendered = len(self._order)

--- a/src/watchdog/pipeline/orchestrate.py
+++ b/src/watchdog/pipeline/orchestrate.py
@@ -355,7 +355,16 @@ def _write_postflight(vault: Path, sha: str, extraction: dict) -> tuple[bool, li
     tmp = vault / ".watchdog" / "tmp" / f"wdg_ex_{sha}.json"
     tmp.parent.mkdir(parents=True, exist_ok=True)
     tmp.write_text(json.dumps(extraction, ensure_ascii=False, indent=2), encoding="utf-8")
-    outcome = postflight.run(vault, tmp, quiet=True)
+    filename = extraction.get("document", {}).get("filename", "")
+
+    def _warn(msg: str) -> None:
+        # Routed through _say/_log (not a raw stderr print) so it survives the live region's
+        # redraw — a print outside that machinery can be erased by the next cursor-up/erase,
+        # and it never reached ingest.log.
+        _say(f"   {_YELLOW}⚠{_RESET}  {filename}  {_DIM}{msg}{_RESET}")
+        _log(vault, f"WARN {filename}: {msg}")
+
+    outcome = postflight.run(vault, tmp, quiet=True, warn=_warn)
     return ("errors" not in outcome), outcome.get("errors", [])
 
 
@@ -629,7 +638,7 @@ def _finish_extraction(vault: Path, sha: str, filename: str, extraction: dict, s
     _log(vault, f"OK {filename}: {n_entities} entities")
     warn = _coverage_warning(extraction, page_count)
     if warn:
-        _say(f"{_YELLOW}⚠{_RESET}  {filename}  {_DIM}{warn}{_RESET}")
+        _say(f"   {_YELLOW}⚠{_RESET}  {_DIM}{warn}{_RESET}")
         _log(vault, f"WARN {filename}: {warn}")
     result = _compact_result(sha, filename, extraction, pf.get("near_dup", {}), round(cost, 6))
     # Persist the compact result so `watchdog finalize` can run post-ingest from disk alone.

--- a/src/watchdog/pipeline/postflight.py
+++ b/src/watchdog/pipeline/postflight.py
@@ -191,7 +191,17 @@ def explode_key_facts(extraction: dict) -> None:
                 ent.setdefault("timeline_events", []).append(event)
 
 
-def run(vault: Path, extraction_path: Path, quiet: bool = False) -> dict:
+def run(vault: Path, extraction_path: Path, quiet: bool = False, warn=None) -> dict:
+    """`warn`, when given, receives each warning message instead of the default raw
+    ``print(..., file=sys.stderr)`` — the caller can route it through a live-region-aware
+    printer and the ingest log (a raw stderr print during a LiveRegion redraw can be erased by
+    the next redraw's cursor-up/erase, and it never reaches ingest.log)."""
+    def _warn(msg: str) -> None:
+        if warn is not None:
+            warn(msg)
+        else:
+            print(f"Warning: {msg}", file=sys.stderr)
+
     if not extraction_path.exists():
         return {"errors": [f"extraction file not found: {extraction_path}"]}
 
@@ -209,13 +219,13 @@ def run(vault: Path, extraction_path: Path, quiet: bool = False) -> dict:
     # Slugify entity ids before anything downstream uses them as a path segment (#303) —
     # a warning per id actually changed, so a malicious/malformed value is visible, not silent.
     for warning in _sanitize_entity_ids(extraction):
-        print(f"Warning: {warning}", file=sys.stderr)
+        _warn(warning)
 
     # Drop non-ISO-shaped key_facts dates before they can reach explode_key_facts or
     # timeline.py's filename construction — a malformed date is a visible warning, not a
     # silent event loss.
     for warning in _sanitize_dates(extraction):
-        print(f"Warning: {warning}", file=sys.stderr)
+        _warn(warning)
 
     # Fan the unified key_facts out into the per-entity evidence_fragments / timeline_events that
     # write_vault and timeline staging consume (#140).
@@ -243,7 +253,7 @@ def run(vault: Path, extraction_path: Path, quiet: bool = False) -> dict:
     # never blocks the document.
     from watchdog.pipeline.quote_verify import verify_quotes
     for warning in verify_quotes(extraction, page_texts):
-        print(f"Warning: {warning}", file=sys.stderr)
+        _warn(warning)
 
     # Write the validated (and match_id-resolved) extraction back so write_vault reads it
     extraction_path.write_text(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1757,17 +1757,19 @@ def _vault_with_queue(configured):
 def test_offer_ingest_yes_runs_ingest_without_reconfirming(configured, monkeypatch):
     from watchdog.cmd import ingest as ing
     vault = _vault_with_queue(configured)
-    monkeypatch.setattr("builtins.input", lambda *a: "y")
+    monkeypatch.setattr("builtins.input", lambda *a: "1")   # pick(): "Ingest now"
     seen = {}
-    monkeypatch.setattr(ing, "cmd_ingest", lambda a, *, confirm=True: seen.update(confirm=confirm))
+    monkeypatch.setattr(ing, "cmd_ingest",
+                        lambda a, *, confirm=True, skip_preview=False: seen.update(
+                            confirm=confirm, skip_preview=skip_preview))
     ing._offer_ingest(args(), vault)
-    assert seen == {"confirm": False}   # chew's prompt is the only confirmation
+    assert seen == {"confirm": False, "skip_preview": True}   # chew's prompt is the only confirmation
 
 
 def test_offer_ingest_no_prints_hint_and_skips(configured, monkeypatch, capsys):
     from watchdog.cmd import ingest as ing
     vault = _vault_with_queue(configured)
-    monkeypatch.setattr("builtins.input", lambda *a: "n")
+    monkeypatch.setattr("builtins.input", lambda *a: "2")   # pick(): "Not now"
     def _boom(*a, **k):
         raise AssertionError("ingest must not run when declined")
     monkeypatch.setattr(ing, "cmd_ingest", _boom)


### PR DESCRIPTION
## What

Four terminal-UX fixes for `watchdog chew`/`watchdog ingest`, reported from a real run:

1. **Duplicate/stale "extracting…" rows** left on screen during ingest. Root cause: `LiveRegion._render()` sized rows using `shutil.get_terminal_size()`, which checks the `COLUMNS`/`LINES` env vars before asking the OS — a stale value can under-report the real width, so a wrapped row isn't accounted for in the redraw's line-count bookkeeping and the next erase leaves stale text behind. Confirmed with a `pyte` VT100-emulator reproduction. Fixed by querying `os.get_terminal_size(stream.fileno())` directly, falling back to `shutil.get_terminal_size()` only for non-tty streams. (D96)

2. **Post-flight warnings (quote-verify, entity-id/date sanitization) vanishing from the terminal and missing from `ingest.log`.** These were raw `print(..., file=sys.stderr)` calls that bypassed the live region and the log entirely. `postflight.run()` now accepts an optional `warn` callback; the orchestrator routes it through `_say()`/`_log()` so the message survives the live region's redraw and lands in the log. The standalone `watchdog postflight` CLI command is unaffected (no callback given → same stderr print as before). (D97)

3. **Coverage warning** (partial-page-extraction notice) now prints on its own indented line under the OK line, without repeating the filename.

4. **Doc-count/pages/tokens estimate and a new per-stage model-usage line now print before the ingest confirm** (both the chew→offer flow and direct `watchdog ingest`), and the confirm is now the arrow-key picker, replacing the old "N documents ready. Ingest now?" / "Using the configured provider(s)." text.

## Testing

Full suite: `1223 passed`.

## Docs

Added D96/D97 to `DECISIONS.md`.