### PR TITLE
Freeze corpus-v1: the benchmark corpus for #361 / #215

### DIFF
--- a/tests/documents/CORPUS-v1.md
+++ b/tests/documents/CORPUS-v1.md
@@ -96,6 +96,15 @@ public university in Canada to use the *Companies' Creditors Arrangement Act*.
 
 Keys live in `keys/` (one YAML per document), drafted from the **source documents** — never from a
 pipeline extraction — and **frozen before any condition runs**. See #361 for why model-drafted keys
-are legitimate for this benchmark and what their limits are. The `must_not_miss` list for document 3
-(the 70-page FY2020-21 report) is **hand-written** — that is the one part a model judge cannot be
-trusted with, because it misses the same buried items the extractor does.
+are legitimate for this benchmark and what their limits are.
+
+The `must_not_miss` list for document 3 (the 70-page FY2020-21 report) gets a **dedicated adversarial
+pass** whose only job is hunting buried items — walk the schedules, footnotes, signature blocks, and
+appendices. Run that pass on **two model families (Opus and Gemini) and take the union**. The risk
+here is *correlation*, not capability: a list drafted by Opus alone omits whatever Opus misses, and
+Opus's blind spots correlate with Sonnet's and Haiku's — so Haiku would "pass" on a schedule nobody
+ever wrote down. Independence fixes that; human labour doesn't.
+
+A human then **reviews** the union — that is where a journalist's judgement earns its keep (is this
+buried item material, or trivia?), and it is the quality gate for the whole benchmark: a frozen key
+with a bad fact in it silently corrupts all four conditions at once, and nothing downstream catches it.

