### PR TITLE
Fix 'Vault not found' when opening a vault registered while Obsidian is running

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -139,6 +139,18 @@ If a vault folder exists on disk but Watchdog doesn't know about it at all, regi
 watchdog register /path/to/the/vault-folder
 ```
 
+## Obsidian says "Vault not found"
+
+You ran `watchdog obsidian <name>` and Obsidian popped up a "Vault not found" error. This happens because Obsidian only reads its list of vaults when it starts up, so a vault created while Obsidian was already running is invisible to it until you restart.
+
+Quit Obsidian completely (not just close the window — use **Quit** so no Obsidian process is left running), then run the command again:
+
+```bash
+watchdog obsidian <name>
+```
+
+Newer versions of Watchdog detect this situation and tell you to restart Obsidian instead of showing the confusing error.
+
 ## Getting help
 
 If something isn't working, open an issue at [github.com/tomcardoso/watchdog/issues](https://github.com/tomcardoso/watchdog/issues). Include:

--- a/src/watchdog/cli.py
+++ b/src/watchdog/cli.py
@@ -39,7 +39,9 @@ from watchdog.cmd.base import (
 )
 from watchdog.cmd.vault import (
     _obsidian_config_path,
+    _obsidian_launch_epoch,
     _obsidian_registered,
+    _obsidian_vault_ts,
     _register_obsidian_vault,
     cmd_archive,
     cmd_delete,

--- a/src/watchdog/cmd/vault.py
+++ b/src/watchdog/cmd/vault.py
@@ -186,6 +186,49 @@ def _register_obsidian_vault(vault: Path) -> None:
         pass  # non-fatal — user can register manually via watchdog obsidian
 
 
+def _obsidian_vault_ts(vault: Path):
+    """The registration timestamp (ms since epoch) for `vault` in obsidian.json, or None."""
+    cfg = _obsidian_config_path()
+    if not cfg.exists():
+        return None
+    try:
+        data = json.loads(cfg.read_text())
+        for v in data.get("vaults", {}).values():
+            if v.get("path") == str(vault):
+                return v.get("ts")
+    except Exception:
+        return None
+    return None
+
+
+def _obsidian_launch_epoch():
+    """Epoch seconds when the running Obsidian was launched, or None if it is not
+    running or the start time can't be determined.
+
+    Obsidian reads obsidian.json only at startup, so a vault registered after
+    launch is invisible to the running instance until it is restarted.
+    """
+    if sys.platform == "win32":
+        return None
+    try:
+        out = subprocess.run(["pgrep", "-x", "Obsidian"], capture_output=True, text=True)
+    except Exception:
+        return None
+    pids = [p for p in out.stdout.split() if p.strip()]
+    if not pids:
+        return None
+    starts = []
+    for pid in pids:
+        try:
+            r = subprocess.run(["ps", "-o", "lstart=", "-p", pid], capture_output=True, text=True)
+            s = r.stdout.strip()
+            if s:
+                starts.append(datetime.strptime(s, "%a %b %d %H:%M:%S %Y").timestamp())
+        except Exception:
+            continue
+    return min(starts) if starts else None
+
+
 def cmd_register(args) -> None:
     vault = Path(args.path).expanduser().resolve() if args.path else Path.cwd()
 
@@ -441,6 +484,19 @@ def cmd_obsidian(args) -> None:
         print(f"  {_CYAN}{vault}{_RESET}")
         print()
         print(f"  After opening it once, {_CYAN}watchdog obsidian {info['name']}{_RESET} will work automatically.\n")
+        return
+    launch = _obsidian_launch_epoch()
+    ts = _obsidian_vault_ts(vault)
+    if launch is not None and ts is not None and launch < ts / 1000:
+        # Obsidian is running but was launched before this vault was registered,
+        # so its in-memory vault list doesn't include it — the URI would fail
+        # with "Vault not found". Ask the user to restart Obsidian.
+        print(f"\n  {_YELLOW}Obsidian is already running but hasn't loaded this vault yet.{_RESET}")
+        print()
+        print(f"  Obsidian only reads its vault list when it starts, and {_BOLD}{info['name']}{_RESET}")
+        print(f"  was registered afterwards.")
+        print()
+        print(f"  Quit Obsidian completely, then run {_CYAN}watchdog obsidian {info['name']}{_RESET} again.\n")
         return
     from urllib.parse import quote
     url = f"obsidian://open?path={quote(str(vault))}"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -376,6 +376,7 @@ def test_cmd_obsidian_opens_url(configured, monkeypatch):
     monkeypatch.setattr("watchdog.cmd.vault.subprocess.run", lambda cmd, **kw: calls.append(cmd) or type("R", (), {"returncode": 0})())
     monkeypatch.setattr("watchdog.cmd.vault.sys.platform", "darwin")
     monkeypatch.setattr("watchdog.cmd.vault._obsidian_registered", lambda v: True)
+    monkeypatch.setattr("watchdog.cmd.vault._obsidian_launch_epoch", lambda: None)
     cli.cmd_obsidian(args(name="My Story"))
     assert len(calls) == 1
     assert calls[0][0] == "open"
@@ -396,8 +397,25 @@ def test_cmd_obsidian_exits_on_failure(configured, monkeypatch):
     monkeypatch.setattr("watchdog.cmd.vault.subprocess.run", lambda cmd, **kw: type("R", (), {"returncode": 1})())
     monkeypatch.setattr("watchdog.cmd.vault.sys.platform", "darwin")
     monkeypatch.setattr("watchdog.cmd.vault._obsidian_registered", lambda v: True)
+    monkeypatch.setattr("watchdog.cmd.vault._obsidian_launch_epoch", lambda: None)
     with pytest.raises(SystemExit):
         cli.cmd_obsidian(args(name="My Story"))
+
+
+def test_cmd_obsidian_stale_launch_warns_to_restart(configured, monkeypatch, capsys):
+    cli.cmd_new(args(name="My Story", dir=str(configured)))
+    calls = []
+    monkeypatch.setattr("watchdog.cmd.vault.subprocess.run", lambda cmd, **kw: calls.append(cmd) or type("R", (), {"returncode": 0})())
+    monkeypatch.setattr("watchdog.cmd.vault.sys.platform", "darwin")
+    monkeypatch.setattr("watchdog.cmd.vault._obsidian_registered", lambda v: True)
+    # Obsidian launched (epoch 1000s) before the vault was registered (2000s) → stale.
+    monkeypatch.setattr("watchdog.cmd.vault._obsidian_launch_epoch", lambda: 1000.0)
+    monkeypatch.setattr("watchdog.cmd.vault._obsidian_vault_ts", lambda v: 2000_000)
+    cli.cmd_obsidian(args(name="My Story"))
+    out = capsys.readouterr().out
+    assert "hasn't loaded this vault yet" in out
+    assert "Quit Obsidian" in out
+    assert calls == []  # URI not fired — it would have shown "Vault not found"
 
 
 def test_cmd_obsidian_infers_project_from_cwd(configured, monkeypatch):
@@ -407,6 +425,7 @@ def test_cmd_obsidian_infers_project_from_cwd(configured, monkeypatch):
     monkeypatch.setattr("watchdog.cmd.vault.subprocess.run", lambda cmd, **kw: calls.append(cmd) or type("R", (), {"returncode": 0})())
     monkeypatch.setattr("watchdog.cmd.vault.sys.platform", "darwin")
     monkeypatch.setattr("watchdog.cmd.vault._obsidian_registered", lambda v: True)
+    monkeypatch.setattr("watchdog.cmd.vault._obsidian_launch_epoch", lambda: None)
     monkeypatch.chdir(vault)
     cli.cmd_obsidian(args(name=None))
     assert len(calls) == 1


### PR DESCRIPTION
## Problem

Running `watchdog obsidian <name>` on a freshly created vault could pop up an Obsidian **"Vault not found"** dialog, even though the vault exists and its entry is present in `obsidian.json`.

Root cause: Obsidian reads its vault list from `obsidian.json` **only at startup**. `watchdog new` pre-writes the vault entry into that file so one-command open works, but if Obsidian is already running it never reloads the file. `watchdog obsidian` saw the entry via `_obsidian_registered()` and fired the `obsidian://open?path=…` URI anyway, which the running instance rejected.

Quitting and relaunching Obsidian fixes it (it re-reads `obsidian.json`), which confirmed the diagnosis.

## Fix

- `_obsidian_launch_epoch()` — determines when the running Obsidian was launched (`pgrep` + `ps -o lstart=`), or `None` if it isn't running.
- `_obsidian_vault_ts()` — the vault's registration timestamp from `obsidian.json`.
- `cmd_obsidian` now compares the two: if Obsidian is running but was launched **before** the vault was registered, it prints a clear "quit Obsidian completely, then run this again" message instead of firing a URI that would fail with the confusing dialog.

When Obsidian isn't running (or already knew the vault at startup), behaviour is unchanged — the URI fires and the vault opens.

## Also

- Troubleshooting entry in `docs/troubleshooting.md`.
- Tests: existing `cmd_obsidian` tests patched to be environment-independent, plus a new test for the stale-launch branch.

All 302 tests in `tests/test_cli.py` pass.