### PR TITLE
Fix picker hint lingering, postflight warning ordering, and chew progress-bar pinning

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -671,3 +671,27 @@ Added `_openai_response_format(base_url, schema)`: returns `{"type": "json_schem
 
 **Tradeoff:** OpenAI and DeepSeek extraction keeps the weaker prompt-only enforcement for now; a real fix for OpenAI would need a parallel all-fields-required schema variant, scoped out here as a separate, larger piece of work. Gemini's remaining entity-count gap versus Claude (if any, after this change) has not been re-measured yet — this addresses one contributing cause, not necessarily the whole gap.
 
+### D99 — Arrow-key picker's "↑/↓ move · Enter select · q cancel" hint is erased, not left in scrollback
+
+A user testing a live `watchdog ingest` run noted the picker's control-hint line stayed on screen after a selection was made — outliving its usefulness, since it's only relevant while a choice is actually being made. Root cause: `interactive.py`'s `pick()` render loop writes the hint without a trailing newline (so the cursor sits at the end of that row for in-place redraws), and its `finally` block only restored terminal (`termios`) settings and printed one blank line — never erasing the hint text itself, so it was permanently committed to scrollback.
+
+Changed the `finally` block to write `\r\x1b[K\n` instead of a bare `print()`: `\r` returns to column 0 of the hint's own row, `\x1b[K` erases it, and `\n` advances — preserving the pre-existing one-blank-line spacing before whatever the caller prints next, but without leaving the hint text behind.
+
+**Tradeoff:** none identified — the erased text was never meant to be a persistent record of the interaction (the picker's own selection outcome is what the caller prints afterward).
+
+### D100 — Post-flight warnings print after their own document's OK line, not whenever post-flight happened to run
+
+Building on D97 (which got warnings into the live region and `ingest.log` at all), a user still reported a warning visually appearing to belong to the wrong document during a concurrent multi-document ingest. Root cause: `_write_postflight()` printed its warnings immediately, at post-flight-validation time — which always happens strictly *before* `_finish_extraction()`'s own "OK" line for that same document. Under async concurrency, another document's OK line can print in the gap between the two, so the warning reads as attached to whichever document happens to be finishing at that moment rather than the one it actually describes.
+
+`_write_postflight()` now collects warnings into a list and returns them instead of printing, threading them through `_simple_extract`/`_extract_sectioned`/`_extract_document`/`_finish_batch_item` into `_finish_extraction()`, which prints them immediately after its own `_settle()` OK line — in the same style/indentation as the pre-existing coverage-warning block, so they visually tuck under the correct document's own block regardless of what else is concurrently in flight.
+
+**Tradeoff:** none identified — this only changes *when* an already-collected warning prints, not whether it prints or what it says.
+
+### D101 — Chew's progress/ETA row is pinned to always render last in the live region, not wherever it was first inserted
+
+A user reported the chew-phase progress bar not staying "put" during a real run — it appeared sandwiched between finished-file lines above and in-flight rows below, rather than staying fixed at the bottom. Root cause: `LiveRegion` renders rows in the order their keys were first inserted into `self._order`, and `preprocess_batch.py` seeded the progress row (`_refresh_progress(0)`) *before* submitting any files to the `ThreadPoolExecutor` — so the progress key was always first in insertion order, with file rows added after it as worker threads picked up work.
+
+Gave `LiveRegion.update()` an optional `pin: bool` parameter: a pinned key is tracked in a new `self._pinned` set and `_render()` now draws non-pinned keys first, pinned keys last, regardless of `self._order`'s actual insertion sequence. `preprocess_batch.py`'s `_refresh_progress` passes `pin=True` for `_PROGRESS_KEY`, so the bar now always renders below every in-flight file row no matter when it was seeded relative to them.
+
+**Tradeoff:** none identified — `pin` is opt-in and unused by every other `LiveRegion` caller (ingest's per-document rows), so existing insertion-order rendering is unchanged for them.
+

--- a/src/watchdog/cmd/live.py
+++ b/src/watchdog/cmd/live.py
@@ -72,19 +72,29 @@ class LiveRegion:
         self.enabled = self.stream.isatty() if enabled is None else enabled
         self._rows: dict[str, str] = {}
         self._order: list[str] = []
+        self._pinned: set[str] = set()   # keys always rendered last, e.g. chew's summary
+                                          # progress bar (#158) — anchored at the bottom instead
+                                          # of wherever it happened to be inserted, so it doesn't
+                                          # appear sandwiched between finished and in-flight rows
         self._rendered = 0          # live rows currently drawn (== physical lines, post-truncation)
         self._lock = threading.Lock()
 
     # ── public API ────────────────────────────────────────────────────────────
 
-    def update(self, key: str, tty_line: str, plain_line: str | None = None) -> None:
-        """Add or mutate the in-flight row for `key`. Non-TTY prints `plain_line` (or `tty_line`)."""
+    def update(self, key: str, tty_line: str, plain_line: str | None = None, *,
+              pin: bool = False) -> None:
+        """Add or mutate the in-flight row for `key`. Non-TTY prints `plain_line` (or `tty_line`).
+        `pin=True` keeps this row rendered last among live rows regardless of insertion order —
+        for a persistent summary row that should stay anchored at the bottom while individual
+        in-flight rows come and go above it."""
         with self._lock:
             if not self.enabled:
                 self._print(plain_line if plain_line is not None else tty_line)
                 return
             if key not in self._rows:
                 self._order.append(key)
+            if pin:
+                self._pinned.add(key)
             self._rows[key] = tty_line
             self._render()
 
@@ -98,6 +108,7 @@ class LiveRegion:
             if key in self._rows:
                 self._order.remove(key)
                 del self._rows[key]
+            self._pinned.discard(key)
             self._render()
 
     def note(self, line: str) -> None:
@@ -130,7 +141,9 @@ class LiveRegion:
     def _render(self) -> None:
         self._clear()
         width = _terminal_width(self.stream)
-        for key in self._order:
+        ordered = [k for k in self._order if k not in self._pinned] + \
+                  [k for k in self._order if k in self._pinned]
+        for key in ordered:
             self.stream.write(_truncate(self._rows[key], width) + "\n")
         self._rendered = len(self._order)
         self.stream.flush()

--- a/src/watchdog/interactive.py
+++ b/src/watchdog/interactive.py
@@ -108,7 +108,11 @@ def pick(items, current=0, *, title=None, hint="↑/↓ move · Enter select · 
                 sel = (sel + 1) % len(selectable); render(False)
     finally:
         termios.tcsetattr(fd, termios.TCSADRAIN, old)
-        print()
+        # The move/select/cancel hint is only useful while a choice is being made — clear it
+        # (cursor is already sitting at the end of that row) instead of leaving it behind in
+        # the scrollback once the interaction is over.
+        sys.stdout.write("\r\x1b[K\n")
+        sys.stdout.flush()
 
     return result
 

--- a/src/watchdog/pipeline/orchestrate.py
+++ b/src/watchdog/pipeline/orchestrate.py
@@ -351,21 +351,18 @@ def _compact_result(sha: str, filename: str, extraction: dict, near_dup: dict, c
     }
 
 
-def _write_postflight(vault: Path, sha: str, extraction: dict) -> tuple[bool, list[str]]:
+def _write_postflight(vault: Path, sha: str, extraction: dict) -> tuple[bool, list[str], list[str]]:
+    """Returns (ok, errors, warnings). Warnings are collected rather than printed here — the
+    caller only knows once the document has actually finished (not discarded for a repair
+    retry) whether they're worth surfacing, and where in the live region's output they belong
+    (tucked under this document's own OK line, not wherever a concurrent document happens to
+    be at the moment post-flight ran, #333 follow-up)."""
     tmp = vault / ".watchdog" / "tmp" / f"wdg_ex_{sha}.json"
     tmp.parent.mkdir(parents=True, exist_ok=True)
     tmp.write_text(json.dumps(extraction, ensure_ascii=False, indent=2), encoding="utf-8")
-    filename = extraction.get("document", {}).get("filename", "")
-
-    def _warn(msg: str) -> None:
-        # Routed through _say/_log (not a raw stderr print) so it survives the live region's
-        # redraw — a print outside that machinery can be erased by the next cursor-up/erase,
-        # and it never reached ingest.log.
-        _say(f"   {_YELLOW}⚠{_RESET}  {filename}  {_DIM}{msg}{_RESET}")
-        _log(vault, f"WARN {filename}: {msg}")
-
-    outcome = postflight.run(vault, tmp, quiet=True, warn=_warn)
-    return ("errors" not in outcome), outcome.get("errors", [])
+    warnings: list[str] = []
+    outcome = postflight.run(vault, tmp, quiet=True, warn=warnings.append)
+    return ("errors" not in outcome), outcome.get("errors", []), warnings
 
 
 def _append_repair_note(base, errors: list[str]):
@@ -399,16 +396,16 @@ async def _simple_extract(vault, sha, pf, skill_text, brief, model, skill_label,
         except model_client.ModelError as e:
             # No valid JSON after the client's own retries — often output truncated on a
             # dense doc. Report failure so the caller can fall back to sectioning.
-            return extraction, scratchpad, cost, False, [f"extraction returned no valid JSON ({e})"]
+            return extraction, scratchpad, cost, False, [f"extraction returned no valid JSON ({e})"], []
         cost += r.cost_usd or 0.0
         extraction = r.parsed
         scratchpad = extraction.pop("scratchpad", "")
         _stamp_document(extraction, sha=sha, pf=pf, skill_label=skill_label, vault=vault,
                         skill_text=skill_text, extract_model=model, extract_effort=effort)
-        ok, errors = _write_postflight(vault, sha, extraction)
+        ok, errors, warnings = _write_postflight(vault, sha, extraction)
         if ok:
-            return extraction, scratchpad, cost, True, []
-    return extraction, scratchpad, cost, False, errors
+            return extraction, scratchpad, cost, True, [], warnings
+    return extraction, scratchpad, cost, False, errors, []
 
 
 # Cap on the observations text carried into the next section's prompt (A5) — only the most
@@ -505,8 +502,8 @@ async def _extract_sectioned(vault, sha, pf, skill_text, plan, model, skill_labe
     cost += digest_cost
     _stamp_document(extraction, sha=sha, pf=pf, skill_label=skill_label, vault=vault,
                     skill_text=skill_text, extract_model=model, extract_effort=effort)
-    ok, errors = _write_postflight(vault, sha, extraction)
-    return extraction, scratchpad, cost, ok, errors
+    ok, errors, warnings = _write_postflight(vault, sha, extraction)
+    return extraction, scratchpad, cost, ok, errors, warnings
 
 
 def _queued_filename(vault: Path, sha: str) -> str | None:
@@ -593,12 +590,12 @@ async def _extract_document(vault: Path, sha: str, brief: str | None,
         n_sections = len(plan.get("sections", []))
         _step(f"{_DIM}→  {filename}  {flow} · extracting · {n_sections} sections…{_RESET}",
               f"{_DIM}→  {filename}  extracting · {n_sections} sections…{_RESET}")
-        extraction, scratchpad, cost, ok, errors = await _extract_sectioned(
+        extraction, scratchpad, cost, ok, errors, warnings = await _extract_sectioned(
             vault, sha, pf, skill_text, plan, extract_model, skill_label, extract_effort, extract_backend, brief)
     else:
         _step(f"{_DIM}→  {filename}  {flow} · extracting…{_RESET}",
               f"{_DIM}→  {filename}  extracting…{_RESET}")
-        extraction, scratchpad, cost, ok, errors = await _simple_extract(
+        extraction, scratchpad, cost, ok, errors, warnings = await _simple_extract(
             vault, sha, pf, skill_text, brief, extract_model, skill_label, extract_effort, extract_backend)
         # Whole-document extraction can overrun the model's output ceiling on entity-dense
         # docs (the agent-SDK backend can't cap output) — the JSON truncates and is rejected.
@@ -611,21 +608,28 @@ async def _extract_document(vault: Path, sha: str, brief: str | None,
                       f"{_DIM}↻  {filename}  whole-doc extraction rejected — "
                       f"re-extracting in {n_sections} sections…{_RESET}")
                 whole_cost = cost
-                extraction, scratchpad, cost, ok, errors = await _extract_sectioned(
+                extraction, scratchpad, cost, ok, errors, warnings = await _extract_sectioned(
                     vault, sha, pf, skill_text, fb, extract_model, skill_label, extract_effort, extract_backend, brief)
                 cost += whole_cost   # account for the failed whole-doc attempt
 
     if not ok:
         return _fail(vault, sha, filename, "post-flight rejected: " + "; ".join(errors[:3]))
-    return _finish_extraction(vault, sha, filename, extraction, scratchpad, cost, pf, page_count)
+    return _finish_extraction(vault, sha, filename, extraction, scratchpad, cost, pf, page_count, warnings)
+
 
 
 def _finish_extraction(vault: Path, sha: str, filename: str, extraction: dict, scratchpad: str,
-                       cost: float, pf: dict, page_count: int | None) -> dict:
-    """Shared tail once an extraction has passed post-flight: settle-print, coverage warning,
-    log, persist `result_<sha>.json`. Used by both the synchronous per-document path
+                       cost: float, pf: dict, page_count: int | None,
+                       warnings: list[str] | None = None) -> dict:
+    """Shared tail once an extraction has passed post-flight: settle-print, warnings, coverage
+    warning, log, persist `result_<sha>.json`. Used by both the synchronous per-document path
     (`_extract_document`) and the batch-collect path (`_finish_batch_item`, #214) so a
-    batch-extracted document produces an identical result shape to a synchronous one."""
+    batch-extracted document produces an identical result shape to a synchronous one.
+
+    `warnings` (post-flight's quote-verify/sanitization messages, if any) are printed here —
+    after the OK line, not when post-flight ran — so they're tucked visually under this
+    document's own row instead of landing wherever a concurrently-extracting document
+    happened to be at the time (#333 follow-up)."""
     if scratchpad:
         (vault / ".watchdog" / "tmp" / f"notes_{sha}.md").write_text(scratchpad, encoding="utf-8")
     for stale in (vault / ".watchdog" / "tmp").glob(f"section_{sha}_*.md"):
@@ -636,6 +640,9 @@ def _finish_extraction(vault: Path, sha: str, filename: str, extraction: dict, s
             f"{_DIM}{n_entities} entit{'ies' if n_entities != 1 else 'y'}{_RESET}  "
             f"{_CYAN}documents/{_doc_slug(filename)}{_RESET}")
     _log(vault, f"OK {filename}: {n_entities} entities")
+    for msg in (warnings or []):
+        _say(f"   {_YELLOW}⚠{_RESET}  {_DIM}{msg}{_RESET}")
+        _log(vault, f"WARN {filename}: {msg}")
     warn = _coverage_warning(extraction, page_count)
     if warn:
         _say(f"   {_YELLOW}⚠{_RESET}  {_DIM}{warn}{_RESET}")
@@ -711,10 +718,11 @@ async def _finish_batch_item(vault: Path, sha: str, item: dict | None, skill_tex
     scratchpad = extraction.pop("scratchpad", "") if isinstance(extraction, dict) else ""
     _stamp_document(extraction, sha=sha, pf=pf, skill_label=skill_label, vault=vault,
                     skill_text=skill_text, extract_model=model, extract_effort=effort)
-    ok, errors = _write_postflight(vault, sha, extraction)
+    ok, errors, warnings = _write_postflight(vault, sha, extraction)
     if not ok:
         return _fail(vault, sha, filename, "post-flight rejected: " + "; ".join(errors[:3]))
-    return _finish_extraction(vault, sha, filename, extraction, scratchpad, cost, pf, page_count)
+    return _finish_extraction(vault, sha, filename, extraction, scratchpad, cost, pf, page_count, warnings)
+
 
 
 async def _resume_batch(vault: Path, state: dict, pinned_skill: str, brief: str | None,

--- a/src/watchdog/pipeline/preprocess_batch.py
+++ b/src/watchdog/pipeline/preprocess_batch.py
@@ -20,7 +20,9 @@ from watchdog.pipeline.preprocess import _perf_cpu_count, sha256_file
 
 DEFAULT_FILE_TIMEOUT = 600
 
-# Key for the persistent progress/ETA row that sits above the in-flight file rows (#158).
+# Key for the persistent progress/ETA row, pinned (LiveRegion `pin=True`) so it always
+# renders last, below the in-flight file rows (#158, #333 follow-up — previously just the
+# first key inserted, so it visually jumped between finished/in-flight rows as files completed).
 _PROGRESS_KEY = "__progress__"
 
 
@@ -383,7 +385,7 @@ def _run_ingest_inner(
             tail = f"  {_DIM}{round(elapsed_wall)}s total{_RESET}"
         else:
             tail = ""
-        live.update(_PROGRESS_KEY, f"  {bar} {_BOLD}{done}/{total}{_RESET}{tail}")
+        live.update(_PROGRESS_KEY, f"  {bar} {_BOLD}{done}/{total}{_RESET}{tail}", pin=True)
 
     def _chew(path: Path) -> dict:
         # Runs in a worker thread: mark the file in-flight the moment a worker picks it up, so the
@@ -395,7 +397,7 @@ def _run_ingest_inner(
     results: dict[str, dict] = {}
     _cancel_event.clear()
 
-    _refresh_progress(0)            # seed the progress row above any file rows
+    _refresh_progress(0)            # seed the pinned progress row; it renders last regardless
     pool = ThreadPoolExecutor(max_workers=pre_workers)
     futures = {pool.submit(_chew, f): f for f in files}
     done = 0

--- a/tests/test_live.py
+++ b/tests/test_live.py
@@ -1,9 +1,12 @@
 """LiveRegion: in-place TTY status rows with append-only non-TTY fallback (#151)."""
 
 import io
+import re
 import threading
 
 from watchdog.cmd.live import LiveRegion, _truncate
+
+_CURSOR_RE = re.compile(r"\x1b\[[0-9;]*[A-Z]")   # cursor-move/erase escapes, not SGR colour codes
 
 
 class _Stream(io.StringIO):
@@ -112,6 +115,32 @@ def test_tty_truncates_rows_to_terminal_width(monkeypatch):
     out = s.getvalue()
     assert "…\x1b[0m" in out                    # row was clipped to width
     assert "ABCDEF" not in out
+
+
+def test_pinned_row_renders_last_even_when_inserted_first():
+    """A summary/progress row (chew's #158 bar) inserted before any file rows must still
+    render below them, not sandwiched between finished lines and in-flight rows (#333
+    follow-up)."""
+    s = _Stream(tty=True)
+    r = LiveRegion(s, enabled=True)
+    r.update("progress", "row-PROGRESS", pin=True)   # seeded first, like _refresh_progress(0)
+    r.update("file-a", "row-A")
+    r.update("file-b", "row-B")
+    out = _CURSOR_RE.sub("", s.getvalue())
+    tail = out.rstrip("\n").split("\n")[-3:]
+    assert tail == ["row-A", "row-B", "row-PROGRESS"]
+
+
+def test_pinned_row_stays_last_after_a_file_row_finishes():
+    s = _Stream(tty=True)
+    r = LiveRegion(s, enabled=True)
+    r.update("progress", "row-PROGRESS", pin=True)
+    r.update("file-a", "row-A")
+    r.update("file-b", "row-B")
+    r.finish("file-a", "OK A")
+    out = _CURSOR_RE.sub("", s.getvalue())
+    tail = out.rstrip("\n").split("\n")[-2:]
+    assert tail == ["row-B", "row-PROGRESS"]
 
 
 # ── thread-safety (#158) ─────────────────────────────────────────────────────────

--- a/tests/test_orchestrate.py
+++ b/tests/test_orchestrate.py
@@ -94,6 +94,24 @@ def test_coverage_warning_handles_missing_page_count():
     assert orchestrate._coverage_warning(_ext_with_fact_pages([1, 2]), None) is None
 
 
+def test_postflight_quote_warning_prints_after_this_documents_ok_line(tmp_path, monkeypatch, capsys):
+    """A post-flight warning (quote-verify, entity-id/date sanitization) must land *after* its
+    own document's OK line, not whenever post-flight happened to run — otherwise it reads as
+    belonging to whichever document is concurrently in flight at that moment (#333 follow-up)."""
+    vault = make_vault(tmp_path)
+    _queue_doc(vault, text="Acme Corp filed an annual report.")
+    ext = _extraction()
+    ext["document"]["key_facts"][0]["quote"] = "this exact sentence never appears in the document"
+    _mock(monkeypatch, extraction=ext)
+
+    asyncio.run(orchestrate.run(vault))
+
+    out = capsys.readouterr().out
+    ok_index = out.index("OK")
+    warn_index = out.index("quote not found")
+    assert ok_index < warn_index
+
+
 def test_briefing_facts_projects_fact_and_date_only():
     """The briefing projection (#150) keeps the fact text and a date when present, and drops
     page/basis/entities/quote — narrative noise the briefing doesn't need."""
@@ -1422,7 +1440,7 @@ def test_extract_sectioned_composes_digest_after_merge(tmp_path, monkeypatch):
                                         cost_usd=0.01)
     monkeypatch.setattr(orchestrate.model_client, "acomplete_json", fake)
 
-    extraction, scratchpad, cost, ok, errors = asyncio.run(orchestrate._extract_sectioned(
+    extraction, scratchpad, cost, ok, errors, warnings = asyncio.run(orchestrate._extract_sectioned(
         vault, "abc123", pf, "SKILL TEXT", plan, "sonnet", "annual-report", backend="claude-api",
         brief="CHASE THE FRAUD"))
 
@@ -1452,7 +1470,7 @@ def test_digest_model_error_falls_back_to_deterministic_stitch(tmp_path, monkeyp
         raise model_client.ModelError("boom")
     monkeypatch.setattr(orchestrate.model_client, "acomplete_json", fake)
 
-    extraction, scratchpad, cost, ok, errors = asyncio.run(orchestrate._extract_sectioned(
+    extraction, scratchpad, cost, ok, errors, warnings = asyncio.run(orchestrate._extract_sectioned(
         vault, "abc123", pf, "SKILL", plan, "sonnet", "annual-report"))
 
     summary = extraction["document"]["summary"]
@@ -1471,7 +1489,7 @@ def test_digest_empty_response_falls_back_to_deterministic_stitch(tmp_path, monk
                                         auth_mode="subscription", cost_usd=0.0)
     monkeypatch.setattr(orchestrate.model_client, "acomplete_json", fake)
 
-    extraction, scratchpad, cost, ok, errors = asyncio.run(orchestrate._extract_sectioned(
+    extraction, scratchpad, cost, ok, errors, warnings = asyncio.run(orchestrate._extract_sectioned(
         vault, "abc123", pf, "SKILL", plan, "sonnet", "annual-report"))
 
     summary = extraction["document"]["summary"]


### PR DESCRIPTION
Follow-up to #333. Three UX bugs found live-testing \`watchdog ingest\`/\`watchdog chew\`:

1. **Picker hint lingers in scrollback.** \`interactive.py\`'s \`pick()\` left "↑/↓ move · Enter select · q cancel" permanently on screen after a selection — it's only useful while a choice is being made. Now erased in the \`finally\` block.

2. **Postflight warning could appear to belong to the wrong document.** \`_write_postflight()\` printed warnings immediately, before the document's own "OK" line — under concurrent async extraction, another document's OK line could print in between, making the warning look misattributed. Warnings are now collected and printed right after their own document's OK line (same style as the existing coverage warning).

3. **Chew's progress bar didn't stay pinned at the bottom.** \`LiveRegion\` renders rows in insertion order, and the progress row was seeded before any file rows existed, so it always rendered first — sandwiched between finished lines and in-flight rows as files completed. Added an opt-in \`pin=True\` to \`LiveRegion.update()\` so a designated row always renders last regardless of insertion order; chew's progress bar now uses it.

See DECISIONS.md D99–D101 for full rationale on each.

Tested: full suite passes (1229 passed), including new regression tests for all three fixes (\`test_live.py\`'s pin tests, \`test_orchestrate.py\`'s warning-ordering test).