### PR TITLE
Consolidate the definition of done into one CLAUDE.md checklist (#350)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,10 +1,22 @@
 # Watchdog — developer notes
 
+## Definition of done
+
+Check every non-trivial change against this list in one pass before calling it finished. Each item's full rule lives in the linked section — this checklist is the single source; the sections carry the detail, not a restatement of the obligation.
+
+- [ ] **Tests** written or updated, and the suite is green ([Testing](#testing))
+- [ ] **Lint** clean: `pipx run ruff check src tests` ([Linting](#linting))
+- [ ] **`ARCHITECTURE.md`** updated if the change alters the pipeline's structure, the code/model split, or the vault/registry layout ([Architecture](#architecture))
+- [ ] **`DECISIONS.md`** has a new `D<n>` entry (ascending order, newest last) if the change forecloses a future option or would read as a bug without the rationale ([Architecture](#architecture))
+- [ ] **Invariants** (`ARCHITECTURE.md` §15) updated if a governing rule was established or revised ([Architecture](#architecture))
+- [ ] The canonical **`docs/`** page updated for any user-facing change — CLI flag, `configure` key, command, default, workflow step ([Documentation](#documentation))
+- [ ] **`README.md`** left alone unless the pitch, requirements, install two-liner, or quick start changed ([Documentation](#documentation))
+
 ## Architecture
 
 Two files, split by how often they're read. **[ARCHITECTURE.md](ARCHITECTURE.md)** is the current-state map — how the pipeline is built, plus §15's **Invariants** (I1–I5), the canonical governing rules. Read it to orient; it's kept lean so it stays loadable every session. **[DECISIONS.md](DECISIONS.md)** is the dated, numbered history of specific decisions (D1, D2, …) — the rationale and tradeoff for each — read on demand when you need the *why* behind a past choice.
 
-**When a change alters the pipeline's structure, the split between deterministic code and the model, or the vault/registry layout, update `ARCHITECTURE.md` in the same change**, and append a `### D<n>` entry to `DECISIONS.md` (ascending order, newest last). If the change establishes or revises a governing rule, update the Invariants section in `ARCHITECTURE.md` too. **Keep decision entries concise** — a few sentences of rationale, then the tradeoff; the full record is in git and the PR, not the log. A decision earns an entry only if it forecloses a future option or would read as a bug without the rationale; pure refactors belong in the commit message. Treat both as part of the definition of done, like tests.
+**When a change alters the pipeline's structure, the split between deterministic code and the model, or the vault/registry layout, update `ARCHITECTURE.md` in the same change**, and append a `### D<n>` entry to `DECISIONS.md` (ascending order, newest last). If the change establishes or revises a governing rule, update the Invariants section in `ARCHITECTURE.md` too. **Keep decision entries concise** — a few sentences of rationale, then the tradeoff; the full record is in git and the PR, not the log. A decision earns an entry only if it forecloses a future option or would read as a bug without the rationale; pure refactors belong in the commit message. Both are items on the [definition of done](#definition-of-done).
 
 ## Documentation
 
@@ -18,7 +30,7 @@ Two files, split by how often they're read. **[ARCHITECTURE.md](ARCHITECTURE.md)
 - `docs/skills.md` — the record-skill catalog (update when adding a skill)
 - `docs/troubleshooting.md` — failure modes and fixes
 
-`README.md` is a deliberately slim front door (~120 lines) — it names capabilities but documents nothing in detail; it only changes when the pitch, requirements, install two-liner, or quick start change. Do not add command tables, configuration keys, or workflow detail back into it. The docs are written for working journalists who may never have used a terminal: serious, precise, conversational — no exclamation marks, no hype, short paragraphs, jargon defined at first use, Canadian English. Treat doc updates as part of the definition of done, like tests.
+`README.md` is a deliberately slim front door (~120 lines) — it names capabilities but documents nothing in detail; it only changes when the pitch, requirements, install two-liner, or quick start change. Do not add command tables, configuration keys, or workflow detail back into it. The docs are written for working journalists who may never have used a terminal: serious, precise, conversational — no exclamation marks, no hype, short paragraphs, jargon defined at first use, Canadian English. Doc updates are an item on the [definition of done](#definition-of-done).
 
 ## Testing
 


### PR DESCRIPTION
Fixes #350.

Adds a **Definition of done** section at the top of CLAUDE.md — a seven-item checklist (tests, lint, ARCHITECTURE.md, DECISIONS.md entry, invariants, canonical docs page, README left alone) that a change can be checked against in one pass. Each item links to the existing section that carries the full rule, so the checklist is the single statement of the *obligation* and the sections keep the *detail* — no rule text was duplicated or moved.

The two scattered "treat X as part of the definition of done, like tests" sentences (in Architecture and Documentation) now point at the checklist instead of restating it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)