--- a/tests/documents/CORPUS-v1.md
+++ b/tests/documents/CORPUS-v1.md
@@ -1,0 +1,101 @@
+# corpus-v1 — the benchmark corpus for #361 / #215
+
+Frozen 2026-07-13. **Do not edit, re-save, or re-export any file listed in `corpus-v1.sha256`.**
+Document identity in the pipeline is the sha256 — changing a single byte silently makes two runs
+incomparable, with nothing to warn you. Verify before every run:
+
+```
+cd tests/documents && shasum -a 256 -c corpus-v1.sha256
+```
+
+These PDFs are committed to git, so the corpus is version-controlled as well as hashed.
+
+## What this corpus is for
+
+One set of documents, re-ingested under four conditions, to settle three decisions:
+
+- **#361** — should the shipped Claude default for extraction stay `sonnet` or drop to `haiku`?
+- **#361** — is DeepSeek good enough to *document* as the cost-saving route for large ingests?
+- **#215** — should the default reasoning effort stay `high` or drop to `medium`?
+
+#217 (`classify_pages`) and #297 (briefing from digests) ride along on the same runs.
+
+## The six documents
+
+| # | File | Pages | Text layer | Role in the benchmark |
+|---|------|-------|-----------|----------------------|
+| 1 | `Annual-Financial-Report-19-20.pdf` | 36 | born-digital | **Contradiction side A** |
+| 2 | `Laurentian Pre-Filing Report of the Proposed Monitor.pdf` | 47 | born-digital | **Contradiction side B** |
+| 3 | `Annual-Financial-Report-20-21.pdf` | 70 | born-digital | **The dense 50+ page document** — sectioning, page coverage, output ceiling |
+| 4 | `CV-21-00656040-00CL Laurentian U Initial Order 1 FEB 2021.pdf` | 17 | **scanned — OCR** | The OCR arm; a clean-PDF corpus flatters every model |
+| 5 | `Laurentian First Report of the Monitor.pdf` | 34 | born-digital | Entity overlap — E&Y, the Board, the DIP facility |
+| 6 | `Pension Order Morawetz CJ- March 17 2021(as stamped by Court).PDF` | 5 | born-digital | A short, sharp document for contrast |
+
+**209 pages.** All are public court filings or published institutional financial reports — nothing
+source-sensitive, which matters because these get shipped to several model providers, repeatedly.
+
+## The contradiction pair (the thing being scored)
+
+Documents 1 and 2. **Neither document mentions the other**, so a model has to *notice* the conflict
+rather than read it off the page — which is the whole point. Both sides are explicit, positive
+claims, so the extractor can actually fire on it (a contradiction needs two stated claims; it
+cannot fire on silence).
+
+**Side A — Annual Financial Report, FY ended 30 April 2020** (published late 2020):
+
+> "The fiscal 2019-20 approved budget expected **balanced results from operations**… the University
+> was **on track** to operating fiscal year 2019-20 with an anticipated **small deficit of $0.9
+> million** from operations." *(p. 4)*
+>
+> "The net impact was an operating deficit of **$5.4 million of which $5.2 million is related to the
+> COVID-19 outbreak**." *(p. 4)*
+>
+> "Laurentian's commitment… is unwavering as it **continues to trace its path to sustainability**."
+> *(pp. 3, 10)*
+>
+> "The University has **$52.8 million in endowment, an increase of $1 million** over 2018-19." *(p. 8)*
+
+**Side B — Pre-Filing Report of the Proposed Monitor (Ernst & Young)**, weeks later:
+
+> "**LU is insolvent** and absent the relief sought in the Initial Order, will not have sufficient
+> funding / liquidity to **meet payroll in February**." *(p. 31, ¶165)*
+
+A university claiming a $0.9M planned deficit, blaming COVID, and tracing a "path to sustainability"
+— then unable to make payroll within months.
+
+## Deliberately excluded
+
+**The Auditor General of Ontario's Special Report on Laurentian University is NOT in this corpus, by
+design.** It *states the contradiction out loud* ("presented budget deficits year over year, while
+publicly saying it was presenting balanced budgets"). Including it would let a model copy the answer
+instead of deriving it — you would be scoring reading comprehension, not the contradiction machinery.
+
+Use it instead as the **answer-key oracle**: an authoritative, page-cited account of what was
+actually true, which is what makes model-drafted keys trustworthy here. It corroborates, among other
+things, that deficits dated to 2014 (not COVID), that $73M in donations were not segregated, and that
+$36.5M in restricted research money had been spent on capital.
+<https://www.auditor.on.ca/en/content/specialreports/specialreports/LaurentianUniversity_EN.pdf>
+
+Also left out of corpus-v1, but available in this folder if a document needs swapping: the Second and
+Third Reports of the Monitor, the Claims Process Order, and the Appointment of Mediator Order.
+
+## Provenance
+
+All documents relate to **Laurentian University's CCAA insolvency** (Ontario Superior Court of
+Justice, Commercial List, **court file CV-21-00656040-00CL**), filed 1 February 2021 — the first
+public university in Canada to use the *Companies' Creditors Arrangement Act*.
+
+- **Annual financial reports** — published by Laurentian University (`laurentian.ca`), audited
+  consolidated statements plus management discussion.
+- **Monitor's reports and the Pre-Filing Report** — Ernst & Young Inc., court-appointed monitor;
+  filed with the court and published to the monitor's public document repository.
+- **Court orders** — issued by the Ontario Superior Court of Justice (Commercial List); the Initial
+  Order is a court-stamped scan, which is why it carries no text layer.
+
+## Answer keys
+
+Keys live in `keys/` (one YAML per document), drafted from the **source documents** — never from a
+pipeline extraction — and **frozen before any condition runs**. See #361 for why model-drafted keys
+are legitimate for this benchmark and what their limits are. The `must_not_miss` list for document 3
+(the 70-page FY2020-21 report) is **hand-written** — that is the one part a model judge cannot be
+trusted with, because it misses the same buried items the extractor does.

