### PR TITLE
Align chew rows, space the progress bar, and stack the model list

### DIFF
--- a/src/watchdog/cmd/ingest.py
+++ b/src/watchdog/cmd/ingest.py
@@ -112,8 +112,7 @@ def _format_models_line(classify_backend, classify_model, extract_backend, extra
     stages = (("classifier", classify_backend, classify_model),
               ("extractor", extract_backend, extract_model),
               ("finalizer", post_backend, post_model))
-    bits = " · ".join(f"{_DIM}{name}{_RESET} {_CYAN}{label(b, m)}{_RESET}" for name, b, m in stages)
-    return f"  {bits}"
+    return "\n".join(f"  {_DIM}{name}{_RESET} {_CYAN}{label(b, m)}{_RESET}" for name, b, m in stages)
 
 
 def _preview_ingest(vault: Path, args) -> tuple[str, str] | None:
@@ -253,7 +252,7 @@ def _offer_ingest(args, vault: Path) -> None:
     preview = _preview_ingest(vault, args)
     if preview:
         estimate_line, models_line = preview
-        print(f"\n{estimate_line}")
+        print(estimate_line)
         print(models_line)
     if interactive.pick(["Ingest now", "Not now"], 0, title="Ingest now?") == 0:
         cmd_ingest(args, confirm=False, skip_preview=True)

--- a/src/watchdog/interactive.py
+++ b/src/watchdog/interactive.py
@@ -61,7 +61,7 @@ def pick(items, current=0, *, title=None, hint="↑/↓ move · Enter select · 
 
     fd, old = _raw_stdin()
     try:
-        fits = os.get_terminal_size().lines >= len(items) + 3
+        fits = os.get_terminal_size().lines >= len(items) + 4
     except OSError:
         fits = True
 
@@ -73,7 +73,7 @@ def pick(items, current=0, *, title=None, hint="↑/↓ move · Enter select · 
 
     def render(first: bool) -> None:
         if not first:
-            sys.stdout.write(f"\x1b[{1 + len(items)}A\r")
+            sys.stdout.write(f"\x1b[{2 + len(items)}A\r")
         sys.stdout.write((f"  {_BOLD}{title}{_RESET}" if title else "") + "\x1b[K\n")
         for i, it in enumerate(items):
             if isinstance(it, Header):
@@ -82,6 +82,7 @@ def pick(items, current=0, *, title=None, hint="↑/↓ move · Enter select · 
                 sys.stdout.write(f"  {_CYAN}❯ {it}{_RESET}\x1b[K\n")
             else:
                 sys.stdout.write(f"    {it}\x1b[K\n")
+        sys.stdout.write("\x1b[K\n")                    # blank line between the menu and the hint
         sys.stdout.write(f"  {_DIM}{hint}{_RESET}\x1b[K")
         sys.stdout.flush()
 
@@ -108,10 +109,10 @@ def pick(items, current=0, *, title=None, hint="↑/↓ move · Enter select · 
                 sel = (sel + 1) % len(selectable); render(False)
     finally:
         termios.tcsetattr(fd, termios.TCSADRAIN, old)
-        # The move/select/cancel hint is only useful while a choice is being made — clear it
-        # (cursor is already sitting at the end of that row) instead of leaving it behind in
-        # the scrollback once the interaction is over.
-        sys.stdout.write("\r\x1b[K\n")
+        # The blank spacer + move/select/cancel hint are only useful while a choice is being
+        # made — erase both (the cursor sits at the end of the hint row, one row below the
+        # spacer) instead of leaving them behind in the scrollback once the interaction is over.
+        sys.stdout.write("\r\x1b[K\x1b[1A\x1b[K\n")
         sys.stdout.flush()
 
     return result

--- a/src/watchdog/pipeline/preprocess_batch.py
+++ b/src/watchdog/pipeline/preprocess_batch.py
@@ -25,6 +25,10 @@ DEFAULT_FILE_TIMEOUT = 600
 # first key inserted, so it visually jumped between finished/in-flight rows as files completed).
 _PROGRESS_KEY = "__progress__"
 
+# A blank pinned row rendered just above the progress bar so the bar always keeps one line of
+# clearance from the finished/in-flight rows above it instead of butting directly against them.
+_SPACER_KEY = "__progress_spacer__"
+
 
 def _compute_near_dup(result: dict, vault: Path) -> dict:
     """Compute near-duplicate check for a freshly chewed document. Never raises."""
@@ -391,12 +395,16 @@ def _run_ingest_inner(
         # Runs in a worker thread: mark the file in-flight the moment a worker picks it up, so the
         # row appears while OCR spins up. Gated to TTYs to keep non-TTY output to finished lines only.
         if live.enabled:
-            live.update(str(path), f"  {_DIM}→  {_rel(path)}  chewing…{_RESET}")
+            # Pad the arrow marker to the same width as the settled status codes ("OK "/"ERR"/
+            # "SKP") so filenames start at the same column whether a row is in-flight or done.
+            live.update(str(path), f"  {_DIM}→  {_RESET}  {_DIM}{_rel(path)}  chewing…{_RESET}")
         return preprocess_one(path, timeout=DEFAULT_FILE_TIMEOUT, chunk_workers=chunk_workers)
 
     results: dict[str, dict] = {}
     _cancel_event.clear()
 
+    if live.enabled:
+        live.update(_SPACER_KEY, "", pin=True)   # blank clearance line above the progress bar
     _refresh_progress(0)            # seed the pinned progress row; it renders last regardless
     pool = ThreadPoolExecutor(max_workers=pre_workers)
     futures = {pool.submit(_chew, f): f for f in files}


### PR DESCRIPTION
Follow-up on CLI feedback from #331, #333, #336.

## Changes

- **Blank line above the progress bar.** A pinned blank spacer row now renders just above the chew progress bar, so the bar keeps one line of clearance from the finished/in-flight rows above it instead of butting directly against them.
- **Aligned filenames across states.** The in-flight `→` marker is padded to the same width as the settled status codes (`OK `/`ERR`/`SKP`), so filenames start at the same column whether a row is in-flight or done.
- **One model per line.** The ingest model list (classifier/extractor/finalizer) prints one stage per line instead of a single long ` · `-joined line.
- **Dropped a duplicate blank line** between the chew summary (`N files ready`) and the ingest preview.
- **Blank line before the picker hint.** `pick()` now renders a blank line between an arrow-key menu and its `↑/↓ move · Enter select · q cancel` hint, and erases both on exit so no stray blank line lingers. This applies to every arrow-key menu (setup wizard, skill picker, etc.), a consistent improvement rather than a one-off.

## Testing

`test_preprocess_batch`, `test_cli`, `test_guided`, `test_setup_skills`, `test_auth`, and `test_resolve` all pass.