### PR TITLE
Log a per-document START line and report wall-clock elapsed in usage

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -636,8 +636,8 @@ Registry/
   registry.json             counts + last-updated
   manifest.json             lightweight id→{name,type,aliases,note_path} lookup
   resolutions.json          acknowledged leads/alerts/contradictions overlay (D68)
-  ingest.log                append-only ingest log
-  usage/usage-<ts>.json     per-run model-call token/cost telemetry (D50, D86)
+  ingest.log                append-only ingest log (START/OK/WARN/FAILED per doc, D102)
+  usage/usage-<ts>.json     per-run model-call token/cost/latency telemetry (D50, D86, D102)
   batch-pending.json        pending claude-batch extraction state (D52)
   .ingest-lock / .write-lock  run lock / write serialization
 backups/<ts>-<operation>/   pre-mutation snapshots for irreversible operations (D71)

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -695,3 +695,15 @@ Gave `LiveRegion.update()` an optional `pin: bool` parameter: a pinned key is tr
 
 **Tradeoff:** none identified — `pin` is opt-in and unused by every other `LiveRegion` caller (ingest's per-document rows), so existing insertion-order rendering is unchanged for them.
 
+
+### D102 — ingest.log gets a per-document START line, and usage records a per-call end_ts for wall-clock elapsed
+
+Following a diagnostic thread about why `ingest.log` reads as if documents extract sequentially: the log only ever recorded completion (`OK`/`FAILED`) and the vault-commit `INGEST` line, both written after a document's multi-minute extraction finishes. Because extraction is concurrent (an `asyncio.gather` over a `Semaphore`) but the log is completion-ordered, a reader can't see that all documents started together — the staggered `OK` lines look like one-after-another work.
+
+Two additions, both purely observational:
+
+1. `_extract_document` now writes `START <filename>` to `ingest.log` the moment a document's extraction begins (after preflight, before classify). The gap between a document's `START` and its own `OK`/`FAILED` is now that document's real extraction time, and the clustered `START` timestamps make the parallel launch visible.
+
+2. `_record_usage` now stamps each call with `end_ts` (epoch seconds at record time). Paired with the existing `latency_s`, this gives every call a `[end_ts − latency_s, end_ts]` interval, so `watchdog usage` can report **wall-clock elapsed** per stage — `max(end) − min(start)` — alongside the summed per-call latency it already showed. For a concurrent stage the summed figure overstates the real wait (three 4-minute calls that overlapped took ~7 minutes of wall time, not 12); the elapsed line makes that explicit, and is shown only when the calls actually overlapped. Old `usage-<ts>.json` files without `end_ts` fall back to the summed figure alone.
+
+**Tradeoff:** the usage schema gains a field, but it's additive and back-compatible — `_wall_span` returns `None` when no call carries `end_ts`, so pre-existing usage files (and the `watchdog status`/estimate paths that read only the `totals` block) are unaffected.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -170,7 +170,7 @@ Sweeps every already-ingested document against the current `watchlist.md` — de
 
 ### watchdog usage
 
-Prints a per-call token, cost, and latency breakdown for ingest runs, reading `.watchdog/Registry/usage/usage-<ts>.json` — no model call. Calls are grouped by stage (classifier/extractor/finalizer), and extraction rows show the filename and the page range or section each call covered, plus cost per page across the vault's whole document registry. Shows the latest run by default; `--all` compares every recorded run, and `--run TIMESTAMP` inspects one specific past run. Also available as `watchdog telemetry`.
+Prints a per-call token, cost, and latency breakdown for ingest runs, reading `.watchdog/Registry/usage/usage-<ts>.json` — no model call. Calls are grouped by stage (classifier/extractor/finalizer), and extraction rows show the filename and the page range or section each call covered, plus cost per page across the vault's whole document registry. Each stage's subtotal shows the summed per-call latency; when that stage's calls overlapped in time (documents extract in parallel), a second line reports the wall-clock elapsed — the real time the stage took — so the summed figure is not mistaken for how long you waited. The run total shows both figures side by side. Shows the latest run by default; `--all` compares every recorded run, and `--run TIMESTAMP` inspects one specific past run. Also available as `watchdog telemetry`.
 
 ### watchdog export
 

--- a/src/watchdog/cmd/usage.py
+++ b/src/watchdog/cmd/usage.py
@@ -39,6 +39,19 @@ def _fmt_secs(s: float) -> str:
     return f"{s:.1f}s" if s < 60 else f"{s / 60:.1f}m"
 
 
+def _wall_span(calls: list[dict]) -> float | None:
+    """Wall-clock elapsed across `calls` — max(end) − min(start), where each call's start is
+    `end_ts − latency_s`. This is the real time the calls took together, which for a stage that
+    ran concurrently is shorter than the summed per-call latency. Returns None when no call
+    carries an `end_ts` (usage files written before #317's follow-up), so callers fall back to
+    the summed call time alone."""
+    ends = [c["end_ts"] for c in calls if c.get("end_ts")]
+    if not ends:
+        return None
+    starts = [c["end_ts"] - (c.get("latency_s") or 0.0) for c in calls if c.get("end_ts")]
+    return max(ends) - min(starts)
+
+
 def _stage_models(calls: list[dict]) -> str:
     """Distinct full model names used across `calls`, in first-seen order — printed once next
     to the stage header rather than truncated into a per-row column (a per-row abbreviation like
@@ -148,6 +161,13 @@ def _print_stage(calls: list[dict]) -> dict:
         f"{_fmt(totals['cache_write_tokens']):>8}  {_fmt(totals['output_tokens']):>7}  "
         f"{_fmt_secs(totals['latency_s']):>8}  ${totals['cost_usd']:>7.4f}"
     )
+    # When the stage's calls overlapped in time, the summed Latency column overstates how long
+    # the stage actually took — show the wall-clock span so a concurrent stage's real duration
+    # is visible (#317 follow-up). Skipped when calls ran back-to-back (span ≈ sum) or the usage
+    # file predates end_ts.
+    span = _wall_span(calls)
+    if span is not None and len(calls) > 1 and totals["latency_s"] - span > 0.1:
+        print(f"  ↳ {_fmt_secs(span)} elapsed (wall-clock; {len(calls)} calls ran concurrently)")
     return totals
 
 
@@ -183,11 +203,14 @@ def _analyze_run(usage_file: Path, vault: Path) -> None:
         n_calls += len(stage_calls)
 
     print(f"\n  {'━' * (W - 2)}")
+    total_span = _wall_span(calls)
+    call_time = f"{_fmt_secs(grand['latency_s'])} call time"
+    elapsed = f"  ·  {_fmt_secs(total_span)} elapsed" if total_span is not None else ""
     print(
         f"  TOTAL  ({n_calls} call{'s' if n_calls != 1 else ''})     "
         f"{_fmt(grand['input_tokens'])} in  ·  {_fmt(grand['cache_read_tokens'])} cache-read  ·  "
         f"{_fmt(grand['cache_write_tokens'])} cache-write  ·  {_fmt(grand['output_tokens'])} out  ·  "
-        f"${grand['cost_usd']:.4f}  ·  {_fmt_secs(grand['latency_s'])} total call time"
+        f"${grand['cost_usd']:.4f}  ·  {call_time}{elapsed}"
     )
     _print_cost_per_page(vault, grand["cost_usd"])
 

--- a/src/watchdog/pipeline/orchestrate.py
+++ b/src/watchdog/pipeline/orchestrate.py
@@ -17,6 +17,7 @@ import json
 import shutil
 import signal
 import sys
+import time
 from pathlib import Path
 
 import yaml
@@ -81,7 +82,10 @@ def _record_usage(task: str, *, model: str, backend: str, usage: dict | None,
     time; batch-collected items have no live call to time, so they keep the 0.0 default (#317).
     `effort` records the reasoning-effort tier the call was made with (or None if the model/task
     doesn't take one), and `auth_mode` ("subscription"/"api-key") which billing lane paid for it
-    — both surfaced per call by `watchdog usage` (#319)."""
+    — both surfaced per call by `watchdog usage` (#319). `end_ts` is the call's completion time
+    (epoch seconds); paired with `latency_s` it gives each call a [start, end] interval, so
+    `watchdog usage` can report wall-clock elapsed per stage — the real time a concurrently-run
+    stage took — alongside the summed per-call time (#317 follow-up)."""
     if _usage is None:
         return
     u = usage or {}
@@ -92,7 +96,7 @@ def _record_usage(task: str, *, model: str, backend: str, usage: dict | None,
         "cache_read_tokens": u.get("cache_read_input_tokens", 0) or 0,
         "cache_write_tokens": u.get("cache_creation_input_tokens", 0) or 0,
         "cost_usd": cost_usd, "attempts": attempts, "latency_s": latency_s, "effort": effort,
-        "auth_mode": auth_mode, "filename": filename, "detail": detail,
+        "auth_mode": auth_mode, "filename": filename, "detail": detail, "end_ts": time.time(),
     })
 
 
@@ -548,6 +552,11 @@ async def _extract_document(vault: Path, sha: str, brief: str | None,
     pages = pf.get("pages", [])
     page_count = pf.get("page_count") or len(pages)
     pg = f"{page_count}p"
+    # Log the moment extraction begins (#317 follow-up). Documents extract concurrently, so a
+    # START line per document makes the staggered starts visible — the later OK/FAILED line
+    # marks completion, and the gap between them is that document's own extraction time (the
+    # log is otherwise completion-ordered, which reads misleadingly like sequential work).
+    _log(vault, f"START {filename}")
 
     # Digest-size telemetry (#216): how much prior-entity context this extraction carries. Watch it
     # on a mature vault to decide whether per-candidate caps are worth adding, and at what sizes.

--- a/tests/test_orchestrate.py
+++ b/tests/test_orchestrate.py
@@ -112,6 +112,21 @@ def test_postflight_quote_warning_prints_after_this_documents_ok_line(tmp_path, 
     assert ok_index < warn_index
 
 
+def test_ingest_log_records_start_before_ok(tmp_path, monkeypatch):
+    """A per-document START line is logged when extraction begins, ahead of its OK line —
+    with concurrent extraction the completion-ordered log otherwise hides the staggered
+    starts (#317 follow-up)."""
+    vault = make_vault(tmp_path)
+    _queue_doc(vault)
+    _mock(monkeypatch, extraction=_extraction())
+
+    asyncio.run(orchestrate.run(vault))
+
+    log = (vault / ".watchdog" / "Registry" / "ingest.log").read_text(encoding="utf-8")
+    assert "START test-doc.pdf" in log
+    assert log.index("START test-doc.pdf") < log.index("OK test-doc.pdf")
+
+
 def test_briefing_facts_projects_fact_and_date_only():
     """The briefing projection (#150) keeps the fact text and a date when present, and drops
     page/basis/entities/quote — narrative noise the briefing doesn't need."""
@@ -1743,6 +1758,7 @@ def test_finish_batch_item_records_usage_for_the_batch_call_itself(tmp_path):
         assert result["status"] == "ok"
         calls = [c for c in orchestrate._usage if c["task"] == "extract"]
         assert len(calls) == 1
+        assert calls[0].pop("end_ts") > 0   # completion timestamp stamped at record time
         assert calls[0] == {
             "task": "extract", "model": "claude-sonnet-4-6", "backend": "claude-batch",
             "input_tokens": 500, "output_tokens": 80, "cache_read_tokens": 0, "cache_write_tokens": 0,

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -12,13 +12,13 @@ from watchdog.cmd.usage import cmd_usage
 
 def _call(task="extract", filename="doc.pdf", detail="pages 1–1", model="claude-sonnet-4-6",
           cost_usd=0.01, input_tokens=100, output_tokens=20, latency_s=1.5,
-          effort=None, auth_mode="api-key", attempts=1):
+          effort=None, auth_mode="api-key", attempts=1, end_ts=None):
     return {
         "task": task, "model": model, "backend": "claude-api",
         "input_tokens": input_tokens, "output_tokens": output_tokens,
         "cache_read_tokens": 0, "cache_write_tokens": 0,
         "cost_usd": cost_usd, "attempts": attempts, "latency_s": latency_s, "effort": effort,
-        "auth_mode": auth_mode, "filename": filename, "detail": detail,
+        "auth_mode": auth_mode, "filename": filename, "detail": detail, "end_ts": end_ts,
     }
 
 
@@ -81,6 +81,46 @@ def test_cmd_usage_shows_auth_mode_and_retry_marker(tmp_path, monkeypatch, capsy
     assert "Auth" in out
     assert "sub" in out and "key" in out
     assert "×3" in out   # the retried call is flagged inline
+
+
+def test_cmd_usage_shows_wall_clock_elapsed_for_concurrent_stage(tmp_path, monkeypatch, capsys):
+    """When a stage's calls overlapped in time, the summed Latency column overstates the stage's
+    real duration — the wall-clock span (max end − min start) is shown alongside it (#317
+    follow-up). Three 3s calls finishing at t=100/101/102 span only 5s of wall time, not 9s."""
+    vault = _build_vault(tmp_path, runs={
+        "usage-2026-01-01T00-00-00": [
+            _call(filename="a.pdf", latency_s=3.0, end_ts=100.0),
+            _call(filename="b.pdf", latency_s=3.0, end_ts=101.0),
+            _call(filename="c.pdf", latency_s=3.0, end_ts=102.0),
+        ],
+    })
+    monkeypatch.chdir(vault)
+
+    cmd_usage(_args())
+
+    out = capsys.readouterr().out
+    assert "9.0s" in out                       # summed call time (subtotal)
+    assert "5.0s elapsed" in out               # wall-clock span, per stage
+    assert "concurrently" in out
+    assert "5.0s elapsed" in out.split("TOTAL")[1]   # and on the TOTAL line
+
+
+def test_cmd_usage_omits_wall_clock_when_no_end_ts(tmp_path, monkeypatch, capsys):
+    """Usage files written before end_ts was recorded have no wall-clock data — the elapsed
+    line is omitted rather than guessed, and the summed call time still prints."""
+    vault = _build_vault(tmp_path, runs={
+        "usage-2026-01-01T00-00-00": [
+            _call(filename="a.pdf", latency_s=3.0),
+            _call(filename="b.pdf", latency_s=3.0),
+        ],
+    })
+    monkeypatch.chdir(vault)
+
+    cmd_usage(_args())
+
+    out = capsys.readouterr().out
+    assert "elapsed" not in out
+    assert "call time" in out
 
 
 def test_cmd_usage_all_compares_every_run(tmp_path, monkeypatch, capsys):


### PR DESCRIPTION
Follow-up on a diagnostic thread about why `ingest.log` reads as if documents extract sequentially when they actually run in parallel.

## Changes

- **`ingest.log` gets a `START <filename>` line.** Written the moment a document's extraction begins (after preflight, before classify). The log previously only recorded completion (`OK`/`FAILED`) and the vault-commit `INGEST` line — all written *after* a multi-minute extraction finishes — so the completion-ordered log made concurrent work look sequential. The gap between a document's `START` and its own `OK`/`FAILED` is now that document's real extraction time, and the clustered `START` timestamps make the parallel launch visible.

- **`watchdog usage` reports wall-clock elapsed, not just summed call time.** Each usage record now carries an `end_ts` (epoch seconds at record time); paired with the existing `latency_s` it gives every call a `[start, end]` interval. `watchdog usage` now shows, per stage, the wall-clock span (`max(end) − min(start)`) alongside the summed per-call latency it already showed — because for a concurrent stage the summed figure overstates the real wait (three overlapping 4-minute calls took ~7 minutes of wall time, not 12). The elapsed line appears only when the stage's calls actually overlapped; the run TOTAL shows both figures side by side.

Old `usage-<ts>.json` files without `end_ts` fall back to the summed figure alone — `_wall_span` returns `None`, and the `totals`-block readers (`watchdog status`, the pre-flight estimate) are untouched.

## Docs / governance

- `docs/commands.md` — updated the `watchdog usage` description.
- `ARCHITECTURE.md` — registry-layout notes for `ingest.log` and usage telemetry.
- `DECISIONS.md` — D102.

## Testing

New: `test_ingest_log_records_start_before_ok`, `test_cmd_usage_shows_wall_clock_elapsed_for_concurrent_stage`, `test_cmd_usage_omits_wall_clock_when_no_end_ts`. Full suite: 1232 passed.