### PR TITLE
Persist the page-coverage gap on the document registry record (#339)

### DIFF
--- a/src/watchdog/pipeline/orchestrate.py
+++ b/src/watchdog/pipeline/orchestrate.py
@@ -301,43 +301,6 @@ async def _classify(doc_excerpt: str, model: str, backend: str | None = None,
     return r.parsed.get("skill") or "general-records.md"
 
 
-# Page-coverage heuristic (skim detection). Advisory only — emits a warning, never a failure.
-_COVERAGE_MIN_PAGES = 8         # don't flag short documents
-# Flag when the largest run of consecutive uncited pages is at least this share of the document.
-# Gap-based rather than tail-based (#339): the old "nothing cited past the halfway point" rule
-# missed interior holes — a model that cites pages 1–10 and 40–50 of a 50-pager read nothing in
-# between, which is the signature of a skim just as much as a truncated tail is.
-_COVERAGE_GAP_FRACTION = 0.4
-
-
-def _coverage_warning(extraction: dict, page_count: int | None) -> str | None:
-    """Flag a possible skim: when a large consecutive run of a multi-page document's pages —
-    leading, interior, or trailing — is cited by no fact, the model likely skipped it (#339).
-    A heuristic, deterministic signal for review, not a hard check: a genuinely boilerplate span
-    (standard-form clauses, recitals) legitimately goes uncited and trips it too. Facts carry an
-    optional `page`; a doc with no page anchors at all can't be assessed."""
-    if not page_count or page_count < _COVERAGE_MIN_PAGES:
-        return None
-    facts = extraction.get("document", {}).get("key_facts", [])
-    cited = sorted({f["page"] for f in facts
-                    if isinstance(f, dict) and isinstance(f.get("page"), int)
-                    and not isinstance(f.get("page"), bool)
-                    and 1 <= f["page"] <= page_count})   # ignore out-of-range citations
-    if not cited:
-        return None
-    # Largest uncited run, including before the first cite and after the last.
-    bounds = [0, *cited, page_count + 1]
-    gap_len, gap_span = 0, (0, 0)
-    for a, b in zip(bounds, bounds[1:]):
-        if b - a - 1 > gap_len:
-            gap_len, gap_span = b - a - 1, (a + 1, b - 1)
-    if gap_len < page_count * _COVERAGE_GAP_FRACTION:
-        return None
-    start, end = gap_span
-    return (f"no facts cite pages {start}–{end} ({gap_len} of {page_count} pages) — the model "
-            f"may have skipped them; check that span of the source for anything missed")
-
-
 def _briefing_facts(doc: dict) -> list[dict]:
     """Project key_facts down to what the briefing needs — the fact text and, when the fact is a
     datable occurrence, its date (for chronology). Drops page/basis/entities/quote, which are
@@ -645,22 +608,22 @@ async def _extract_document(vault: Path, sha: str, brief: str | None,
 
     if not ok:
         return _fail(vault, sha, filename, "post-flight rejected: " + "; ".join(errors[:3]))
-    return _finish_extraction(vault, sha, filename, extraction, scratchpad, cost, pf, page_count, warnings)
+    return _finish_extraction(vault, sha, filename, extraction, scratchpad, cost, pf, warnings)
 
 
 
 def _finish_extraction(vault: Path, sha: str, filename: str, extraction: dict, scratchpad: str,
-                       cost: float, pf: dict, page_count: int | None,
+                       cost: float, pf: dict,
                        warnings: list[str] | None = None) -> dict:
-    """Shared tail once an extraction has passed post-flight: settle-print, warnings, coverage
-    warning, log, persist `result_<sha>.json`. Used by both the synchronous per-document path
+    """Shared tail once an extraction has passed post-flight: settle-print, warnings, log,
+    persist `result_<sha>.json`. Used by both the synchronous per-document path
     (`_extract_document`) and the batch-collect path (`_finish_batch_item`, #214) so a
     batch-extracted document produces an identical result shape to a synchronous one.
 
-    `warnings` (post-flight's quote-verify/sanitization messages, if any) are printed here —
-    after the OK line, not when post-flight ran — so they're tucked visually under this
-    document's own row instead of landing wherever a concurrently-extracting document
-    happened to be at the time (#333 follow-up)."""
+    `warnings` (post-flight's quote-verify/sanitization/coverage-gap messages, if any) are
+    printed here — after the OK line, not when post-flight ran — so they're tucked visually
+    under this document's own row instead of landing wherever a concurrently-extracting
+    document happened to be at the time (#333 follow-up)."""
     if scratchpad:
         (vault / ".watchdog" / "tmp" / f"notes_{sha}.md").write_text(scratchpad, encoding="utf-8")
     for stale in (vault / ".watchdog" / "tmp").glob(f"section_{sha}_*.md"):
@@ -674,10 +637,6 @@ def _finish_extraction(vault: Path, sha: str, filename: str, extraction: dict, s
     for msg in (warnings or []):
         _say(f"   {_YELLOW}⚠{_RESET}  {_DIM}{msg}{_RESET}")
         _log(vault, f"WARN {filename}: {msg}")
-    warn = _coverage_warning(extraction, page_count)
-    if warn:
-        _say(f"   {_YELLOW}⚠{_RESET}  {_DIM}{warn}{_RESET}")
-        _log(vault, f"WARN {filename}: {warn}")
     result = _compact_result(sha, filename, extraction, pf.get("near_dup", {}), round(cost, 6))
     # Persist the compact result so `watchdog finalize` can run post-ingest from disk alone.
     (vault / ".watchdog" / "tmp" / f"result_{sha}.json").write_text(
@@ -754,7 +713,7 @@ async def _finish_batch_item(vault: Path, sha: str, item: dict | None, skill_tex
     ok, errors, warnings = _write_postflight(vault, sha, extraction)
     if not ok:
         return _fail(vault, sha, filename, "post-flight rejected: " + "; ".join(errors[:3]))
-    return _finish_extraction(vault, sha, filename, extraction, scratchpad, cost, pf, page_count, warnings)
+    return _finish_extraction(vault, sha, filename, extraction, scratchpad, cost, pf, warnings)
 
 
 

--- a/src/watchdog/pipeline/postflight.py
+++ b/src/watchdog/pipeline/postflight.py
@@ -18,6 +18,51 @@ from pathlib import Path
 _VALID_BASIS = {"stated", "inferred"}
 _DATE_RE = re.compile(r"^\d{4}(-\d{2}(-\d{2})?)?$")
 
+# Page-coverage heuristic (skim detection). Advisory only — emits a warning, never a failure.
+_COVERAGE_MIN_PAGES = 8         # don't flag short documents
+# Flag when the largest run of consecutive uncited pages is at least this share of the document.
+# Gap-based rather than tail-based (#339): the old "nothing cited past the halfway point" rule
+# missed interior holes — a model that cites pages 1–10 and 40–50 of a 50-pager read nothing in
+# between, which is the signature of a skim just as much as a truncated tail is.
+_COVERAGE_GAP_FRACTION = 0.4
+
+
+def _find_coverage_gap(extraction: dict, page_count: int | None) -> dict | None:
+    """Find a possible skim: when a large consecutive run of a multi-page document's pages —
+    leading, interior, or trailing — is cited by no fact, the model likely skipped it (#339).
+    A heuristic, deterministic signal for review, not a hard check: a genuinely boilerplate span
+    (standard-form clauses, recitals) legitimately goes uncited and trips it too. Facts carry an
+    optional `page`; a doc with no page anchors at all can't be assessed. Returns the flagged
+    span as ``{"start", "end", "pages"}``, or None when there's no qualifying gap."""
+    if not page_count or page_count < _COVERAGE_MIN_PAGES:
+        return None
+    facts = extraction.get("document", {}).get("key_facts", [])
+    cited = sorted({f["page"] for f in facts
+                    if isinstance(f, dict) and isinstance(f.get("page"), int)
+                    and not isinstance(f.get("page"), bool)
+                    and 1 <= f["page"] <= page_count})   # ignore out-of-range citations
+    if not cited:
+        return None
+    # Largest uncited run, including before the first cite and after the last.
+    bounds = [0, *cited, page_count + 1]
+    gap_len, gap_span = 0, (0, 0)
+    for a, b in zip(bounds, bounds[1:]):
+        if b - a - 1 > gap_len:
+            gap_len, gap_span = b - a - 1, (a + 1, b - 1)
+    if gap_len < page_count * _COVERAGE_GAP_FRACTION:
+        return None
+    start, end = gap_span
+    return {"start": start, "end": end, "pages": gap_len}
+
+
+def _render_coverage_warning(gap: dict, page_count: int) -> str:
+    """Render `_find_coverage_gap`'s structured result as the human-readable warning text —
+    byte-identical to the pre-#339-persistence wording, since the log format downstream depends
+    on it."""
+    return (f"no facts cite pages {gap['start']}–{gap['end']} ({gap['pages']} of {page_count} "
+            f"pages) — the model may have skipped them; check that span of the source for "
+            f"anything missed")
+
 
 def _validate(data: dict) -> list[str]:
     errors: list[str] = []
@@ -263,6 +308,17 @@ def run(vault: Path, extraction_path: Path, quiet: bool = False, warn=None) -> d
     from watchdog.pipeline.file_metadata import check_date_mismatch
     for warning in check_date_mismatch(extraction, processing):
         _warn(warning)
+
+    # Skim-detection heuristic (#339), computed after the sanitization above so it reflects the
+    # facts that actually persist. Persisted structurally on the document record — `coverage_gap`
+    # is written explicitly even when None, so a record with the key present means "assessed by
+    # the gap detector" (#339 follow-up: benchmark scoring and gap-frequency questions no longer
+    # need to scrape ingest.log).
+    page_count = extraction.get("document", {}).get("page_count")
+    gap = _find_coverage_gap(extraction, page_count)
+    extraction["document"]["coverage_gap"] = gap
+    if gap:
+        _warn(_render_coverage_warning(gap, page_count))
 
     # Write the validated (and match_id-resolved) extraction back so write_vault reads it
     extraction_path.write_text(

--- a/src/watchdog/pipeline/write_vault.py
+++ b/src/watchdog/pipeline/write_vault.py
@@ -906,6 +906,7 @@ def run(extraction_path: Path, vault_path: Path, neardup_file: Path | None = Non
             "extract_model":    doc.get("extract_model"),
             "extract_effort":   doc.get("extract_effort"),
             "file_metadata":    doc.get("file_metadata") or {},
+            "coverage_gap":     doc.get("coverage_gap"),
             "entities_extracted": [e["id"] for e in incoming_entities],
             "near_duplicate_of": doc.get("near_duplicate_of"),
             "minhash":          sig,

--- a/tests/test_orchestrate.py
+++ b/tests/test_orchestrate.py
@@ -65,55 +65,6 @@ def _mock(monkeypatch, *, extraction):
     monkeypatch.setattr(orchestrate.model_client, "acomplete_json", fake)
 
 
-def _ext_with_fact_pages(pages):
-    return {"document": {"key_facts": [{"fact": "f", "page": p} for p in pages]}}
-
-
-def test_coverage_warning_flags_front_loaded_extraction():
-    # 36-page doc, facts only on pages 1-4 → the trailing 32-page uncited run (89%) → warn
-    warn = orchestrate._coverage_warning(_ext_with_fact_pages([1, 2, 3, 4]), 36)
-    assert warn and "may have skipped" in warn and "of 36 pages" in warn
-    assert "pages 5–36" in warn              # actionable span = the uncited run
-
-
-def test_coverage_warning_flags_interior_gap():
-    # 50-page doc cited at both ends but with a 29-page hole in the middle (58%) — the old
-    # tail-only rule passed this clean; the gap rule is the point of #339.
-    warn = orchestrate._coverage_warning(
-        _ext_with_fact_pages([1, 4, 7, 10, 40, 45, 50]), 50)
-    assert warn and "pages 11–39" in warn and "29 of 50 pages" in warn
-
-
-def test_coverage_warning_flags_leading_gap():
-    # Facts only in the back half: the *leading* 44-page run is the flagged span.
-    warn = orchestrate._coverage_warning(_ext_with_fact_pages([45, 48, 50]), 50)
-    assert warn and "pages 1–44" in warn
-
-
-def test_coverage_warning_ignores_out_of_range_citations():
-    # A fabricated page 999 must not mask the real uncited tail (or create negative gaps).
-    warn = orchestrate._coverage_warning(_ext_with_fact_pages([1, 2, 999]), 40)
-    assert warn and "pages 3–40" in warn
-
-
-def test_coverage_warning_silent_when_well_covered():
-    # Largest uncited run is 14 pages (6–19) of 36 — under the 40% gap threshold → no warning
-    assert orchestrate._coverage_warning(_ext_with_fact_pages([1, 5, 20, 30]), 36) is None
-
-
-def test_coverage_warning_skips_short_docs():
-    assert orchestrate._coverage_warning(_ext_with_fact_pages([1]), 5) is None
-
-
-def test_coverage_warning_skips_when_no_page_anchors():
-    ext = {"document": {"key_facts": [{"fact": "f"}, {"fact": "g", "page": None}]}}
-    assert orchestrate._coverage_warning(ext, 40) is None
-
-
-def test_coverage_warning_handles_missing_page_count():
-    assert orchestrate._coverage_warning(_ext_with_fact_pages([1, 2]), None) is None
-
-
 def test_postflight_quote_warning_prints_after_this_documents_ok_line(tmp_path, monkeypatch, capsys):
     """A post-flight warning (quote-verify, entity-id/date sanitization) must land *after* its
     own document's OK line, not whenever post-flight happened to run — otherwise it reads as

--- a/tests/test_postflight.py
+++ b/tests/test_postflight.py
@@ -1,7 +1,14 @@
 import json
 from pathlib import Path
 
-from watchdog.pipeline.postflight import _apply_match_ids, _sanitize_dates, _sanitize_entity_ids, explode_key_facts
+from watchdog.pipeline.postflight import (
+    _apply_match_ids,
+    _find_coverage_gap,
+    _render_coverage_warning,
+    _sanitize_dates,
+    _sanitize_entity_ids,
+    explode_key_facts,
+)
 from watchdog.pipeline.postflight import run as postflight_run
 
 
@@ -167,6 +174,61 @@ def test_sanitize_entity_ids_identical_duplicate_keeps_references_on_first():
     assert [e["id"] for e in extraction["entities"]] == ["acme-corp", "acme-corp-2"]
     assert extraction["document"]["key_facts"][0]["entities"] == ["acme-corp"]
     assert extraction["entities"][1]["roles"][0]["target_id"] == "acme-corp"
+
+# ── _find_coverage_gap / _render_coverage_warning (#339 gap detector) ───────────────────────
+
+def _ext_with_fact_pages(pages):
+    return {"document": {"key_facts": [{"fact": "f", "page": p} for p in pages]}}
+
+
+def test_coverage_gap_flags_front_loaded_extraction():
+    # 36-page doc, facts only on pages 1-4 → the trailing 32-page uncited run (89%) → flagged
+    gap = _find_coverage_gap(_ext_with_fact_pages([1, 2, 3, 4]), 36)
+    assert gap == {"start": 5, "end": 36, "pages": 32}
+    warn = _render_coverage_warning(gap, 36)
+    assert "may have skipped" in warn and "of 36 pages" in warn and "pages 5–36" in warn
+
+
+def test_coverage_gap_flags_interior_gap():
+    # 50-page doc cited at both ends but with a 29-page hole in the middle (58%) — the old
+    # tail-only rule passed this clean; the gap rule is the point of #339.
+    gap = _find_coverage_gap(_ext_with_fact_pages([1, 4, 7, 10, 40, 45, 50]), 50)
+    assert gap == {"start": 11, "end": 39, "pages": 29}
+    warn = _render_coverage_warning(gap, 50)
+    assert "pages 11–39" in warn and "29 of 50 pages" in warn
+
+
+def test_coverage_gap_flags_leading_gap():
+    # Facts only in the back half: the *leading* 44-page run is the flagged span.
+    gap = _find_coverage_gap(_ext_with_fact_pages([45, 48, 50]), 50)
+    assert gap == {"start": 1, "end": 44, "pages": 44}
+    assert "pages 1–44" in _render_coverage_warning(gap, 50)
+
+
+def test_coverage_gap_ignores_out_of_range_citations():
+    # A fabricated page 999 must not mask the real uncited tail (or create negative gaps).
+    gap = _find_coverage_gap(_ext_with_fact_pages([1, 2, 999]), 40)
+    assert gap == {"start": 3, "end": 40, "pages": 38}
+    assert "pages 3–40" in _render_coverage_warning(gap, 40)
+
+
+def test_coverage_gap_silent_when_well_covered():
+    # Largest uncited run is 14 pages (6–19) of 36 — under the 40% gap threshold → no gap
+    assert _find_coverage_gap(_ext_with_fact_pages([1, 5, 20, 30]), 36) is None
+
+
+def test_coverage_gap_skips_short_docs():
+    assert _find_coverage_gap(_ext_with_fact_pages([1]), 5) is None
+
+
+def test_coverage_gap_skips_when_no_page_anchors():
+    ext = {"document": {"key_facts": [{"fact": "f"}, {"fact": "g", "page": None}]}}
+    assert _find_coverage_gap(ext, 40) is None
+
+
+def test_coverage_gap_handles_missing_page_count():
+    assert _find_coverage_gap(_ext_with_fact_pages([1, 2]), None) is None
+
 
 # ── end-to-end through postflight ───────────────────────────────────────────
 
@@ -351,3 +413,54 @@ def test_postflight_silent_on_date_mismatch_when_ocr_used(tmp_path, capsys):
 
     err = capsys.readouterr().err
     assert "postdates" not in err
+
+
+# ── coverage_gap persisted on the document registry record (#339 skip-telemetry) ────────────
+
+def _gappy_extraction(sha="sha777aaa"):
+    """A 12-page doc with a fact only on page 1 — an 11-page uncited tail (92%) flags a gap."""
+    ext = _extraction(sha)
+    ext["document"]["page_count"] = 12
+    ext["document"]["key_facts"] = [{"fact": "Filed.", "page": 1, "entities": ["lu"]}]
+    return ext
+
+
+def test_postflight_persists_coverage_gap_on_document_registry_record(tmp_path):
+    vault = _full_vault(tmp_path)
+    (vault / "_INCOMING" / "doc.pdf").write_text("pdf")
+    ext_path = vault / ".watchdog" / "tmp" / "wdg_ex_sha777aaa.json"
+    ext_path.write_text(json.dumps(_gappy_extraction()), encoding="utf-8")
+
+    result = postflight_run(vault, ext_path)
+    assert result.get("ok"), result
+
+    documents_reg = json.loads((vault / ".watchdog" / "Registry" / "documents.json").read_text())
+    assert documents_reg["sha777aaa"]["coverage_gap"] == {"start": 2, "end": 12, "pages": 11}
+
+
+def test_postflight_persists_none_coverage_gap_for_clean_extraction(tmp_path):
+    vault = _full_vault(tmp_path)
+    (vault / "_INCOMING" / "doc.pdf").write_text("pdf")
+    ext_path = vault / ".watchdog" / "tmp" / "wdg_ex_sha777aaa.json"
+    # The default fixture's page_count (2) is under the 8-page minimum — never assessable as a gap.
+    ext_path.write_text(json.dumps(_extraction()), encoding="utf-8")
+
+    result = postflight_run(vault, ext_path)
+    assert result.get("ok"), result
+
+    documents_reg = json.loads((vault / ".watchdog" / "Registry" / "documents.json").read_text())
+    record = documents_reg["sha777aaa"]
+    assert "coverage_gap" in record   # key present even when assessed clean/not-assessable
+    assert record["coverage_gap"] is None
+
+
+def test_postflight_coverage_gap_warning_reaches_warn_callback(tmp_path):
+    vault = _full_vault(tmp_path)
+    (vault / "_INCOMING" / "doc.pdf").write_text("pdf")
+    ext_path = vault / ".watchdog" / "tmp" / "wdg_ex_sha777aaa.json"
+    ext_path.write_text(json.dumps(_gappy_extraction()), encoding="utf-8")
+
+    warnings = []
+    result = postflight_run(vault, ext_path, warn=warnings.append)
+    assert result.get("ok"), result
+    assert any("pages 2–12" in w and "may have skipped" in w for w in warnings)


### PR DESCRIPTION
Part of #339 (step 1 follow-up). The skim-detection warning previously reached only the terminal and the append-only ingest log, so answering "how often do coverage gaps fire, and where" — the telemetry #361's benchmark scoring and #339's step-3 decision are sized from — meant scraping `ingest.log`.

## What changed

- The old `_coverage_warning` in `orchestrate.py` is split into a pure gap-finder (`postflight._find_coverage_gap`, returning `{"start", "end", "pages"}` or `None`) and a renderer that reproduces the warning text byte-identically. Same thresholds and semantics: 8-page minimum, 40% gap fraction, out-of-range citations ignored, no page anchors ⇒ not assessable.
- The check now runs in post-flight, after fact sanitization, so the persisted gap reflects the facts that actually land in the vault. Post-flight stamps `document.coverage_gap` (explicitly, even when `None` — a record with the key present means "assessed by the gap detector") before `write_vault` reads the extraction.
- `write_vault` copies `coverage_gap` onto the `documents.json` registry record alongside the other extraction provenance fields (`extract_model`, `extract_effort`).
- The rendered warning reaches `_finish_extraction`'s existing warnings loop via post-flight's `warn` callback, so terminal and ingest-log output are unchanged. Both extraction paths (synchronous and claude-batch) funnel through the same post-flight call site, so one implementation point covers both.

No new config keys, no threshold or wording changes, no behaviour change beyond the persisted field.

## Testing

The eight gap-finder unit tests moved from `test_orchestrate.py` to `test_postflight.py` (now asserting the structured return), plus three new end-to-end tests: the registry record carries the structured gap for a gappy document, carries an explicit `None` for a clean one, and the warning reaches the `warn` callback. Mutation-checked: inverting the gap comparison turns seven tests red. Full suite: 1398 passed; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)