--- a/tests/documents/HANDOFF.md
+++ b/tests/documents/HANDOFF.md
@@ -1,0 +1,97 @@
+# Handoff — pick up the #361 / #215 measurement pass
+
+Paste the block below into a fresh session, from the repo root.
+
+---
+
+We're running the extraction benchmark that gates #361 (shipped Claude default + DeepSeek
+validation), #215 (reasoning-effort default), and several issues riding along on the same runs.
+**corpus-v1 is already frozen — do not re-select or re-freeze documents.**
+
+## Read these first, in this order
+
+1. `tests/documents/CORPUS-v1.md` — the frozen corpus: which six documents, why each one, the
+   contradiction pair being scored, and what's deliberately excluded. Start here.
+2. The runbook artifact: <https://claude.ai/code/artifact/ef5f5a01-bc42-49d5-9b91-12a6c3383bce>
+   — the seven steps, whose job each one is, and what it costs. **Steps 1 and 2 are done.**
+3. GitHub issue #361 (`gh issue view 361`) — the protocol and the decision rules. Note the
+   2026-07-13 revision: **answer keys are model-drafted, not hand-written.**
+
+## Where things stand
+
+- **Step 1 (choose documents) — DONE.** Six Laurentian CCAA documents, 209 pages, born-digital and
+  scanned mixed, all public.
+- **Step 2 (freeze) — DONE.** `tests/documents/corpus-v1.sha256`; provenance in `CORPUS-v1.md`.
+  Committed on branch `benchmark-corpus-v1` (not yet merged — open a PR for it, or fold it into the
+  first real PR). Verify any time with:
+  `cd tests/documents && shasum -a 256 -c corpus-v1.sha256`
+- **Steps 3–7 — TO DO.** Detailed below.
+
+## Step 3 — build the answer keys
+
+One YAML per document in `tests/documents/keys/`, drafted **from the source PDFs — never from a
+pipeline extraction** — and **frozen before any condition runs**. Schema and rationale are in
+`CORPUS-v1.md` and #361.
+
+Two rules that are load-bearing, not stylistic:
+
+- **The `must_not_miss` list for `Annual-Financial-Report-20-21.pdf` (the dense 70-page document) is
+  hand-written by Tom.** ~20 minutes. Do not draft it for him and do not skip it. A model skimming a
+  70-page filing misses the same buried items the extractor misses, so both look fine and the
+  benchmark quietly learns nothing — and buried-item degradation is exactly how Haiku and DeepSeek
+  are expected to fail. **Ask him for it; don't proceed without it.**
+- **Use the Auditor General's special report as the oracle** when drafting the keys — it is the
+  page-cited account of what was actually true. Keep it OUT of the corpus.
+  <https://www.auditor.on.ca/en/content/specialreports/specialreports/LaurentianUniversity_EN.pdf>
+
+The contradiction that must appear in the keys is documented in full, with quotes and page numbers,
+in `CORPUS-v1.md`. Don't re-derive it.
+
+## Step 4 — four vaults, one condition each
+
+Fresh vault per condition — **never reuse a vault**, carried-over entities contaminate everything
+downstream of pre-flight. Same documents, same order, `--skill` pinned so classification variance
+doesn't pollute an extraction comparison.
+
+| Vault | Condition | Flags |
+|-------|-----------|-------|
+| bench-a | Baseline (and #215's `high` arm) | `--extractor-model sonnet --extractor-effort high` |
+| bench-b | #215: medium effort | `--extractor-model sonnet --extractor-effort medium` |
+| bench-c | #361: Haiku as shipped default? | `--extractor-model haiku --extractor-effort high` |
+| bench-d | #361: DeepSeek | `--extractor-model deepseek:<model>` |
+
+## Step 5 — the runs ⚠️
+
+**Do not run these without Tom's explicit go-ahead.** They cost real money and share his
+subscription session window. Roughly **$10–15 total** across the four conditions (209 pages;
+the artifact's "$6–9" predates the final corpus and is low — correct it if you touch the page).
+
+`watchdog ingest --estimate` gives a free cost preview first. After each run, capture before
+touching the next vault — usage, briefings, timeline, hot.md, and a Registry snapshot — and **keep
+the terminal output**: page-coverage warnings and per-document digest-size lines print only there
+and are not recoverable afterwards.
+
+## Steps 6–7 — score and decide
+
+Judge model must **not** be a model under test (self-preference bias), and blind it regardless:
+strip which condition produced which output, randomize order. Credit matches in three tiers —
+verbatim / credited normalization / ungrounded — not exact match.
+
+**Tom reads the first scorecard by hand.** That is why #362 (the scoring script) is deliberately not
+built yet; automating before reading one scorecard automates the wrong thing.
+
+Decision rules are in #361 and were written down before the numbers exist, on purpose. Apply them as
+written.
+
+## Working agreements for this repo
+
+- **Always work in a git worktree** — Tom runs concurrent sessions on the same checkout.
+  In a worktree, run pytest as `PYTHONPATH=<worktree>/src ~/.local/pipx/venvs/watchdog-intel/bin/pytest`
+  or you'll silently test the main checkout.
+- **Never `git checkout --` to undo an experiment** if you have uncommitted work — it restores from
+  HEAD and eats it. Commit first, or copy the file aside.
+- Definition of done, docs rules, and the `DECISIONS.md` convention are in `CLAUDE.md`. Read it.
+- `git push` over SSH currently fails (no identities in the agent). Push with
+  `git -c credential.helper='!gh auth git-credential' push -u https://github.com/tomcardoso/watchdog.git <branch>`
+- Tom is an investigative reporter, not a developer by trade. Explain in plain terms, and don't hand
+  him plans whose critical path is hours of his manual labour — he'll (rightly) refuse them.

--- a/tests/documents/HANDOFF.md
+++ b/tests/documents/HANDOFF.md
@@ -33,16 +33,21 @@ One YAML per document in `tests/documents/keys/`, drafted **from the source PDFs
 pipeline extraction** — and **frozen before any condition runs**. Schema and rationale are in
 `CORPUS-v1.md` and #361.
 
-Two rules that are load-bearing, not stylistic:
+Three rules that are load-bearing, not stylistic:
 
-- **The `must_not_miss` list for `Annual-Financial-Report-20-21.pdf` (the dense 70-page document) is
-  hand-written by Tom.** ~20 minutes. Do not draft it for him and do not skip it. A model skimming a
-  70-page filing misses the same buried items the extractor misses, so both look fine and the
-  benchmark quietly learns nothing — and buried-item degradation is exactly how Haiku and DeepSeek
-  are expected to fail. **Ask him for it; don't proceed without it.**
+- **`must_not_miss` for `Annual-Financial-Report-20-21.pdf` (the dense 70-page document) gets a
+  dedicated adversarial pass, drafted twice and unioned.** Its *only* job is hunting buried items:
+  walk the schedules, footnotes, signature blocks, and appendices, and enumerate what is buried
+  there. Run it on **two model families — Opus and Gemini — and union the two lists.** Do not draft
+  it with Opus alone: the risk is *correlation*, not capability. Anything Opus misses is absent from
+  the key, and Opus's blind spots correlate with Sonnet's and Haiku's, so Haiku would "pass" on a
+  schedule nobody wrote down.
 - **Use the Auditor General's special report as the oracle** when drafting the keys — it is the
   page-cited account of what was actually true. Keep it OUT of the corpus.
   <https://www.auditor.on.ca/en/content/specialreports/specialreports/LaurentianUniversity_EN.pdf>
+- **Then hand the drafted keys to Tom to review** (~20 min) before freezing. He is the quality gate,
+  not the author: a frozen key with a bad fact in it corrupts all four conditions at once and nothing
+  downstream will catch it. Do not freeze the keys until he has read them.
 
 The contradiction that must appear in the keys is documented in full, with quotes and page numbers,
 in `CORPUS-v1.md`. Don't re-derive it.
@@ -76,6 +81,16 @@ and are not recoverable afterwards.
 Judge model must **not** be a model under test (self-preference bias), and blind it regardless:
 strip which condition produced which output, randomize order. Credit matches in three tiers —
 verbatim / credited normalization / ungrounded — not exact match.
+
+**Which judge, per arm — this matters and is easy to get wrong:**
+
+- **Sonnet vs Haiku, and the #215 effort A/B:** an **Opus** judge is fine. Both arms are the same
+  family, so any family preference lands on both equally and cancels out of the comparison.
+- **DeepSeek vs Claude:** it does **not** cancel. An Anthropic judge scoring Anthropic output against
+  a competitor's is asymmetric and would flatter Claude on precisely the question Tom most needs to
+  get right (DeepSeek is his intended personal ingest path). **Cross-check this arm with a
+  non-Anthropic judge (Gemini)** and compare the two verdicts. If they agree, the result stands.
+  **If they disagree, that disagreement is the finding.**
 
 **Tom reads the first scorecard by hand.** That is why #362 (the scoring script) is deliberately not
 built yet; automating before reading one scorecard automates the wrong thing.

--- a/tests/documents/corpus-v1.sha256
+++ b/tests/documents/corpus-v1.sha256
@@ -1,0 +1,6 @@
+66788b16ad5cbfff78a6c5d01f96125affe248e79af7b5f6d4441477ef40a837  Annual-Financial-Report-19-20.pdf
+c5e89ac26f89d571136b9231f6cb943bcdd61199cfd4b622745f85489a480dcb  Laurentian Pre-Filing Report of the Proposed Monitor.pdf
+e5719ed1f525bc284d6da314dc74bfbeb8f76476251b1489ae589632b3d30550  Annual-Financial-Report-20-21.pdf
+e943be8173383b5d077a492401ce783a50e188cc5336547acd5090acb1d73408  CV-21-00656040-00CL Laurentian U Initial Order 1 FEB 2021.pdf
+afa4ca9505db70174489fef51e79ec0a2d24e316065cd841a07c53d595306a0d  Laurentian First Report of the Monitor.pdf
+40df3314772023baee9c229d62d23336e99f08012a94ec3ca6c72418a94bc8df  Pension Order Morawetz CJ- March 17 2021(as stamped by Court).PDF


### PR DESCRIPTION
Freezes six of the Laurentian CCAA documents already in `tests/documents` as the benchmark corpus, with a sha256 manifest (`corpus-v1.sha256`) and a provenance note (`CORPUS-v1.md`). The PDFs were already committed — this adds only text.

This is step 2 of the [measurement runbook](https://claude.ai/code/artifact/ef5f5a01-bc42-49d5-9b91-12a6c3383bce). Step 1 (choosing the documents) is done; steps 3–7 are described in `HANDOFF.md`.

## The corpus

Six documents, 209 pages, born-digital and scanned mixed, all public court filings or published financial reports:

| Document | Pages | Role |
|---|---|---|
| Annual Financial Report 19-20 | 36 | Contradiction side A |
| Pre-Filing Report of the Proposed Monitor | 47 | Contradiction side B |
| Annual Financial Report 20-21 | 70 | The dense 50+ page document |
| Initial Order, 1 Feb 2021 | 17 | Scanned — the OCR arm |
| First Report of the Monitor | 34 | Entity overlap |
| Pension Order, Morawetz CJ | 5 | Short document for contrast |

## Why these

The corpus is built around a contradiction the extractor can actually **fire** on — two explicit, positive claims that cannot both be true, in documents that never mention each other:

- **FY2019-20 annual report:** budget "expected balanced results from operations", university "on track" with "an anticipated small deficit of $0.9 million"; the actual $5.4M deficit is attributed to COVID ("$5.2 million is related to the COVID-19 outbreak"); "unwavering as it continues to trace its path to sustainability".
- **Monitor's pre-filing report, weeks later:** "LU is insolvent and absent the relief sought in the Initial Order, will not have sufficient funding / liquidity to meet payroll in February."

A contradiction that could only be detected by noticing an *absence* would be useless here — the extractor cannot fire on silence. This one is stated on both sides.

## What's deliberately excluded

The Auditor General's special report, which states the contradiction outright ("presented budget deficits year over year, while publicly saying it was presenting balanced budgets"). In the corpus it would let a model copy the answer rather than derive it. It serves as the **answer-key oracle** instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)