### PR TITLE
model_client: give DeepSeek thinking-mode calls a higher max_tokens ceiling

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -695,7 +695,6 @@ Gave `LiveRegion.update()` an optional `pin: bool` parameter: a pinned key is tr
 
 **Tradeoff:** none identified — `pin` is opt-in and unused by every other `LiveRegion` caller (ingest's per-document rows), so existing insertion-order rendering is unchanged for them.
 
-
 ### D102 — ingest.log gets a per-document START line, and usage records a per-call end_ts for wall-clock elapsed
 
 Following a diagnostic thread about why `ingest.log` reads as if documents extract sequentially: the log only ever recorded completion (`OK`/`FAILED`) and the vault-commit `INGEST` line, both written after a document's multi-minute extraction finishes. Because extraction is concurrent (an `asyncio.gather` over a `Semaphore`) but the log is completion-ordered, a reader can't see that all documents started together — the staggered `OK` lines look like one-after-another work.
@@ -707,3 +706,11 @@ Two additions, both purely observational:
 2. `_record_usage` now stamps each call with `end_ts` (epoch seconds at record time). Paired with the existing `latency_s`, this gives every call a `[end_ts − latency_s, end_ts]` interval, so `watchdog usage` can report **wall-clock elapsed** per stage — `max(end) − min(start)` — alongside the summed per-call latency it already showed. For a concurrent stage the summed figure overstates the real wait (three 4-minute calls that overlapped took ~7 minutes of wall time, not 12); the elapsed line makes that explicit, and is shown only when the calls actually overlapped. Old `usage-<ts>.json` files without `end_ts` fall back to the summed figure alone.
 
 **Tradeoff:** the usage schema gains a field, but it's additive and back-compatible — `_wall_span` returns `None` when no call carries `end_ts`, so pre-existing usage files (and the `watchdog status`/estimate paths that read only the `totals` block) are unaffected.
+
+### D103 — DeepSeek thinking-mode extraction/briefing get a higher `max_tokens` ceiling than non-thinking calls
+
+A comparative ingest of the same 3 documents on DeepSeek-v4-pro with thinking enabled extracted 25-58% fewer key facts per document than the same run on Claude Sonnet, and elided the middle of one verbatim quote with "…". Root cause: DeepSeek's reasoning-model API caps chain-of-thought + final answer under one combined `max_tokens` (default 32K, max 64K — https://api-docs.deepseek.com/guides/reasoning_model), but `acomplete_json` applied the same flat, thinking-agnostic ceiling from `_TASK_MAX_TOKENS` (16000 for extract/extract-section/briefing) regardless of whether thinking was on. With thinking enabled, the CoT ate into that budget before the model wrote any of the actual JSON, starving the structured output (#337).
+
+Added `_DEEPSEEK_THINKING_MAX_TOKENS = 48000`, applied in `acomplete_json` only when the resolved backend is `deepseek`, the model id carries the `-thinking` suffix, and the task is one of the large-output tasks already in `_TASK_MAX_TOKENS`. Every other backend/task keeps its existing ceiling — Claude's extended thinking uses a separate `budget_tokens`, not a shared pool with the final answer, so it doesn't have this failure mode.
+
+**Tradeoff:** a DeepSeek-thinking extraction/briefing call now costs more per call (more output tokens available, and DeepSeek bills the CoT tokens as output) — acceptable since thinking mode is opt-in via the `-thinking` suffix, not the default.

--- a/src/watchdog/model_client.py
+++ b/src/watchdog/model_client.py
@@ -475,6 +475,13 @@ def _openai_cost(model_id: str, usage: dict | None) -> float | None:
 # https://api-docs.deepseek.com/guides/thinking_mode  (D88)
 _DEEPSEEK_THINKING_SUFFIX = "-thinking"
 
+# DeepSeek's reasoning mode caps chain-of-thought + final answer under one combined `max_tokens`
+# (default 32K, max 64K: https://api-docs.deepseek.com/guides/reasoning_model). The flat per-task
+# ceilings in `_TASK_MAX_TOKENS` starve the JSON output once the CoT eats into that same budget —
+# fewer key facts, elided quotes (#337). Applied only to deepseek + `-thinking` + the large-output
+# tasks; every other backend/task keeps its normal ceiling.
+_DEEPSEEK_THINKING_MAX_TOKENS = 48000
+
 
 def _split_deepseek_thinking(model_id: str) -> tuple[str, bool]:
     """(bare model id, thinking?) from a DeepSeek model token — strips a `-thinking` marker.
@@ -658,11 +665,15 @@ async def acomplete_json(*, task: str, prompt: str | list[dict], schema: dict, m
     """
     chosen, provider, api_key, auth_mode = _resolve_backend_auth(backend)
     backend_fn = _ABACKENDS[chosen]
-    max_tokens = _TASK_MAX_TOKENS.get(task, _API_MAX_TOKENS)
 
     requested = model or DEFAULT_TIER
     model_id = resolve_model_id(requested)
     effort_arg = _resolve_effort(provider, model_id, effort)   # provider-native value or None
+
+    max_tokens = _TASK_MAX_TOKENS.get(task, _API_MAX_TOKENS)
+    if (chosen == "deepseek" and task in _TASK_MAX_TOKENS
+            and model_id.endswith(_DEEPSEEK_THINKING_SUFFIX)):
+        max_tokens = _DEEPSEEK_THINKING_MAX_TOKENS
 
     start = time.monotonic()
     total_cost = 0.0


### PR DESCRIPTION
Fixes #337.

DeepSeek's reasoning API caps CoT + final answer under one combined `max_tokens` (default 32K, max 64K). Watchdog's flat 16000-token ceiling for `extract`/`extract-section`/`briefing` was applied the same whether or not thinking mode was on, so with thinking enabled the CoT ate into that budget before the model wrote any of the actual JSON — starving the structured output.

Comparative testing on the same 3 documents showed DeepSeek-v4-pro-thinking extracting 25-58% fewer key facts per document than the same run on Claude Sonnet, plus one elided verbatim quote (`…` in the middle) consistent with the model economizing on remaining output tokens.

## Change

Adds `_DEEPSEEK_THINKING_MAX_TOKENS = 48000`, applied in `acomplete_json` only when the resolved backend is `deepseek`, the model id carries the `-thinking` suffix, and the task is one of the existing large-output tasks. Every other backend/task keeps its current ceiling unchanged. 48000 is a deliberate margin under DeepSeek's 64K hard limit, not the max itself (see DECISIONS.md D102).

## Testing

- Full suite passes locally (1226 tests).
- Not yet re-validated against a real ingest run — next step is re-ingesting the same Laurentian CCAA documents with `deepseek:deepseek-v4-pro-thinking` as extractor/finalizer to confirm key-fact counts close the gap with Sonnet.