### PR TITLE
corpus-v1 answer keys, run protocol, and benchmarking guide for #361 / #215

### DIFF
--- a/tests/documents/BENCHMARKING.md
+++ b/tests/documents/BENCHMARKING.md
@@ -1,0 +1,219 @@
+# Running the extraction benchmark (#361 / #215)
+
+A step-by-step guide to measuring the three ingest model stages against corpus-v1. Written to be
+followed top to bottom. Nothing here spends money until Step 4, and every run gets a free cost
+preview first.
+
+## What we are deciding
+
+Watchdog makes three kinds of model call during ingest. This benchmark picks the right-size default
+for each, across Claude tiers and DeepSeek, plus the reasoning-effort knob where it applies.
+
+| Stage | Flag | Default | Effort knob? | Cost shape |
+|---|---|---|---|---|
+| **Classifier** | `--classifier-model` | `haiku` | no | 1 call/doc, first 5 pages only — trivial |
+| **Extractor** | `--extractor-model` / `--extractor-effort` | `sonnet` / `high` | yes | per page — **essentially the whole bill** |
+| **Finalizer** | `--finalizer-model` / `--finalizer-effort` | `haiku` / `high` | yes | ~3 calls + reconciliation per ingest — near-constant |
+
+Candidate models per stage: Claude `haiku` / `sonnet` / `opus`, and DeepSeek `deepseek:deepseek-v4-flash` /
+`deepseek:deepseek-v4-pro`. Notes that matter:
+
+- **Haiku has no effort knob** (`_EFFORT_UNSUPPORTED`) — `--extractor-effort` is ignored on Haiku.
+  So a Haiku arm is a single point, not a high/medium/low sweep.
+- **The classifier has no effort knob at all.**
+- **DeepSeek's "effort" is its thinking toggle, not high/medium/low.** Test it by swapping the
+  model id: `deepseek:deepseek-v4-flash` (thinking off) vs `deepseek:deepseek-v4-flash-thinking` (on), same for
+  `-pro`. Tom's prior testing found non-thinking DeepSeek weak, so test both.
+
+## What changed with #381 (read this before designing runs)
+
+Extraction is now **stateless** — a pure function of the document, its skill, the brief, and its
+sidecar. Entity resolution and cross-document contradiction detection moved to the finalizer's
+**reconciliation pass**. Two consequences for how you run and read this:
+
+1. **Concurrency and ingest order no longer affect extraction output.** Run at the default
+   concurrency, any order. (Earlier drafts of the protocol mandated `--concurrency 1` and a fixed
+   order — that is obsolete. See `keys/README.md`.)
+2. **Metric attribution split by stage.** Material-fact recall and `must_not_miss` measure the
+   **extractor**. Entity-duplicate count and the C1/C2 contradictions measure the **finalizer**,
+   because reconciliation runs there. This is why the finalizer model is now worth benchmarking at
+   all, and why you must not leave it at the Haiku default for the DeepSeek decision without
+   deciding to.
+
+## The method: isolate one stage at a time
+
+Each stage is measured by varying it while holding the other two fixed at a known baseline.
+
+- **Extractor sweep** — vary `--extractor-model` × `--extractor-effort`; hold the finalizer fixed
+  at a strong baseline (`sonnet` / `high`); pin `--skill` so the classifier is out of the loop.
+  These are full ingests: this is where the money goes.
+- **Finalizer sweep** — vary `--finalizer-model` × `--finalizer-effort`; hold the extractor fixed
+  at **`deepseek:deepseek-v4-flash`**. Two reasons for the cheap fixed extractor: (a) it keeps the wasted
+  re-extraction cheap — you cannot re-finalize a finished vault (#384), so each finalizer arm is its
+  own full ingest; (b) a messier extraction gives reconciliation *more* to do (more duplicate
+  candidates, more borderline contradictions), which discriminates finalizer models better than a
+  near-perfect one would. Because extraction is deterministic (#381), that fixed input is identical
+  across every finalizer arm, so the comparison is clean.
+- **Classifier** — a **smoke test only**. corpus-v1 spans just two skills (`bankruptcy`,
+  `financial-statements`), so it cannot *rank* classifier models. It can confirm the default gets
+  these six right. Ranking classifier models needs a type-diverse corpus — separate future work.
+
+Every condition is its own fresh vault. Never reuse a vault — carried-over entities contaminate
+everything downstream of pre-flight.
+
+## Step 0 — freeze the keys
+
+The answer keys must be frozen before any condition runs, or a key edited mid-benchmark
+invalidates every comparison made against the earlier version. Review them (see `keys/README.md`),
+then:
+
+```
+cd tests/documents/keys && shasum -a 256 *.yaml > keys-v1.sha256
+```
+
+## Step 1 — verify the corpus
+
+```
+cd tests/documents && shasum -a 256 -c corpus-v1.sha256
+```
+
+All six must report `OK`. If any fails, stop — a single changed byte makes runs incomparable.
+
+## Step 2 — check auth
+
+You need Anthropic and DeepSeek credentials stored:
+
+```
+watchdog auth
+```
+
+Confirm both providers show as authenticated. (Gemini is only needed later, for the DeepSeek-arm
+judge cross-check in scoring — not for the runs.)
+
+## Step 3 — the per-condition recipe
+
+Every condition follows the same shape. Example for the baseline (`extractor sonnet/high`,
+`finalizer sonnet/high`):
+
+```
+# 1. Fresh vault
+watchdog new "bench-ex-sonnet-high"
+cd <projects_dir>/bench-ex-sonnet-high
+
+# 2. Pass 1 — the four bankruptcy documents
+cp "<corpus>/Laurentian Pre-Filing Report of the Proposed Monitor.pdf" _INCOMING/
+cp "<corpus>/CV-21-00656040-00CL Laurentian U Initial Order 1 FEB 2021.pdf" _INCOMING/
+cp "<corpus>/Laurentian First Report of the Monitor.pdf" _INCOMING/
+cp "<corpus>/Pension Order Morawetz CJ- March 17 2021(as stamped by Court).PDF" _INCOMING/
+watchdog chew
+
+# FREE cost preview — always run this first
+watchdog ingest --skill bankruptcy \
+  --extractor-model sonnet --extractor-effort high \
+  --finalizer-model sonnet --finalizer-effort high --estimate
+
+# The real run (same flags, no --estimate)
+watchdog ingest --skill bankruptcy \
+  --extractor-model sonnet --extractor-effort high \
+  --finalizer-model sonnet --finalizer-effort high
+
+# 3. Pass 2 — the two annual reports, SAME model flags
+cp "<corpus>/Annual-Financial-Report-19-20.pdf" _INCOMING/
+cp "<corpus>/Annual-Financial-Report-20-21.pdf" _INCOMING/
+watchdog chew
+watchdog ingest --skill financial-statements \
+  --extractor-model sonnet --extractor-effort high \
+  --finalizer-model sonnet --finalizer-effort high
+```
+
+Two passes because `--skill` pins **one** skill for the whole queue, and the corpus needs two (see
+`expected_skill` in each key). Keep the model flags **identical across both passes** — they are one
+condition. Run the `bankruptcy` pass first so all four insolvency documents are present when the
+annual reports are reconciled (the scored contradiction C1 spans a `bankruptcy` document and a
+`financial-statements` one).
+
+**Capture, per vault, before touching the next one** (the terminal output is not recoverable — page
+-coverage warnings and per-document digest-size lines print only there):
+
+```
+watchdog usage --all > usage.txt      # token/cost/latency per stage
+cp -r briefings/ ../captures/<vault>-briefings/
+cp -r .watchdog/Registry ../captures/<vault>-registry/
+# and save the scrollback of each ingest run
+```
+
+## Step 4 — extractor sweep (the spend)
+
+Finalizer fixed at `sonnet` / `high`. One vault each. Run `--estimate` before each.
+
+| Vault | `--extractor-model` | `--extractor-effort` | Serves |
+|---|---|---|---|
+| `bench-ex-sonnet-high` | `sonnet` | `high` | baseline · #215 high arm |
+| `bench-ex-sonnet-med` | `sonnet` | `medium` | #215 medium arm |
+| `bench-ex-haiku` | `haiku` | — (ignored) | #361: Haiku as shipped default? |
+| `bench-ex-opus-high` | `opus` | `high` | is Opus worth the premium? |
+| `bench-ex-ds-flash` | `deepseek:deepseek-v4-flash` | — | #361: DeepSeek, thinking off |
+| `bench-ex-ds-flash-think` | `deepseek:deepseek-v4-flash-thinking` | — | DeepSeek flash, thinking on |
+| `bench-ex-ds-pro` | `deepseek:deepseek-v4-pro` | — | DeepSeek pro, thinking off |
+| `bench-ex-ds-pro-think` | `deepseek:deepseek-v4-pro-thinking` | — | DeepSeek pro, thinking on |
+
+Optional expansion if the core set leaves a question open: `sonnet`/`low`, `opus`/`medium`.
+
+Score against the frozen keys: **material-fact recall** and **`must_not_miss`** (the extractor
+metrics). Also read the coverage warnings on the 70-page report — that is where cheap conditions
+degrade first.
+
+## Step 5 — finalizer sweep (cheap)
+
+Extractor fixed at `deepseek:deepseek-v4-flash`. One vault each.
+
+| Vault | `--finalizer-model` | `--finalizer-effort` |
+|---|---|---|
+| `bench-fn-haiku` | `haiku` | — (ignored) |
+| `bench-fn-sonnet-high` | `sonnet` | `high` |
+| `bench-fn-sonnet-med` | `sonnet` | `medium` |
+| `bench-fn-opus-high` | `opus` | `high` |
+| `bench-fn-ds-flash` | `deepseek:deepseek-v4-flash` | — |
+| `bench-fn-ds-pro-think` | `deepseek:deepseek-v4-pro-thinking` | — |
+
+Score: **entity-duplicate count** and **contradictions C1/C2** (the finalizer metrics). Read the
+contradictions from the `[!contradiction]` callouts written into the entity notes — each carries a
+label, both values, both document slugs, and both page numbers — not the briefing's "flagged" count.
+
+## Step 6 — classifier smoke test
+
+One vault, no `--skill` (let it classify), default classifier:
+
+```
+watchdog new "bench-classify"
+# load all six documents, chew, then:
+watchdog ingest --extractor-model deepseek:deepseek-v4-flash --finalizer-model deepseek:deepseek-v4-flash
+```
+
+Check the classified skill for each document against `expected_skill` in the keys. All six should
+land on `bankruptcy` or `financial-statements` correctly. If they do, the classifier is fine on
+these types. This does **not** rank classifier models — corpus-v1 has too few skills for that.
+(A cheap extractor is used here because we only care about the classification decision.)
+
+## Step 7 — score and decide
+
+Full scoring protocol and the decision rules are in **#361** and **`keys/README.md`**. In brief:
+
+- Judge model must not be a model under test; blind it (strip which condition produced which
+  output, randomize order). Credit matches in three tiers — verbatim / credited normalization /
+  ungrounded.
+- **Claude-vs-Claude arms** (Sonnet vs Haiku, the #215 effort A/B): an **Opus** judge is fine —
+  same family, bias cancels.
+- **DeepSeek-vs-Claude arm:** cross-check with a **non-Anthropic judge (Gemini)** and compare the
+  two verdicts. If they agree, the result stands; if they disagree, that disagreement is the
+  finding.
+- **Read the first scorecard by hand** before automating anything (#362).
+
+## Rough cost
+
+Order-of-magnitude, from the per-token pricing (extraction is output-dominated). The full corpus on
+Sonnet is around $5; scale by the model's output rate relative to Sonnet ($15/Mtok): Haiku ~⅓,
+Opus ~1.7×, DeepSeek flash ~2% of Sonnet, DeepSeek pro ~6%; thinking variants add roughly 2–4× for
+the chain-of-thought. The extractor sweep lands near **$20**, dominated by the Opus and Sonnet arms;
+the finalizer sweep and classifier test are **~$2** combined. **`watchdog ingest --estimate` is the
+real number — trust it over this paragraph**, and run it before every condition.

--- a/tests/documents/keys/README.md
+++ b/tests/documents/keys/README.md
@@ -1,0 +1,66 @@
+# Answer keys — corpus-v1
+
+One YAML per corpus document. These are the fixed reference the four benchmark conditions
+(#361, #215) are scored against. **Not yet frozen — pending Tom's review.**
+
+## What these are, and what they are not
+
+A key is a **ranking device between conditions**, not a gold standard. Every decision rule in #361
+has the form "does Haiku hold ≥95% of *Sonnet's* recall" — which needs a fixed, consistent
+reference applied identically to every arm, not a true gold key.
+
+**Never quote a recall number from these keys as an absolute measure of Watchdog's accuracy.**
+"87% fact recall" only ever means "Haiku retained 87% of what Sonnet retained, against a common
+reference." That limitation is recorded in #361 and is not negotiable.
+
+## How they were drafted
+
+- **From the source PDFs.** Never from a pipeline extraction, never from chewed text. A key built
+  from the pipeline's own output inherits the pipeline's blind spots, so the extractor is never
+  scored on anything the pipeline already drops.
+- **The scanned Initial Order was read visually, not OCR'd first** — same reason, one stage earlier.
+- **`must_not_miss` for the dense 70-page report was built against a mechanical inventory** — all 27
+  note headings enumerated programmatically with page numbers, so a buried item cannot be absent
+  from the key merely because the drafting model overlooked it. This is the fix for the
+  *correlation* risk #361 identifies (see "The mistake worth recording" in that issue).
+
+## Schema
+
+| Field | Purpose |
+|---|---|
+| `document` | File, sha256, pages, text layer, type, role in the benchmark |
+| `entities` | Name, type, `aliases`, role, page |
+| `relationships` | subject / predicate / object / page |
+| `facts` | 19–22 material facts, each with `page` and a **verbatim `quote`** |
+| `contradictions` | Cross-document conflicts, with both sides quoted. **An empty list is meaningful** — it means an invented contradiction scores as a false positive |
+| `must_not_miss` | Buried items, **scored separately**. This is where cheap conditions degrade first |
+| `ocr_hazards` | Initial Order only — scanned-page features OCR can mangle |
+
+`quote` and `aliases` exist to support the **three grounding tiers** (verbatim / credited
+normalization / ungrounded) rather than exact match. "LU" for "Laurentian University of Sudbury" is
+a credited normalization, not a miss.
+
+## Scoring notes that are easy to get wrong
+
+- **`ocr_hazards` are checked FIRST** on the Initial Order. Page 17 (the backsheet) is rotated 90°
+  and is the only place the applicant's counsel is named. A condition that returns no counsel has
+  probably hit a rotation failure, not a reasoning failure — look at the chew output before
+  charging it to the extractor.
+- **The scored contradiction is C1** in `annual-financial-report-19-20.yaml` ↔
+  `prefiling-report-monitor.yaml`. Neither document cites the other.
+- **The $52.8M endowment figure is NOT a contradiction** — documents 1 and 2 agree on it. Flagging
+  it is a false positive.
+- **Two source documents contain errors**, recorded deliberately: both Monitor's reports date the
+  Haché affidavit to "January 30, 2020" (the Initial Order shows it is 2021), and the First Report
+  prints the court file number without leading zeros. Faithfully extracting the wrong value is
+  *correct* extraction. Neither is a miss.
+
+## The freeze
+
+Once reviewed, hash the keys the way the corpus is hashed and do not touch them again:
+
+```
+cd tests/documents/keys && shasum -a 256 *.yaml > keys-v1.sha256
+```
+
+A key that drifts between conditions invalidates every comparison made with it.

--- a/tests/documents/keys/README.md
+++ b/tests/documents/keys/README.md
@@ -57,24 +57,29 @@ a credited normalization, not a miss.
 
 ## The run protocol these keys assume
 
-Two settings are load-bearing. Getting either wrong makes the results uninterpretable, silently.
+One setting is load-bearing: the **skill pin**. Concurrency and ingest order used to be too — that
+changed with #381, and the history matters for reading this benchmark, so it is recorded below.
 
-### `--concurrency 1` — not optional
+### Concurrency and order no longer matter (#381 / D118)
 
-`preflight.run()` is called *inside* `_extract_document`, so each document snapshots the entity
-registry **at the moment its own extraction starts**. At the default `--concurrency 5`, the first
-five documents extract in parallel and every one of them takes its digest snapshot before any of
-the others has written a single entity. **They cannot see each other.**
+Earlier drafts of this file mandated `--concurrency 1` and a fixed ingest order. That was because
+`preflight.run()` used to snapshot the entity registry *inside* each document's extraction, so
+entity resolution and contradiction detection depended on which documents had already landed — a
+correctness property riding on a throughput knob (the bug that became #381).
 
-A contradiction can only fire when the second document of a pair is read *after* the first has
-landed in the registry. So at default concurrency, whether the scored contradiction is catchable
-at all is decided by which parallel wave each document happens to fall into — and if it lands
-badly, every condition scores zero on contradictions and the result reads as "no model catches
-these" when the pipeline never gave any of them the chance.
+**As of #381, extraction carries no vault state.** It is a pure function of the document, its
+skill, the brief, and its sidecar. Entity resolution and contradiction detection moved to the
+finalizer's **reconciliation pass** (`reconcile.py`), which runs once in post-ingest after every
+document has landed and reads the complete per-entity claim ledger. So:
 
-Sequential extraction costs wall-clock time, not tokens.
+- **Extraction output is independent of `--concurrency` and ingest order.** Run at the default
+  concurrency; there is no reason to serialize.
+- **Contradictions are caught in reconciliation, not extraction** — which is concurrency-immune and
+  order-immune by construction, and annotates *both* sides of a conflict.
 
-### Two passes, because `--skill` pins ONE skill for the whole run
+This has a direct bearing on what the benchmark measures — see "What each arm measures" below.
+
+### Still two passes, because `--skill` pins ONE skill for the whole run
 
 The corpus needs two skills (see `expected_skill` in each key). `--skill` applies one skill to
 every queued document, so a single pinned run would extract two of the six under the wrong skill —
@@ -83,35 +88,40 @@ primes for and `bankruptcy` does not. Use `chew --file` to control what is queue
 queue twice:
 
 ```
-# Pass 1 — the four insolvency documents, in chronological order
-watchdog ingest --skill bankruptcy --concurrency 1 [--extractor-model … --extractor-effort …]
+# Pass 1 — the four insolvency documents
+watchdog ingest --skill bankruptcy [--extractor-model … --extractor-effort … --finalizer-model …]
 
 # Pass 2 — the two annual reports
-watchdog ingest --skill financial-statements --concurrency 1 [same model flags]
+watchdog ingest --skill financial-statements [same model flags]
 ```
 
-### Ingest order (fixed across all conditions)
+Split the two skills across two passes; within each pass, order and concurrency are free.
 
-| # | Skill | Document |
-|---|---|---|
-| 1 | `bankruptcy` | Pre-Filing Report of the Proposed Monitor |
-| 2 | `bankruptcy` | CCAA Initial Order |
-| 3 | `bankruptcy` | First Report of the Monitor |
-| 4 | `bankruptcy` | Pension Order |
-| 5 | `financial-statements` | Annual Financial Report 2019-20 |
-| 6 | `financial-statements` | Annual Financial Report 2020-21 |
-
-The order is chosen, not incidental:
-
-- **FY2019-20 is fifth**, so its digest already holds the Pre-Filing Report's "LU is insolvent…
-  will not have sufficient funding / liquidity to meet payroll in February." Both sides of the
-  scored contradiction are then explicitly available — one on the page, one in the digest — which
-  is what the contradiction machinery needs to fire.
-- **FY2020-21 is last**, so it sees FY2019-20 and the restatement contradictions (C2) become
-  catchable too.
+| Skill | Documents |
+|---|---|
+| `bankruptcy` | Pre-Filing Report · Initial Order · First Report · Pension Order |
+| `financial-statements` | Annual Financial Report 2019-20 · 2020-21 |
 
 Consequence to expect, not trip over: two ingest passes means the finalizer runs twice, so each
-vault gets two briefings. Identical across all conditions, so it does not distort the comparison.
+vault gets two briefings and two reconciliation passes. Identical across all conditions, so it does
+not distort the comparison — but the *second* reconciliation is the one that can see all six
+documents, so it is the one that catches the cross-skill contradiction (C1 spans a `bankruptcy`
+document and a `financial-statements` one). Run the `bankruptcy` pass first so the annual reports
+are present for the reconciliation that matters.
+
+## What each arm measures (post-#381)
+
+The split of labour across models changed, so the attribution of each metric changed with it:
+
+- **Material-fact recall and `must_not_miss`** — the **extractor** model (`--extractor-model`).
+  Extraction is now pure per-document reading, which is exactly what these keys score.
+- **Entity resolution (duplicate count) and contradiction detection (C1, C2)** — the **finalizer**
+  model (`--finalizer-model`), because reconciliation runs there. #361 weights entity/relationship
+  quality highest for the DeepSeek decision, so for that arm the finalizer model matters as much as
+  the extractor — do not hold it fixed at the Haiku default without recording that choice.
+- **Contradictions are scored from the `[!contradiction]` callouts** written into entity notes
+  (label, both values, both document slugs, both page numbers) — not the briefing's "flagged"
+  count. Check the quoted values and pages against C1/C2.
 
 ## The freeze
 

--- a/tests/documents/keys/README.md
+++ b/tests/documents/keys/README.md
@@ -55,6 +55,64 @@ a credited normalization, not a miss.
   prints the court file number without leading zeros. Faithfully extracting the wrong value is
   *correct* extraction. Neither is a miss.
 
+## The run protocol these keys assume
+
+Two settings are load-bearing. Getting either wrong makes the results uninterpretable, silently.
+
+### `--concurrency 1` — not optional
+
+`preflight.run()` is called *inside* `_extract_document`, so each document snapshots the entity
+registry **at the moment its own extraction starts**. At the default `--concurrency 5`, the first
+five documents extract in parallel and every one of them takes its digest snapshot before any of
+the others has written a single entity. **They cannot see each other.**
+
+A contradiction can only fire when the second document of a pair is read *after* the first has
+landed in the registry. So at default concurrency, whether the scored contradiction is catchable
+at all is decided by which parallel wave each document happens to fall into — and if it lands
+badly, every condition scores zero on contradictions and the result reads as "no model catches
+these" when the pipeline never gave any of them the chance.
+
+Sequential extraction costs wall-clock time, not tokens.
+
+### Two passes, because `--skill` pins ONE skill for the whole run
+
+The corpus needs two skills (see `expected_skill` in each key). `--skill` applies one skill to
+every queued document, so a single pinned run would extract two of the six under the wrong skill —
+and several `must_not_miss` items in the FY20-21 report are exactly what `financial-statements`
+primes for and `bankruptcy` does not. Use `chew --file` to control what is queued, then drain the
+queue twice:
+
+```
+# Pass 1 — the four insolvency documents, in chronological order
+watchdog ingest --skill bankruptcy --concurrency 1 [--extractor-model … --extractor-effort …]
+
+# Pass 2 — the two annual reports
+watchdog ingest --skill financial-statements --concurrency 1 [same model flags]
+```
+
+### Ingest order (fixed across all conditions)
+
+| # | Skill | Document |
+|---|---|---|
+| 1 | `bankruptcy` | Pre-Filing Report of the Proposed Monitor |
+| 2 | `bankruptcy` | CCAA Initial Order |
+| 3 | `bankruptcy` | First Report of the Monitor |
+| 4 | `bankruptcy` | Pension Order |
+| 5 | `financial-statements` | Annual Financial Report 2019-20 |
+| 6 | `financial-statements` | Annual Financial Report 2020-21 |
+
+The order is chosen, not incidental:
+
+- **FY2019-20 is fifth**, so its digest already holds the Pre-Filing Report's "LU is insolvent…
+  will not have sufficient funding / liquidity to meet payroll in February." Both sides of the
+  scored contradiction are then explicitly available — one on the page, one in the digest — which
+  is what the contradiction machinery needs to fire.
+- **FY2020-21 is last**, so it sees FY2019-20 and the restatement contradictions (C2) become
+  catchable too.
+
+Consequence to expect, not trip over: two ingest passes means the finalizer runs twice, so each
+vault gets two briefings. Identical across all conditions, so it does not distort the comparison.
+
 ## The freeze
 
 Once reviewed, hash the keys the way the corpus is hashed and do not touch them again:

--- a/tests/documents/keys/annual-financial-report-19-20.yaml
+++ b/tests/documents/keys/annual-financial-report-19-20.yaml
@@ -20,7 +20,6 @@ document:
     An annual report built around audited consolidated financial statements plus MD&A. The
     catalog's `audit-reports` description explicitly redirects an organization's own audited
     statements here.
-  ingest_order: 5
   role_in_benchmark: "Contradiction side A — the reassuring account, three months before insolvency."
 
 entities:
@@ -232,8 +231,9 @@ contradictions:
     why_it_matters: >
       THE SCORED CONTRADICTION. Two explicit, positive, incompatible claims — one that the trouble
       is a pandemic blip on a sustainable institution, one that the institution is insolvent and
-      has been failing since 2014. Neither document cites the other, so the extractor must catch it
-      by comparing against the vault digest. This is the whole point of the corpus.
+      has been failing since 2014. Neither document cites the other, so catching it requires
+      comparing claims across documents — the job of the finalizer's reconciliation pass as of
+      #381, not the extractor. This is the whole point of the corpus.
 
   - id: C2
     type: cross-document

--- a/tests/documents/keys/annual-financial-report-19-20.yaml
+++ b/tests/documents/keys/annual-financial-report-19-20.yaml
@@ -1,0 +1,356 @@
+# Answer key — corpus-v1, document 1 — CONTRADICTION SIDE A
+#
+# Drafted from the SOURCE PDF. Frozen before any condition runs.
+#
+# The other half of the scored contradiction pair is the Pre-Filing Report of the Proposed
+# Monitor (document 2), published weeks later. Neither document mentions the other.
+
+document:
+  file: "Annual-Financial-Report-19-20.pdf"
+  sha256: 66788b16ad5cbfff78a6c5d01f96125affe248e79af7b5f6d4441477ef40a837
+  pages: 36
+  text_layer: born-digital
+  doc_type: annual financial report (audited consolidated financial statements + MD&A)
+  fiscal_year_end: 2020-04-30
+  auditors_report_date: 2020-10-30
+  publisher: Laurentian University of Sudbury
+  auditor: KPMG LLP
+  role_in_benchmark: "Contradiction side A — the reassuring account, three months before insolvency."
+
+entities:
+  - name: Laurentian University of Sudbury
+    type: organization
+    aliases: ["LU", "the University", "Laurentian"]
+    role: reporting entity
+    page: 3
+  - name: KPMG LLP
+    type: organization
+    role: independent auditor; unqualified opinion dated 30 October 2020, Sudbury
+    page: 16
+  - name: Lorella Hayes
+    type: person
+    role: Vice-President, Administration; signatory to the Statement of Administrative Responsibility
+    page: 14
+    credentials: "CPA, CA"
+  - name: Normand Lavallée
+    type: person
+    role: Associate Vice-President, Financial Services; signatory to the Statement of Administrative Responsibility
+    page: 14
+    credentials: "FCPA, FCMA, FCA"
+  - name: Eckler Ltd.
+    type: organization
+    role: actuary retained to estimate pension and employee future benefit liabilities
+    page: 14
+  - name: Board of Governors
+    type: organization
+    role: governing body; discharges financial oversight through its Audit Committee
+    page: 14
+  - name: Audit Committee
+    type: organization
+    role: >
+      Committee of the Board; members are not officers or full-time employees; auditors have full
+      access with and without administration present.
+    page: 14
+  - name: MIRARCO
+    type: organization
+    role: consolidated entity
+    page: 5
+  - name: SNOLAB
+    type: organization
+    role: consolidated at 20%
+    page: 5
+  - name: Federated Universities
+    type: organization
+    role: LU administers the pension plan and RHBP on their behalf
+    page: 8
+
+relationships:
+  - subject: KPMG LLP
+    predicate: auditor of
+    object: Laurentian University of Sudbury
+    page: 16
+  - subject: Eckler Ltd.
+    predicate: actuary for
+    object: Laurentian University of Sudbury
+    page: 14
+  - subject: Lorella Hayes
+    predicate: Vice-President, Administration of
+    object: Laurentian University of Sudbury
+    page: 14
+  - subject: Normand Lavallée
+    predicate: Associate Vice-President, Financial Services of
+    object: Laurentian University of Sudbury
+    page: 14
+  - subject: Laurentian University of Sudbury
+    predicate: consolidates
+    object: MIRARCO and 20% of SNOLAB
+    page: 5
+  - subject: Laurentian University of Sudbury
+    predicate: principal employer of the pension plan and administrator of the RHBP for
+    object: the Federated Universities and SNOLAB
+    page: 8
+
+facts:
+  - id: F1
+    fact: >
+      The FY2019-20 approved budget expected BALANCED results from operations, and LU says it was
+      "on track" to operate the year with an anticipated small deficit of $0.9 million.
+    page: 5
+    quote: "The fiscal 2019-20 approved budget expected balanced results from operations … the University was on track to operating fiscal year 2019-20 with an anticipated a small deficit of $0.9 million from operations."
+    note: "CONTRADICTION SIDE A, part 1."
+  - id: F2
+    fact: >
+      The operating deficit was $5.4 million, of which $5.2 million is attributed to the COVID-19
+      outbreak — i.e. 96% of the miss is blamed on the pandemic.
+    page: 5
+    quote: "The net impact was an operating deficit of $5.4 million of which $5.2 million is related to the COVID-19 outbreak."
+    note: "CONTRADICTION SIDE A, part 2. The Monitor and the FY20-21 report both attribute the deficits to years of structural decline instead."
+  - id: F3
+    fact: "LU describes its commitment as 'unwavering as it continues to trace its path to sustainability'."
+    page: 4
+    quote: "Laurentian's commitment to providing world-class education and opportunities for students is unwavering as it continues to trace its path to sustainability."
+    note: "CONTRADICTION SIDE A, part 3."
+  - id: F4
+    fact: >
+      LU reports $52.8 million in endowment, "an increase of $1 million over 2018-19", with a
+      spending rate of 3.5%.
+    page: 9
+    quote: "The University has $52.8 million in endowment, an increase of $1 million over 2018-19. For 2019-20, the University assigned a spending rate of 3.5% towards the scholarships and other commitments supported by the funds."
+  - id: F5
+    fact: >
+      KPMG issued an UNQUALIFIED opinion — the statements "present fairly, in all material
+      respects" — dated 30 October 2020 at Sudbury. The opinion carries NO going-concern
+      modification and no emphasis of matter.
+    pages: [16, 18]
+    quote: "In our opinion, the accompanying financial statements present fairly, in all material respects, the consolidated financial position of Laurentian University of Sudbury as at April 30, 2020 … Sudbury, Canada October 30, 2020"
+    note: >
+      The single most consequential fact in this document. Three months later the Monitor told the
+      court LU was insolvent and could not make payroll. Compare the FY20-21 report, whose audit
+      report DOES carry a Material Uncertainty Related to Going Concern.
+  - id: F6
+    fact: "Deficiency of revenue over expenses for FY2020: $3,120 thousand (FY2019: $4,100 thousand)."
+    page: 20
+    quote: "Deficiency of revenue over expenses $ (3,120) $ (4,100)"
+    note: "Later RESTATED to $(3,387) in the FY20-21 report. See contradictions C2."
+  - id: F7
+    fact: "Total net assets at 30 April 2020: $36,682 thousand (2019: $53,164 thousand) — a $16.5M decline in one year."
+    page: 19
+    quote: "36,682 53,164"
+    note: "Later restated to $34,824. See C2."
+  - id: F8
+    fact: "Unrestricted net assets (the accumulated operating deficit) worsened from $14,544 thousand to $19,986 thousand."
+    pages: [5, 19]
+    quote: "The Unrestricted net assets (ie. Accumulated operating deficit) increased from $14.544 million to $19.986 million due to the operating budget deficit."
+    note: "Later restated to $(23,640). See C2."
+  - id: F9
+    fact: "Employee future benefits liabilities rose $11.5 million, from $9,237 thousand to $20,788 thousand, and the prior year's $1,929 thousand benefit ASSET became a liability."
+    pages: [12, 19]
+    quote: "Employee future benefits liabilities increased $11.5M based on actuarial valuation."
+  - id: F10
+    fact: "Cash and short-term investments fell to $4,544 thousand from $7,505 thousand."
+    page: 19
+    quote: "Cash and short-term investments (note 2) $ 4,544 $ 7,505"
+    note: "Later restated to $3,425 (2020) and $5,185 (2019). See C2."
+  - id: F11
+    fact: "$14.4 million of the line of credit was drawn at 30 April 2020 — and it was used for CAPITAL SPENDING."
+    page: 12
+    quote: "At April 30, 2020, $14.4M of the University's line of credit was utilized for capital spending, a decrease of $3.2M."
+  - id: F12
+    fact: >
+      The DB Pension Plan solvency ratio was 85.4% at 1 January 2020 (2019: 87.8%). LU is only
+      required to fund solvency deficits up to an 85% level.
+    page: 8
+    quote: "The solvency ratio deficit for the January 1, 2020 was 85.4% (2019, 87.8%) … The University is only required to fund solvency deficits up to an 85% level with a 5-year amortization period."
+  - id: F13
+    fact: "The Provision for Adverse Deviation (PfAD) rate rose to 10.3% from 7.94%."
+    page: 8
+    quote: "The current PfAD rate is 10.3% (2019, 7.94%) applied to current services costs."
+  - id: F14
+    fact: >
+      LU claims $20 million in pre-COVID savings under its Long Term Sustainability Plan, plus
+      ~$10 million post-COVID — over $30 million total since 2018, as of August 2020.
+    page: 4
+    quote: "Pre-Covid, our Long Term Sustainability Plan enabled Laurentian to achieve $20 million in savings and cost reductions compared to plan, and post COVID, the accelerated plan enabled additional savings of approx. $10 million, bringing total savings achieved since 2018 to over $30 million as of August 2020."
+  - id: F15
+    fact: >
+      Budget-to-actual reconciliation: the 2019-20 budget was $160,983 revenue / $160,983 expenses
+      / net (0.0) — a literally balanced budget. Actual audited result was $198,397 / $201,517 /
+      $(3,120).
+    page: 5
+    quote: "Per 2019-20 Budget 160,983 160,983 (0.0)"
+  - id: F16
+    fact: "Tuition revenue fell 7.6% because of the provincially mandated 10% domestic tuition reduction."
+    page: 13
+    quote: "Tuition revenue decreased by 7.6% due to the 10.0% reduction in domestic tuition fees"
+  - id: F17
+    fact: >
+      Operating grants rose 7.7% mainly because of a ONE-TIME Northern Sustainability grant — a
+      non-recurring prop under the year's revenue.
+    page: 13
+    quote: "Operating grants increased 7.7% mainly due to a one-time Northern Sustainability grant received in 2020."
+  - id: F18
+    fact: >
+      SMA3 reset the corridor midpoint at 16,423.53 Weighted Grant Units. Enrolment-based funding
+      of $2,903 per WGU in 2019-20 is anticipated to fall to $1,173 per WGU.
+    pages: [8, 9]
+    quote: "Correspondingly, enrolment-based funding which in 2019-20 was at $2,903 per WGU is anticipated to decrease to $1,173 per WGU."
+  - id: F19
+    fact: "Endowment returns were NEGATIVE for the year; the 3.5% spending rate was funded from the operating fund at a cost of $1.8 million."
+    page: 9
+    quote: "Due to COVID-19 the fund had returned a negative value for the year. As a result, the amounts spent to cover the spending rate were a cost of the operating fund in the amount of $1.8 million."
+  - id: F20
+    fact: "Ancillary contribution came in at $2,747 thousand against a budget of $3,639 thousand; $1.2 million of residence and ancillary refunds were issued to students."
+    page: 9
+    quote: "the actual contribution is lower than anticipated due to the residence and ancillary services refunds of $1.2 million provided to the students"
+  - id: F21
+    fact: "Long-term debt stood at $88,973 thousand, with $2,738 thousand in current portion."
+    page: 19
+    quote: "Long-term debt (note 8) 88,973 91,711"
+
+contradictions:
+  - id: C1
+    type: cross-document
+    scored: true
+    against: "Laurentian Pre-Filing Report of the Proposed Monitor.pdf (corpus document 2)"
+    this_document_claims: >
+      LU expected a BALANCED budget, was "on track" for a "small deficit of $0.9 million", blames
+      $5.2M of the $5.4M actual operating deficit on COVID-19, and "continues to trace its path to
+      sustainability". KPMG signed an unqualified opinion with no going-concern flag on
+      30 October 2020.
+    pages: [4, 5, 16]
+    other_document_claims: >
+      "LU is insolvent and absent the relief sought in the Initial Order, will not have sufficient
+      funding / liquidity to meet payroll in February" (p. 31, ¶165), caused by "the pattern of
+      recurring deficits over a number of years" (¶206), with net assets down $32.9M since
+      FY2014-15 (¶154).
+    why_it_matters: >
+      THE SCORED CONTRADICTION. Two explicit, positive, incompatible claims — one that the trouble
+      is a pandemic blip on a sustainable institution, one that the institution is insolvent and
+      has been failing since 2014. Neither document cites the other, so the extractor must catch it
+      by comparing against the vault digest. This is the whole point of the corpus.
+
+  - id: C2
+    type: cross-document
+    against: "Annual-Financial-Report-20-21.pdf (corpus document 3)"
+    this_document_claims: >
+      The FY2020 audited figures as originally published: deficiency $(3,120); total net assets
+      $36,682; unrestricted $(19,986); cash $4,544 (2019: $7,505); endowment $52,845.
+    pages: [19, 20]
+    other_document_claims: >
+      The FY20-21 report restates every one of those figures (Notes 25 and 27): deficiency
+      $(3,387); total net assets $34,824; unrestricted $(23,640); cash $3,425 (2019: $5,185);
+      endowment $54,299.
+    why_it_matters: >
+      LU's own later filing declares these numbers wrong. Both values are explicitly stated in
+      their respective documents, so this is checkable without any outside knowledge — a
+      restatement is a self-declared contradiction with a prior published document.
+
+must_not_miss:
+  - id: M1
+    item: >
+      The auditors' report is CLEAN — an unqualified opinion, dated 30 October 2020, with no
+      going-concern material uncertainty and no emphasis of matter.
+    pages: [16, 18]
+    location: Independent Auditors' Report, opinion paragraph and signature block
+    why: >
+      Three months before EY told the court LU was insolvent, KPMG said the statements presented
+      fairly with no going-concern flag. The FY20-21 audit report DOES carry that flag. Scoring
+      note — an extractor cannot prove an absence, so score the PRESENCE of the unqualified opinion
+      and its date; the significance of what is missing is for the human reading the scorecard.
+
+  - id: M2
+    item: >
+      The Statement of Administrative Responsibility is signed by Lorella Hayes (CPA, CA),
+      Vice-President Administration, and Normand Lavallée (FCPA, FCMA, FCA), Associate
+      Vice-President Financial Services.
+    page: 14
+    location: signature block, Statement of Administrative Responsibility
+    why: >
+      The only place in the document where an individual human being personally attests to the
+      numbers, by name. Signature blocks are the first thing an extractor drops.
+
+  - id: M3
+    item: "Eckler Ltd. is the actuary retained to estimate the pension and employee future benefit liabilities."
+    page: 14
+    location: Statement of Administrative Responsibility, second paragraph
+    why: >
+      Names the firm behind the single largest and most judgement-dependent liability on the
+      balance sheet. Mentioned exactly once, inside a governance boilerplate page.
+
+  - id: M4
+    item: >
+      The line of credit was used for CAPITAL SPENDING — $14.4M drawn at 30 April 2020.
+    page: 12
+    location: Financial Statement Highlights commentary
+    why: >
+      Funding long-lived capital assets with a revolving short-term facility is a liquidity red
+      flag. It is stated plainly, in a caption-like commentary block beside a chart, and reads as
+      routine.
+
+  - id: M5
+    item: >
+      The 7.7% rise in operating grants was driven by a ONE-TIME Northern Sustainability grant.
+    page: 13
+    location: Financial Statement Highlights, revenue commentary
+    why: >
+      The year's single biggest revenue improvement was non-recurring. Without it the picture is
+      materially worse — and the FY20-21 report duly shows operating grants falling back to $79.3M.
+
+  - id: M6
+    item: >
+      LU is only required to fund solvency deficits up to an 85% level — and the plan sits at 85.4%.
+    page: 8
+    location: Employee Future Benefits section
+    why: >
+      The plan is 0.4 percentage points above the threshold that would trigger mandatory solvency
+      funding. Two numbers in adjacent sentences; the relationship between them is never stated.
+
+  - id: M7
+    item: >
+      Endowment returns were NEGATIVE, and the 3.5% distribution was paid out of the operating fund
+      at a cost of $1.8 million.
+    page: 9
+    location: Endowments section
+    why: >
+      LU borrowed from operations to keep paying scholarships when the endowment lost money — while
+      simultaneously reporting the endowment as having "increased $1 million". Both claims sit in
+      the same short section.
+
+  - id: M8
+    item: >
+      Enrolment-based funding is projected to fall from $2,903 per WGU to $1,173 per WGU — a ~60%
+      cut in the core funding rate.
+    page: 9
+    location: Funding Formula and Strategic Mandate Agreement section
+    why: "The most consequential forward-looking number in the document, given as a bare comparison."
+
+  - id: M9
+    item: >
+      The 2019-20 budget was presented as exactly balanced: revenues $160,983 = expenses $160,983,
+      net (0.0).
+    page: 5
+    location: budget-to-actual reconciliation table
+    why: >
+      A literally zero-net budget. The Auditor General later found LU "presented budget deficits
+      year over year, while publicly saying it was presenting balanced budgets" — this table is
+      that practice, on the page.
+
+  - id: M10
+    item: >
+      The Audit Committee's members are not officers or full-time employees, and the auditors have
+      full access to it with and without administration present.
+    page: 14
+    location: Statement of Administrative Responsibility, third paragraph
+    why: >
+      A governance safeguard asserted in the document. Worth capturing because the Auditor General
+      later concluded the oversight did not work.
+
+  - id: M11
+    item: >
+      The prior year's $1,929 thousand employee future benefit ASSET flipped to a $20,788 thousand
+      liability — an $11.5M swing driven by a discount-rate change.
+    pages: [12, 19]
+    location: balance sheet line + highlights commentary
+    why: >
+      An asset became a liability. It is presented as a routine actuarial remeasurement in a single
+      commentary sentence.

--- a/tests/documents/keys/annual-financial-report-19-20.yaml
+++ b/tests/documents/keys/annual-financial-report-19-20.yaml
@@ -15,6 +15,12 @@ document:
   auditors_report_date: 2020-10-30
   publisher: Laurentian University of Sudbury
   auditor: KPMG LLP
+  expected_skill: financial-statements
+  expected_skill_rationale: >
+    An annual report built around audited consolidated financial statements plus MD&A. The
+    catalog's `audit-reports` description explicitly redirects an organization's own audited
+    statements here.
+  ingest_order: 5
   role_in_benchmark: "Contradiction side A — the reassuring account, three months before insolvency."
 
 entities:

--- a/tests/documents/keys/annual-financial-report-20-21.yaml
+++ b/tests/documents/keys/annual-financial-report-20-21.yaml
@@ -1,0 +1,526 @@
+# Answer key — corpus-v1, document 3 (THE DENSE DOCUMENT)
+#
+# Drafted from the SOURCE PDF. Frozen before any condition runs.
+#
+# The `must_not_miss` list below was built against a MECHANICAL INVENTORY of the document
+# (every note heading 1–27 enumerated programmatically with its page number) rather than from a
+# model skim. That matters: the risk #361 identifies is CORRELATION — if a drafting model simply
+# overlooks page 41, the item is absent from the key and every condition "passes" on it. The
+# inventory removes that failure mode, because the schedule is on the list whether or not any
+# model noticed it. See CORPUS-v1.md and #361.
+#
+# Note map (mechanical, complete):
+#   p23 title | p24-27 Independent Auditors' Report | p28 Financial Position | p29 Operations
+#   p30 Changes in Net Assets | p31 Cash Flows
+#   N1 Description p32 · N2 Basis of presentation/going concern p32 · N3 Accounting policies p35
+#   N4 Cash and investments p39 · N5 Accounts receivable p40 · N6 Employee future benefits p40
+#   N7 Capital assets p45 · N8 Accounts payable p46 · N9 Short-term loan p46 · N10 DIP loan p46
+#   N11 Long-term debt p47 · N12 Liabilities subject to compromise p48 · N13 Deferred contributions p50
+#   N14 Endowment p52 · N15 Investment in capital assets p54 · N16 Internally restricted p54
+#   N17 Internally financed capital projects p55 · N18 Commitments and contingencies p55
+#   N19 Non-cash working capital p57 · N20 Other fees and income p57 · N21 Restructuring costs p58
+#   N22 Financial risks p58 · N23 Effects of COVID-19 p60 · N24 Related party transactions p60
+#   N25 Restatement of comparative information p62 · N26 Subsequent events p67
+#   N27 Restatement of financial statements p68
+
+document:
+  file: "Annual-Financial-Report-20-21.pdf"
+  sha256: e5719ed1f525bc284d6da314dc74bfbeb8f76476251b1489ae589632b3d30550
+  pages: 70
+  text_layer: born-digital
+  doc_type: annual financial report (audited consolidated financial statements + MD&A)
+  fiscal_year_end: 2021-04-30
+  publisher: Laurentian University of Sudbury
+  auditor: KPMG LLP
+  role_in_benchmark: >
+    The dense 50+ page document. Tests sectioning, page coverage, and the 16K output ceiling
+    (#309). Entities, relationships, facts and contradictions all compete for the same output
+    budget here — this is where cheap conditions are expected to degrade first, and where the
+    must_not_miss list does its real work.
+
+entities:
+  - name: Laurentian University of Sudbury
+    type: organization
+    aliases: ["LU", "the University", "Laurentian"]
+    role: reporting entity; CCAA applicant; registered charity, tax-exempt under s.149(1)(f) ITA
+    page: 32
+  - name: KPMG LLP
+    type: organization
+    role: independent auditor (Sudbury office; report signed Ottawa)
+    page: 24
+  - name: Ernst & Young Inc.
+    type: organization
+    aliases: ["E&Y", "the Monitor"]
+    role: court-appointed Monitor under the CCAA
+    page: 32
+  - name: Firm Capital Corporation
+    type: organization
+    aliases: ["FCC", "the DIP lender"]
+    role: original DIP lender ($25M facility, 8.50% floor)
+    page: 46
+  - name: Ontario Ministry of Colleges and Universities
+    type: organization
+    aliases: ["MCU"]
+    role: provider of the Replacement DIP Facility and the government support package
+    page: 67
+  - name: Ontario Superior Court of Justice (Commercial List)
+    type: organization
+    aliases: ["the CCAA Court", "the Court"]
+    role: supervising court
+    page: 32
+  - name: Board of Governors
+    type: organization
+    role: governing body; addressee of the auditors' report; subject to mandated renewal
+    page: 24
+  - name: TD Canada Trust
+    type: organization
+    role: lender of the unsecured short-term loan financing the Student Recreation Centre
+    page: 46
+  - name: Desjardins
+    type: organization
+    role: provider of a $26.0M unsecured line of credit; $14.4M drawn at 30 April 2020
+    page: 55
+  - name: Royal Bank
+    type: organization
+    role: provider of a $5.0M unsecured line of credit; undrawn
+    page: 55
+  - name: Northern Ontario School of Medicine
+    type: organization
+    aliases: ["NOSM"]
+    role: related party; LU and Lakehead are its only voting members
+    page: 60
+  - name: Lakehead University
+    type: organization
+    role: the only other voting member of NOSM
+    page: 60
+  - name: Centre for Excellence in Mining and Innovation
+    type: organization
+    aliases: ["CEMI"]
+    role: related party, created 23 April 2007 with $10.0M of provincial money contributed by LU
+    page: 61
+  - name: Thorneloe University
+    type: organization
+    role: federated university; relationship terminated/disclaimed in the restructuring
+    page: 6
+  - name: University of Sudbury
+    type: organization
+    role: federated university; relationship terminated/disclaimed in the restructuring
+    page: 6
+  - name: Huntington University
+    type: organization
+    role: federated university; active employees ceased accruing pension entitlement 30 June 2021
+    page: 6
+  - name: Students' General Association
+    type: organization
+    aliases: ["Student General Association", "SGA"]
+    role: holder of a long-term debt facility guaranteed by LU for $8.5M
+    page: 55
+  - name: SNOLAB
+    type: organization
+    role: participating employer in the LU-administered Pension Plan
+    page: 56
+  - name: MIRARCO
+    type: organization
+    role: participating employer in the LU-administered Pension Plan
+    page: 56
+  - name: McEwen School of Architecture
+    type: organization
+    role: became the 12th accredited architecture school in Canada during 2020-21
+    page: 7
+  - name: Chief Redevelopment Officer
+    type: role
+    aliases: ["CRO"]
+    role: court-appointed officer assisting LU with strategic initiatives
+    page: 6
+
+relationships:
+  - subject: KPMG LLP
+    predicate: auditor of
+    object: Laurentian University of Sudbury
+    page: 24
+  - subject: Ernst & Young Inc.
+    predicate: court-appointed Monitor of
+    object: Laurentian University of Sudbury
+    page: 32
+  - subject: Firm Capital Corporation
+    predicate: DIP lender to
+    object: Laurentian University of Sudbury
+    page: 46
+  - subject: Ontario Ministry of Colleges and Universities
+    predicate: replacement DIP lender to
+    object: Laurentian University of Sudbury
+    page: 67
+  - subject: Laurentian University of Sudbury
+    predicate: guarantor of the $8.5M loan to
+    object: Students' General Association
+    page: 55
+  - subject: Laurentian University of Sudbury
+    predicate: principal employer of the Pension Plan covering
+    object: Federated Universities, SNOLAB, CEMI, MIRARCO
+    page: 56
+  - subject: Laurentian University of Sudbury
+    predicate: voting member of
+    object: Northern Ontario School of Medicine
+    page: 60
+  - subject: Lakehead University
+    predicate: voting member of
+    object: Northern Ontario School of Medicine
+    page: 60
+  - subject: Laurentian University of Sudbury
+    predicate: disclaimed federation agreements with
+    object: Thorneloe University, University of Sudbury, Huntington University
+    page: 6
+  - subject: TD Canada Trust
+    predicate: lender to
+    object: Laurentian University of Sudbury
+    page: 46
+
+facts:
+  - id: F1
+    fact: "Deficiency of revenue over expenses for FY2021: $66,671 thousand ($66.7M), against $3,387 thousand ($3.4M) restated in FY2020."
+    page: 29
+    quote: "Deficiency of revenue over expenses $ (66,671) $ (3,387)"
+  - id: F2
+    fact: "Total net assets swung to a DEFICIENCY of $15,366 thousand, from positive $34,824 thousand a year earlier — a $50.2M reversal."
+    page: 28
+    quote: "Endowment (note 14) 61,482 54,299 … (15,366) 34,824"
+  - id: F3
+    fact: "Unrestricted net assets fell to a deficiency of $89,207 thousand from $23,640 thousand."
+    page: 28
+    quote: "Unrestricted (89,207) (23,640)"
+  - id: F4
+    fact: "Restructuring costs of $78,904 thousand were recognized in FY2021 (nil in FY2020) — the single largest expense line after salaries."
+    page: 29
+    quote: "Restructuring costs (note 21) 78,904 –"
+  - id: F5
+    fact: "Liabilities subject to compromise total $186,820 thousand."
+    page: 48
+    quote: "$           186,820"
+  - id: F6
+    fact: >
+      Total claims ASSERTED by creditors are $360,291 thousand — but only $186,820 thousand is
+      recognized. The $173.5M difference is NOT recognized in the financial statements because
+      LU cannot yet estimate it.
+    page: 49
+    quote: "Total claims asserted by creditors are $360,291 pursuant to the claim procedures approved by the Court. The difference between the total claims asserted and the amount recognized as subject to compromise of $186,820 is not recognized in these financial statements"
+    note: "The largest single number in the document, and it is off the balance sheet."
+  - id: F7
+    fact: >
+      The DIP loan was provided by Firm Capital Corporation at the higher of 8.50% or TD prime
+      plus a 6.05% margin. Initial draw $10,000 thousand (16 Feb 2021), second draw $15,000
+      thousand (26 Mar 2021). Debt issuance costs $591 thousand; interest expense $583 thousand.
+    page: 46
+    quote: "with interest at the higher of 8.50% or the TD Canada Trust Posted Bank Prime Interest Rate plus a margin of 6.05%"
+  - id: F8
+    fact: >
+      The Replacement DIP Facility from the Ontario MCU (executed 19 Jan 2022, court-authorized
+      27 Jan 2022, capped at $35,000 thousand) carried an interest rate of 1.11% on advance.
+    page: 67
+    quote: "As at the advance of funds on January 28, 2022 the rate of interest was 1.11%"
+    note: "1.11% from the province versus 8.50% from Firm Capital — a striking spread."
+  - id: F9
+    fact: "An interest rate swap termination obligation of $24,700 thousand forms part of both restructuring costs and liabilities subject to compromise."
+    page: 48
+    quote: "Interest rate swap termination obligation (note 11) 24,700"
+  - id: F10
+    fact: >
+      Restructuring costs break down as: interest rate swap termination $24,700; employee
+      restructuring and termination costs $44,658; employee future benefit liabilities $704;
+      accounts payable $35; legal fees $4,903; Monitor fees $2,800; consulting fees $223;
+      interest and finance costs $881.
+    page: 58
+    quote: "Legal fees   $       4,903 \nMonitor fees           2,800 \nConsulting fees              223"
+  - id: F11
+    fact: "Employee compensation costs of $59,568 thousand sit within liabilities subject to compromise."
+    page: 48
+    quote: "Employee compensation costs  59,568"
+  - id: F12
+    fact: >
+      The auditors' report contains a Material Uncertainty Related to Going Concern, pointing to
+      Note 2 and the CCAA stay extended to 31 May 2022. The opinion is NOT modified in respect of it.
+    page: 24
+    quote: "Material Uncertainty Related to Going Concern … Our opinion is not modified in respect of this matter."
+  - id: F13
+    fact: >
+      The financial statements were AMENDED after issuance. Statements originally reported on
+      7 March 2022 were corrected for errors found afterwards, changing the reported deficiency
+      from $(65,982) to $(66,671).
+    page: 68
+    quote: "The financial statements that were original issued with an auditors' report date of March 7, 2022 have been amended for errors identified after their issuance."
+  - id: F14
+    fact: >
+      Note 27 corrections: Other fees and income decreased $2,138; Salaries and benefits decreased
+      $141; Operating and research decreased $1,075; Restructuring costs decreased $233; Employee
+      future benefits remeasurements increased $689.
+    page: 68
+    quote: "(i) Decreased Other fees and income revenue by $2,138"
+  - id: F15
+    fact: >
+      FY2020 comparatives were separately restated (Note 25) for changes in accounting policy AND
+      for "items that had not been properly recognized, measured or presented". Opening net assets
+      were restated from $53,164 thousand as previously reported to $52,010 thousand.
+    page: 30
+    quote: "Net assets (deficiency), beginning of year, previously reported $ (14,544) … $ 53,164 … Restatement adjustments (note 25) … Net assets (deficiency), beginning of year, restated (17,761) … 52,010"
+  - id: F16
+    fact: >
+      MD&A attributes the insolvency to LONG-RUN causes, not the pandemic: "many years of
+      recurring operational deficits", declining enrolment from 2015-16 to 2019-20, and the
+      provincially mandated 10% tuition cut (2019-20) followed by a freeze (2020-21). The combined
+      accumulated unrestricted deficit and employee benefit liabilities deficit had reached
+      $42.2 million by the end of April 2020.
+    page: 5
+    quote: "Laurentian had generated operating losses for a number of years and as result, the University's combined accumulated unrestricted fund deficit and employee benefit liabilities deficit had grown to $42.2 million at the end of April 2020."
+    note: "Directly relevant to the scored contradiction — see `contradictions` below."
+  - id: F17
+    fact: "LU closed 39 English-language programs and 27 French-language programs under the CCAA process."
+    page: 5
+    quote: "Laurentian approved the closure of 39 English-language programs and 27 French-language programs"
+  - id: F18
+    fact: "Restructuring reduced operating expenses by $40 million per year, a 25% reduction."
+    page: 6
+    quote: "The restructuring initiatives implemented to date have resulted in a reduction of operating expenses by $40 million per year, representing a 25% reduction."
+  - id: F19
+    fact: >
+      Endowment net assets rose to $61,482 thousand from $54,299 thousand (restated), driven by
+      $8,211 thousand of long-term investment income — not by contributions, which were only
+      $175 thousand (down from $1,193 thousand).
+    page: 53
+    quote: "Balance, beginning of year  $         54,299 … Endowment contributions                  175 … Balance, end of year  $         61,482"
+  - id: F20
+    fact: >
+      The endowment distribution policy was cut from 3.5% to 2.0% of the trailing 12-month fair
+      value of the endowment pool, and LU charged a $590 thousand administrative fee against
+      endowment investment income (2020: nil).
+    page: 52
+    quote: "constrains the amount of investment income available for distribution to 2.0% (2020 – 3.5%) of the last 12 months fair value of the endowment investment pool"
+  - id: F21
+    fact: "Enrolment headcount rose 4.2% to 9,323 in fall 2020, but fell 14% for fall 2021 after the CCAA filing."
+    page: 9
+    quote: "Subsequent to the end of fiscal year 2020-21, the University has seen a reduction of total enrolment (headcount) of 14% for fall 2021."
+  - id: F22
+    fact: >
+      The Ontario government support package: up to $6,000 thousand in COVID-19 relief and up to
+      $22,000 thousand of enrolment corridor and performance protection — conditional on renewal
+      of the Board of Governors and completion of a long-term strategic plan.
+    page: 67
+    quote: "up to $6,000 in COVID-19 relief funding for the University, and enrolment corridor and performance protection of up to $22,000 over a number of years … subject to certain conditions, which include renewal at the Board of Governors"
+
+# Cross-document contradiction. The SCORED pair for the benchmark is documents 1 and 2 (see
+# CORPUS-v1.md), but this document independently contradicts document 1 and that is worth
+# scoring — it fires only if the extractor compares against the vault digest, which is exactly
+# the machinery under test.
+contradictions:
+  - id: C1
+    type: cross-document
+    against: "Annual-Financial-Report-19-20.pdf (corpus document 1)"
+    this_document_claims: >
+      The deficits are long-run and structural — "many years of recurring operational deficits",
+      declining enrolment since 2015-16, and the 2019 tuition cut and freeze. The accumulated
+      deficit had already reached $42.2M by the end of April 2020.
+    page: 5
+    other_document_claims: >
+      The FY2019-20 report attributes the $5.4M operating deficit almost entirely to the pandemic
+      ("$5.2 million is related to the COVID-19 outbreak") and says LU was "on track" with an
+      anticipated "small deficit of $0.9 million", while "tracing its path to sustainability".
+    why_it_matters: >
+      The same institution, one year apart, gives two incompatible accounts of WHY it was losing
+      money. Both are explicit positive claims, so an extractor can fire on the conflict without
+      having to prove a negative.
+  - id: C2
+    type: cross-document
+    against: "Annual-Financial-Report-19-20.pdf (corpus document 1)"
+    this_document_claims: >
+      FY2020 figures as previously reported were WRONG and have been restated: opening net assets
+      $53,164 → $52,010; opening cash $7,505 → $5,185.
+    page: 30
+    other_document_claims: "The FY2019-20 report presented those original, later-corrected figures as audited fact."
+    why_it_matters: >
+      A restatement is a self-declared contradiction with a prior published document. If the vault
+      holds both reports, the extractor has both numbers stated explicitly.
+
+# Buried items — built against the mechanical note inventory above. Scored SEPARATELY from facts.
+must_not_miss:
+  - id: M1
+    item: >
+      The auditors' report is DUAL-DATED: "March 7, 2022, except as to Note 27, which is as of
+      April 22, 2022."
+    page: 27
+    location: auditors' signature block, final line
+    why: >
+      A dual date is the auditor formally limiting how far forward their responsibility runs. It
+      is one line, in a signature block, on the last page of the audit report — and it is the
+      strongest single signal in the document that something went wrong after publication.
+
+  - id: M2
+    item: "The Board of Governors signature block on the balance sheet has TWO BLANK 'Governor' lines."
+    page: 28
+    location: foot of the Consolidated Statement of Financial Position
+    why: >
+      The statements are presented "On behalf of the Board of Governors" over two unsigned lines.
+      Extractors reliably drop signature blocks entirely.
+
+  - id: M3
+    item: >
+      Note 27 exists at all — a restatement OF the already-restated statements, made after issuance
+      for errors discovered post-publication.
+    page: 68
+    location: final substantive note, page 68 of 70
+    why: >
+      Second-to-last note in a 70-page document. This is the archetypal buried item: the most
+      damaging disclosure, placed last.
+
+  - id: M4
+    item: >
+      Total claims asserted by creditors of $360,291 thousand versus $186,820 thousand recognized —
+      a $173.5M gap deliberately not recognized.
+    page: 49
+    location: Note 12, prose paragraph AFTER the table
+    why: >
+      Sits below a table. Extractors that parse the table capture $186,820 and stop reading before
+      the sentence that says the real number may be nearly twice that.
+
+  - id: M5
+    item: "Interest rate swap termination obligation of $24,700 thousand."
+    page: 48
+    location: Note 12 table row; repeated in Note 21 (p. 58)
+    why: >
+      A derivative unwind buried as a single table row. Nothing in the MD&A mentions that LU held
+      interest rate swaps at all.
+
+  - id: M6
+    item: >
+      Uncertified class action claims relating to a DATA BREACH, plus claims from employees.
+    page: 56
+    location: Note 18(d), commitments and contingencies
+    why: >
+      A data breach is disclosed nowhere else in the report — not in the MD&A, not in the risk
+      note. It appears once, in a subclause of the contingencies note.
+
+  - id: M7
+    item: >
+      LU guaranteed the Students' General Association loan for $8,500 thousand, and "No amount has
+      been recorded in these financial statements relating to the University's guarantee."
+    pages: [55, 62]
+    location: Note 18(c) and Note 24(c)
+    why: "An $8.5M off-balance-sheet guarantee, explicitly unrecorded. Stated twice, capture-rate still low."
+
+  - id: M8
+    item: >
+      Firm Capital Corporation lent at the higher of 8.50% or TD prime + 6.05%; the province's
+      replacement facility charged 1.11%.
+    pages: [46, 67]
+    location: Note 10 and Note 26 — two notes, 21 pages apart
+    why: >
+      Neither rate is remarkable alone; the pair is the story. Requires joining two notes at
+      opposite ends of the document, which is exactly what section-chunked extraction does badly.
+
+  - id: M9
+    item: >
+      A new $590 thousand administrative fee charged against endowment investment income
+      (2020 – nil), alongside the distribution policy cut from 3.5% to 2.0%.
+    page: 52
+    location: Note 14, closing sentence of the opening paragraph
+    why: >
+      LU began charging the endowment a fee it had never charged, in the year it went insolvent.
+      One sentence, end of a dense policy paragraph.
+
+  - id: M10
+    item: "Stayed payables of $1,412 thousand owed to NOSM, up from $28 thousand."
+    page: 61
+    location: Note 24(a), prose after the transactions table
+    why: >
+      LU stayed money owed to the medical school it co-founded — a 50x increase, in a sentence
+      after a table.
+
+  - id: M11
+    item: >
+      Note 25's cash restatement: cash at the beginning of FY2020 was corrected from $7,505
+      thousand to $5,185 thousand — a $2,320 thousand error in previously reported cash.
+    page: 67
+    location: Note 25 continuation table, top of page
+    why: "An error in *cash* — the least estimable line on the statements. Buried in a restatement table."
+
+  - id: M12
+    item: >
+      LU is principal employer of a Pension Plan that also covers the Federated Universities,
+      SNOLAB, CEMI and MIRARCO. Huntington employees ceased accruing 30 June 2021; University of
+      Sudbury and Thorneloe employees became suspended members after 31 December 2021.
+    page: 56
+    location: Note 18(e)
+    why: >
+      The blast radius of the pension problem extends to four other institutions. Buried in the
+      fifth subclause of the contingencies note.
+
+  - id: M13
+    item: >
+      The Royal Bank ($5,000 thousand) and Desjardins ($26,000 thousand) lines of credit were
+      withdrawn — "At April 30, 2021 these lines of credit are no longer available to the University."
+    page: 55
+    location: Note 18(a)
+    why: "$31M of committed liquidity vanished. One clause at the end of a subsection."
+
+  - id: M14
+    item: >
+      Professional fees inside restructuring costs: legal $4,903, Monitor $2,800, consulting $223,
+      interest and finance $881 — $8,807 thousand of "Legal, Monitor, consulting, interest and
+      finance costs".
+    page: 58
+    location: Note 21 table, lower half
+    why: "What the insolvency cost in fees. A lower-table block, routinely truncated."
+
+  - id: M15
+    item: >
+      LU participates in a reciprocal insurance exchange sharing property and liability risk with
+      forty other Canadian universities.
+    page: 55
+    location: Note 18(b)
+    why: "A contingent, shared liability with 40 institutions. A single sentence, no dollar figure attached."
+
+  - id: M16
+    item: >
+      CEMI was created on 23 April 2007 with $10,000 thousand of provincial money that LU received
+      and contributed.
+    page: 61
+    location: Note 24(b)
+    why: "$10M of public money routed through LU into a separate entity LU does not consolidate."
+
+  - id: M17
+    item: >
+      The TD Canada Trust short-term loan financed the Student Recreation Centre; the CCAA filing
+      was an event of default that made it due on demand.
+    page: 46
+    location: Note 9
+    why: "Names both the lender and what the money built. Short note, sandwiched between two longer ones."
+
+  - id: M18
+    item: >
+      Internally financed capital projects, itemized: Campus Modernization $14,739; Cardiovascular
+      Metabolic Research Lab $5,027; Great Hall renovations $1,146; Ancillaries $855; Cliff Fielding
+      Building $146; Parking Lot 4 $761; School of Education Building $341; DNA Lab $161.
+    page: 55
+    location: Note 17 table
+    why: >
+      A named, itemized schedule of what LU spent internal money on. Precisely the kind of table
+      that gets flattened or dropped — and it names the projects.
+
+  - id: M19
+    item: >
+      The government support package is CONDITIONAL on renewal of the Board of Governors and
+      completion of a long-term strategic plan; first phase of Board renewal began 16 Dec 2021.
+    page: 67
+    location: Note 26, final paragraph
+    why: "The province made governance change a condition of the money. Last paragraph of the subsequent-events note."
+
+  - id: M20
+    item: >
+      The "Laurentian by the Numbers" infographic (p. 3): total revenue $193.4M, total expenses
+      $260.1M, deficiency $66.7M, total net assets -$15.4M, available expendable resources -$85.9M,
+      capital spending $1.4M, endowment per FTE $8,672, FTE 7,090.
+    page: 3
+    location: page-3 infographic
+    why: >
+      TEXT-EXTRACTION HAZARD, flagged deliberately. In the raw text layer the figures detach from
+      their labels and interleave (the "-$85.9M" appears adjacent to "Capital Spending", which is
+      wrong). Any condition that reports these numbers with the WRONG labels attached has been
+      caught by a table-flattening failure, not a reasoning failure — score it as such, and check
+      whether chew/Docling reproduces the same scrambling before blaming the extractor.

--- a/tests/documents/keys/annual-financial-report-20-21.yaml
+++ b/tests/documents/keys/annual-financial-report-20-21.yaml
@@ -32,6 +32,12 @@ document:
   fiscal_year_end: 2021-04-30
   publisher: Laurentian University of Sudbury
   auditor: KPMG LLP
+  expected_skill: financial-statements
+  expected_skill_rationale: >
+    Same as doc 1. Carries CCAA disclosure in the notes, but it is still an annual report built
+    around audited financial statements — the CCAA content is disclosure within the statements,
+    not the document's type.
+  ingest_order: 6
   role_in_benchmark: >
     The dense 50+ page document. Tests sectioning, page coverage, and the 16K output ceiling
     (#309). Entities, relationships, facts and contradictions all compete for the same output

--- a/tests/documents/keys/annual-financial-report-20-21.yaml
+++ b/tests/documents/keys/annual-financial-report-20-21.yaml
@@ -37,7 +37,6 @@ document:
     Same as doc 1. Carries CCAA disclosure in the notes, but it is still an annual report built
     around audited financial statements — the CCAA content is disclosure within the statements,
     not the document's type.
-  ingest_order: 6
   role_in_benchmark: >
     The dense 50+ page document. Tests sectioning, page coverage, and the 16K output ceiling
     (#309). Entities, relationships, facts and contradictions all compete for the same output
@@ -313,8 +312,8 @@ facts:
 
 # Cross-document contradiction. The SCORED pair for the benchmark is documents 1 and 2 (see
 # CORPUS-v1.md), but this document independently contradicts document 1 and that is worth
-# scoring — it fires only if the extractor compares against the vault digest, which is exactly
-# the machinery under test.
+# scoring — it fires only if the finalizer's reconciliation pass compares claims across documents
+# (#381), which is exactly the machinery under test.
 contradictions:
   - id: C1
     type: cross-document

--- a/tests/documents/keys/first-report-monitor.yaml
+++ b/tests/documents/keys/first-report-monitor.yaml
@@ -3,8 +3,10 @@
 # Drafted from the SOURCE PDF. Frozen before any condition runs.
 #
 # Role: entity overlap. This document shares E&Y, the Board, LUFA, Firm Capital and the DIP
-# facility with documents 2 and 3, which is what makes it useful — it tests whether an extractor
-# RESOLVES entities against the vault digest or duplicates them.
+# facility with documents 2 and 3, which is what makes it useful — it tests whether the finalizer's
+# reconciliation pass (#381) RESOLVES these to the same entities as the other documents or leaves
+# duplicates. (Under #381 the extractor no longer resolves against vault state; it names entities
+# per-document and reconciliation merges them afterward.)
 
 document:
   file: "Laurentian First Report of the Monitor.pdf"
@@ -18,7 +20,6 @@ document:
   expected_skill: bankruptcy
   expected_skill_rationale: >
     A monitor's report in a CCAA proceeding — named verbatim in the catalog description.
-  ingest_order: 3
   role_in_benchmark: "Entity overlap — E&Y, the Board, the DIP facility, LUFA."
 
 entities:

--- a/tests/documents/keys/first-report-monitor.yaml
+++ b/tests/documents/keys/first-report-monitor.yaml
@@ -1,0 +1,341 @@
+# Answer key — corpus-v1, document 5
+#
+# Drafted from the SOURCE PDF. Frozen before any condition runs.
+#
+# Role: entity overlap. This document shares E&Y, the Board, LUFA, Firm Capital and the DIP
+# facility with documents 2 and 3, which is what makes it useful — it tests whether an extractor
+# RESOLVES entities against the vault digest or duplicates them.
+
+document:
+  file: "Laurentian First Report of the Monitor.pdf"
+  sha256: afa4ca9505db70174489fef51e79ec0a2d24e316065cd841a07c53d595306a0d
+  pages: 34
+  text_layer: born-digital
+  doc_type: monitor's report (first report), CCAA
+  date: 2021-02-07
+  author: Ernst & Young Inc. (Monitor)
+  court_file: "CV-21-656040-00CL (as printed — note the format differs from other corpus documents; see M1)"
+  role_in_benchmark: "Entity overlap — E&Y, the Board, the DIP facility, LUFA."
+
+entities:
+  - name: Ernst & Young Inc.
+    type: organization
+    aliases: ["EY", "the Monitor"]
+    role: court-appointed Monitor
+    page: 1
+  - name: Laurentian University of Sudbury
+    type: organization
+    aliases: ["LU", "the Applicant"]
+    role: CCAA applicant
+    page: 1
+  - name: Firm Capital Corporation
+    type: organization
+    role: counterparty that EXECUTED the DIP Term Sheet — then assigned its interest away
+    page: 8
+  - name: Firm Capital Mortgage Fund Inc.
+    type: organization
+    aliases: ["the DIP Lender"]
+    role: >
+      The actual DIP Lender, by assignment from Firm Capital Corporation. A DISTINCT legal entity
+      from Firm Capital Corporation.
+    page: 8
+  - name: Sean Dunphy
+    type: person
+    aliases: ["Justice Sean Dunphy", "the Honourable Justice Sean Dunphy"]
+    role: >
+      Judge of the Ontario Superior Court of Justice, appointed Court-Appointed Mediator; formerly
+      a leading insolvency lawyer; bilingual.
+    page: 7
+  - name: G.B. Morawetz
+    type: person
+    aliases: ["Chief Justice Morawetz"]
+    role: Chief Justice; issued the Initial Order and endorsements
+    page: 5
+  - name: Laurentian University Faculty Association
+    type: organization
+    aliases: ["LUFA"]
+    role: faculty union; counterparty to the mandated negotiated settlement
+    page: 6
+  - name: Robert Haché
+    type: person
+    aliases: ["Dr. Robert Haché", "Dr. Haché"]
+    role: affiant (the Haché Affidavit)
+    page: 3
+  - name: Ontario Ministry of Colleges and Universities
+    type: organization
+    aliases: ["MCU"]
+    role: participated in a call with LU and the Monitor
+    page: 5
+  - name: TD Canada Trust
+    type: organization
+    role: its posted prime rate is the DIP facility's floating benchmark
+    page: 9
+
+relationships:
+  - subject: Ernst & Young Inc.
+    predicate: Monitor of
+    object: Laurentian University of Sudbury
+    page: 1
+  - subject: Firm Capital Corporation
+    predicate: assigned its DIP interest to
+    object: Firm Capital Mortgage Fund Inc.
+    page: 8
+  - subject: Firm Capital Mortgage Fund Inc.
+    predicate: DIP Lender to
+    object: Laurentian University of Sudbury
+    page: 8
+  - subject: Sean Dunphy
+    predicate: Court-Appointed Mediator for
+    object: the LU CCAA proceedings
+    page: 7
+  - subject: G.B. Morawetz
+    predicate: issued the Initial Order in
+    object: the LU CCAA proceedings
+    page: 1
+  - subject: Laurentian University Faculty Association
+    predicate: counterparty to the mandated settlement with
+    object: Laurentian University of Sudbury
+    page: 8
+
+facts:
+  - id: F1
+    fact: "The Initial Order was granted 1 February 2021, appointing E&Y as Monitor with a 10-day stay period."
+    page: 1
+    paragraph: 2
+    quote: "On February 1, 2021, the Court granted an initial order (the \"Initial Order\") that, among other things, appointed Ernst & Young Inc. as monitor of the Applicant in these CCAA proceedings … and approved a stay of proceedings for the initial 10-day period"
+  - id: F2
+    fact: "The comeback motion was scheduled for 9:00am on 10 February 2021."
+    page: 1
+    paragraph: 3
+    quote: "The Court scheduled a comeback motion for 9:00am on February 10, 2021"
+  - id: F3
+    fact: "The Administration Charge is to increase from $400,000 to $1,250,000."
+    page: 2
+    paragraph: "4(d)(iii)"
+    quote: "an increase in the Administration Charge from $400,000 to $1,250,000"
+  - id: F4
+    fact: "The Directors' Charge is to increase from $2,000,000 to $5,000,000."
+    page: 2
+    paragraph: "4(d)(iv)"
+    quote: "an increase in the Directors' Charge from $2,000,000 to $5,000,000"
+  - id: F5
+    fact: >
+      The Administration Charge, Directors' Charge and DIP Lender's Charge are to rank in priority
+      to ALL other secured creditors as defined in the CCAA.
+    page: 2
+    paragraph: "4(d)(v)"
+    quote: "the granting of the Administration Charge, the Directors' Charge and the DIP Lender's Charge in priority to all other \"secured creditors\" as defined in the CCAA"
+  - id: F6
+    fact: "The Stay Period, set to expire 11 February 2021, is to be extended to 30 April 2021."
+    page: 10
+    paragraph: 38
+    quote: "The Stay Period is currently set to expire on February 11, 2021. The Applicant requests an extension of the Stay Period up to and including April 30, 2021."
+  - id: F7
+    fact: >
+      Justice Sean Dunphy of the Ontario Superior Court of Justice was appointed Court-Appointed
+      Mediator. The Court proposed him; all parties confirmed no objection.
+    page: 7
+    paragraph: 28
+    quote: "the Court proposed to appoint the Honourable Justice Sean Dunphy of the Ontario Superior Court of Justice as the Court-Appointed Mediator … All parties at the case conference confirmed that there were no objections to Justice Dunphy's appointment as mediator."
+  - id: F8
+    fact: "Dunphy was previously a leading insolvency lawyer with CCAA and complex labour experience, and is bilingual."
+    page: 7
+    paragraph: 28
+    quote: "During his career, Justice Dunphy was a leading insolvency lawyer with extensive experience in CCAA restructurings, including complex labour negotiations, and is bilingual."
+  - id: F9
+    fact: >
+      LU approached FOUR external lenders specializing in real-estate and infrastructure lending;
+      three submitted non-binding draft term sheets; two were shortlisted; one term sheet was
+      executed.
+    pages: [7, 8]
+    paragraph: "29, 32, 33"
+    quote: "These discussions resulted in the Applicant receiving non-binding draft term sheets from three potential lenders … determined that of the three initial proposals, two were sufficiently preferable to merit narrowing ongoing negotiations to these two parties."
+  - id: F10
+    fact: >
+      LU executed the DIP Term Sheet with Firm Capital Corporation, which then ASSIGNED its
+      interest to Firm Capital Mortgage Fund Inc. — the entity that is the actual DIP Lender.
+    page: 8
+    paragraph: 33
+    quote: "the Applicant executed a term sheet (the \"DIP Term Sheet\") with Firm Capital Corporation. Subsequent to the execution of the DIP Term Sheet, Firm Capital Corporation assigned its interest to Firm Capital Mortgage Fund Inc. (the \"DIP Lender\")."
+  - id: F11
+    fact: >
+      DIP facility: secured, non-revolving, maximum principal $25 million, maturity 1 May 2021,
+      extendable by 90 days on milestones.
+    page: 8
+    paragraph: "34(b)"
+    quote: "the maximum principal amount is $25 million with a maturity date of May 1, 2021. The maturity date may be extended for an additional 90 days if LU achieves the following milestones"
+  - id: F12
+    fact: >
+      DIP interest: the greater of 8.50% per annum or the TD Canada Trust posted prime rate plus
+      6.05% per annum, compounded and payable monthly in arrears.
+    page: 9
+    paragraph: "34(e)"
+    quote: "at a rate that is the greater of 8.50% per annum or the TD Canada Trust Posted Bank Prime Rate of Interest from time to time plus 6.05% per annum"
+  - id: F13
+    fact: >
+      A COMMITMENT FEE of $500,000 is deemed fully earned and payable to the DIP Lender on the date
+      the Court approves the Amended and Restated Initial Order.
+    page: 9
+    paragraph: "34(f)"
+    quote: "a commitment fee of $500,000 shall be deemed to have been fully earned and payable to the DIP Lender on the date that the Court approves the Amended and Restated Initial Order approving the DIP financing."
+  - id: F14
+    fact: >
+      The DIP extension milestones are judged by the DIP Lender "in its sole and unfettered
+      discretion" — including whether LU is financially sustainable.
+    page: 8
+    paragraph: "34(b)"
+    quote: "to the satisfaction of the DIP Lender in its sole and unfettered discretion"
+  - id: F15
+    fact: >
+      The milestones require LU to reach consensus on academic restructuring, to settle with LUFA
+      (terminations, grievances, a new collective agreement), and to deliver a multi-year budget
+      showing sustainability.
+    page: 8
+    paragraph: "34(b)(i)-(iii)"
+    quote: "LU enters into a negotiated settlement with LUFA with respect to terminations to be effected, resolution of outstanding grievances, and the terms of a new collective agreement"
+  - id: F16
+    fact: >
+      TWO parties expressed interest in submitting COMPETING DIP proposals (a law firm on 4 Feb
+      2021 and another party on 5 Feb 2021). LU DECLINED both.
+    page: 9
+    paragraph: 36
+    quote: "the Applicant determined that given the number of weeks it took other potential lenders to conduct their due diligence … it was highly unlikely that a new party could negotiate and execute a non-disclosure agreement, conduct its due diligence and be in a position to submit a binding offer … Accordingly, the Applicant declined the request from the law firm to proceed with any due diligence process"
+  - id: F17
+    fact: >
+      The Monitor repeats the reliability caveat: LU's Finance department "has experienced certain
+      challenges as a result of its limited team and resources", so the Information may be limited.
+    page: 3
+    paragraph: 9
+    quote: "Dr. Haché Notes that he has relied upon information provided by LU's Finance department which has experienced certain challenges as a result of its limited team and resources. As a result, the Monitor notes that the Information relied upon for purposes of this First Report may be limited by these challenges."
+  - id: F18
+    fact: >
+      The Notice to Creditors was mailed to all known creditors with claims over $1,000, and
+      published on 4 February 2021 in the Globe and Mail (National Edition) and the Sudbury Star.
+    pages: [5, 6]
+    paragraph: "23(b), 23(d)"
+    quote: "On February 4, 2021, the Monitor published the Notice to Creditors in the Globe and Mail (National Edition) and the Sudbury Star."
+  - id: F19
+    fact: >
+      The Monitor established a case website (ey.com/ca/Laurentian), a toll-free hotline
+      (1-855-338-1766) and an email address (LaurentianUniversity.Monitor@ca.ey.com).
+    page: 5
+    paragraph: 22
+    quote: "the Monitor has arranged for a toll-free hotline phone number (1-855-338-1766) for calls related to this matter and an e-mail address (LaurentianUniversity.Monitor@ca.ey.com)"
+  - id: F20
+    fact: >
+      LU launched stakeholder websites at laurentianu.info and ulaurentienne.info, and implemented
+      new fiscal restraint policies authorizing only necessary expenses.
+    page: 4
+    paragraph: "18, 19"
+    quote: "the Applicant has drafted and implemented new fiscal restraint policies to monitor and authorize only necessary expenses during the pendency of this CCAA proceeding."
+  - id: F21
+    fact: "Classes continued virtually with no disruption following the Initial Order."
+    page: 4
+    paragraph: 17
+    quote: "Student classes are continuing (virtually due to the Pandemic) with no disruption."
+
+# No internal contradiction. Recorded explicitly so an invented one scores as a false positive.
+contradictions: []
+
+must_not_miss:
+  - id: M1
+    item: >
+      The court file number is printed as "CV-21-656040-00CL" — WITHOUT the leading zeros that
+      appear in the other corpus documents ("CV-21-00656040-00CL").
+    page: 1
+    location: cover page header
+    why: >
+      A formatting discrepancy in the source, recorded so scoring can distinguish faithful
+      extraction of what the page says from silent normalization to the other documents' format.
+      Both behaviours are informative; neither is a miss. It also tests whether the extractor
+      resolves this to the SAME court file entity as the other documents rather than creating a
+      duplicate.
+
+  - id: M2
+    item: >
+      Firm Capital Corporation executed the term sheet, then ASSIGNED its interest to Firm Capital
+      Mortgage Fund Inc., which is the actual DIP Lender. These are two distinct entities.
+    page: 8
+    paragraph: 33
+    why: >
+      Document 3 names only "Firm Capital Corporation". An extractor that collapses these into one
+      entity has lost the assignment; one that creates two unlinked entities has lost the
+      relationship. Both failure modes are worth catching, and this is the only place the
+      distinction is stated.
+
+  - id: M3
+    item: "The $500,000 DIP commitment fee, deemed FULLY EARNED on the date of court approval."
+    page: 9
+    paragraph: "34(f)"
+    why: >
+      Half a million dollars payable simply for the court signing — earned before a dollar is
+      advanced. It is the last item in a lettered list of facility terms, exactly where attention
+      runs out.
+
+  - id: M4
+    item: >
+      LU declined TWO expressions of interest in competing DIP financing, received 4 and 5 February
+      2021, days before the comeback motion.
+    page: 9
+    paragraph: 36
+    why: >
+      The insolvent institution turned away potential competing lenders while locked into an 8.5%
+      facility with a $500K fee. The paragraph reads as procedural housekeeping and is easy to skim.
+
+  - id: M5
+    item: >
+      The DIP extension milestones rest on the lender's "sole and unfettered discretion" — the
+      phrase appears twice, including on the question of whether LU is financially sustainable.
+    page: 8
+    paragraph: "34(b)"
+    why: >
+      A private lender holds unilateral judgment over whether a public university continues. Buried
+      in sub-sub-clauses.
+
+  - id: M6
+    item: >
+      The Administration Charge triples ($400K → $1.25M) and the Directors' Charge more than
+      doubles ($2M → $5M), all ranking ahead of every other secured creditor.
+    page: 2
+    paragraph: "4(d)"
+    why: >
+      $6.25M of super-priority charges jumping the queue ahead of existing secured lenders, listed
+      as roman-numeral sub-items on page 2 in a purpose statement.
+
+  - id: M7
+    item: >
+      Justice Sean Dunphy — the mediator — was himself a leading insolvency lawyer before the
+      bench, and the Court proposed him rather than the parties.
+    page: 7
+    paragraph: 28
+    why: >
+      The mediator's identity and provenance, given once. Note also that bilingualism was added as
+      a criterion here that was NOT in the Pre-Filing Report's list — a small drift worth catching.
+
+  - id: M8
+    item: >
+      The Monitor's reliability caveat about LU's Finance department, repeated from the Pre-Filing
+      Report — including the same erroneous affidavit date ("sworn January 30, 2020").
+    page: 3
+    paragraph: 9
+    why: >
+      Buried in disclaimer boilerplate. The repetition of the date error across two documents is
+      itself a fact: it is a copy-paste, not a fresh statement.
+
+  - id: M9
+    item: >
+      Creditors were notified only if owed more than $1,000, by ordinary mail, based on contact
+      information supplied by LU itself.
+    pages: [5, 6]
+    paragraph: "23(b)"
+    why: >
+      The notice threshold and its dependence on the debtor's own records — a due-process detail
+      that determines who found out. One clause in a list of postings.
+
+  - id: M10
+    item: >
+      The DIP process ran under two successive NDAs, with LU's identity withheld until the first
+      was signed.
+    page: 7
+    paragraph: 30
+    why: "How an insolvent public university shopped for money in secret. Procedural, and routinely dropped."

--- a/tests/documents/keys/first-report-monitor.yaml
+++ b/tests/documents/keys/first-report-monitor.yaml
@@ -15,6 +15,10 @@ document:
   date: 2021-02-07
   author: Ernst & Young Inc. (Monitor)
   court_file: "CV-21-656040-00CL (as printed — note the format differs from other corpus documents; see M1)"
+  expected_skill: bankruptcy
+  expected_skill_rationale: >
+    A monitor's report in a CCAA proceeding — named verbatim in the catalog description.
+  ingest_order: 3
   role_in_benchmark: "Entity overlap — E&Y, the Board, the DIP facility, LUFA."
 
 entities:

--- a/tests/documents/keys/initial-order-2021-02-01.yaml
+++ b/tests/documents/keys/initial-order-2021-02-01.yaml
@@ -16,6 +16,11 @@ document:
   doc_type: court order (CCAA Initial Order)
   date: 2021-02-01
   court_file: "CV-21-___656040___-00CL (typed into blank rules on the form — see ocr_hazards)"
+  expected_skill: bankruptcy
+  expected_skill_rationale: >
+    A CCAA initial order. `court-documents` explicitly redirects: "for bankruptcy or
+    receivership orders use `bankruptcy`".
+  ingest_order: 2
   role_in_benchmark: >
     The OCR arm. A clean-PDF corpus flatters every model; this document is where the pipeline
     actually meets a scanned court document with a seal, a wet signature, a registry stamp and a

--- a/tests/documents/keys/initial-order-2021-02-01.yaml
+++ b/tests/documents/keys/initial-order-2021-02-01.yaml
@@ -1,0 +1,394 @@
+# Answer key — corpus-v1, document 4 — THE OCR ARM
+#
+# Drafted from the SOURCE PDF by reading the SCANNED PAGES VISUALLY — deliberately NOT from an
+# OCR pass. OCRing the scan first and drafting from that would bake the pipeline's own OCR errors
+# into the key: anything the OCR mangles would be absent from the key, the extractor would never
+# be scored on it, and every condition would "pass". That is the correlation failure mode #361
+# warns about, one stage earlier. So the key records what is ON THE PAGE, and the OCR hazards are
+# enumerated in `ocr_hazards` below so scoring can tell an OCR failure apart from an extraction
+# failure.
+
+document:
+  file: "CV-21-00656040-00CL Laurentian U Initial Order 1 FEB 2021.pdf"
+  sha256: e943be8173383b5d077a492401ce783a50e188cc5336547acd5090acb1d73408
+  pages: 17
+  text_layer: "NONE — court-stamped scan, requires OCR"
+  doc_type: court order (CCAA Initial Order)
+  date: 2021-02-01
+  court_file: "CV-21-___656040___-00CL (typed into blank rules on the form — see ocr_hazards)"
+  role_in_benchmark: >
+    The OCR arm. A clean-PDF corpus flatters every model; this document is where the pipeline
+    actually meets a scanned court document with a seal, a wet signature, a registry stamp and a
+    sideways backsheet.
+
+entities:
+  - name: Laurentian University of Sudbury
+    type: organization
+    aliases: ["LU", "the Applicant"]
+    role: Applicant; DECLARED INSOLVENT by the Court in this order
+    page: 2
+  - name: G.B. Morawetz
+    type: person
+    aliases: ["Chief Justice Morawetz", "THE HONOURABLE CHIEF JUSTICE MORAWETZ"]
+    role: Chief Justice; signed the Initial Order
+    page: 1
+  - name: Ernst & Young Inc.
+    type: organization
+    aliases: ["EY", "the Monitor"]
+    role: appointed Monitor, an officer of the Court
+    page: 9
+  - name: Robert Haché
+    type: person
+    aliases: ["Dr. Robert Haché"]
+    role: affiant; the Haché Affidavit sworn 30 January 2021
+    page: 1
+  - name: Laurentian University Students General Association
+    type: organization
+    aliases: ["SGA"]
+    role: >
+      Designated a "Non-Applicant Stay Party" — not a CCAA applicant, but granted the benefit of a
+      limited stay.
+    page: 2
+  - name: Thornton Grout Finnigan LLP
+    type: organization
+    aliases: ["TGF"]
+    role: Lawyers for the Applicant
+    page: 17
+  - name: D.J. Miller
+    type: person
+    role: counsel for LU (LSO# 344393P)
+    page: 17
+  - name: Mitchell W. Grossell
+    type: person
+    role: counsel for LU (LSO# 69993I)
+    page: 17
+  - name: Andrew Hanrahan
+    type: person
+    role: counsel for LU (LSO# 78003K)
+    page: 17
+  - name: Derek Harland
+    type: person
+    role: counsel for LU (LSO# 79504N)
+    page: 17
+  - name: Ontario Ministry of Colleges and Universities
+    type: organization
+    aliases: ["MCU"]
+    role: government body the Monitor is empowered to talk to
+    page: 10
+  - name: Board of Governors
+    type: organization
+    aliases: ["the Board"]
+    role: beneficiary of the Directors' Charge and the indemnity
+    page: 8
+
+relationships:
+  - subject: G.B. Morawetz
+    predicate: issued
+    object: the Initial Order
+    page: 16
+  - subject: Ernst & Young Inc.
+    predicate: appointed Monitor of
+    object: Laurentian University of Sudbury
+    page: 9
+  - subject: Thornton Grout Finnigan LLP
+    predicate: counsel for
+    object: Laurentian University of Sudbury
+    page: 17
+  - subject: Laurentian University Students General Association
+    predicate: Non-Applicant Stay Party in
+    object: the LU CCAA proceedings
+    page: 2
+  - subject: Laurentian University of Sudbury
+    predicate: indemnifies
+    object: its directors, officers and the Board
+    page: 9
+
+facts:
+  - id: F1
+    fact: "The Court ORDERS AND DECLARES that the Applicant is insolvent and is a company to which the CCAA applies."
+    page: 2
+    paragraph: 4
+    quote: "THIS COURT ORDERS AND DECLARES that the Applicant is insolvent and is a company to which the CCAA applies."
+    note: "The judicial finding of insolvency — the legal fact the whole corpus turns on."
+  - id: F2
+    fact: "The order was made Monday, 1 February 2021 by Chief Justice Morawetz, heard by Zoom videoconference in Toronto because of the COVID-19 pandemic."
+    page: 1
+    quote: "was heard this day by videoconference via Zoom in Toronto, Ontario due to the COVID-19 pandemic."
+  - id: F3
+    fact: >
+      The Court read the Haché Affidavit sworn JANUARY 30, 2021 and the Pre-Filing Report of the
+      proposed monitor, Ernst & Young Inc., dated January 30, 2021.
+    page: 1
+    quote: "ON READING the affidavit of Dr. Robert Haché sworn January 30, 2021 and the Exhibits thereto (the \"Haché Affidavit\"), the pre-filing report of the proposed monitor, Ernst & Young Inc. (\"EY\"), dated January 30, 2021"
+    note: >
+      NOTE THE DATE. This order says the affidavit was sworn January 30, **2021**. Both the
+      Pre-Filing Report (¶8) and the First Report (¶9) say "sworn January 30, **2020**". This
+      document is the correct one; the Monitor's reports carry a copy-pasted typo. Relevant to
+      must_not_miss M2 in prefiling-report-monitor.yaml.
+  - id: F4
+    fact: "The Laurentian University Students General Association (SGA) is designated a 'Non-Applicant Stay Party' — not a CCAA applicant, but given the benefit of a limited stay."
+    page: 2
+    paragraph: 3
+    quote: "THIS COURT ORDERS that the Laurentian University Students General Association (the \"SGA\") shall be referred to herein as a \"Non-Applicant Stay Party\"."
+  - id: F5
+    fact: >
+      SEGREGATED FUNDS: segregated bank accounts established from and after 1 DECEMBER 2020 —
+      holding research grants, restricted donations, endowments and benefit-plan contributions —
+      must be used for their specific purpose, and SHALL NOT FORM PART OF the Applicant's Property.
+    page: 3
+    paragraph: 7
+    quote: "the Segregated Funds shall not form part of the Applicant's Property."
+    note: >
+      The court ring-fencing the restricted money that the Pre-Filing Report (¶167) says had been
+      co-mingled. The 1 December 2020 date matters — it is two months before filing.
+  - id: F6
+    fact: "The Property subject to the Charges does NOT include the Segregated Accounts."
+    page: 13
+    paragraph: 38
+    quote: "the Property subject to the Charges herein shall not include the Segregated Accounts."
+    note: "Reinforces F5 — even the super-priority charges cannot reach the restricted funds."
+  - id: F7
+    fact: >
+      Payments to former employees and retirees under the SuRP and the RHBP, and termination or
+      severance payments, are STAYED — while ordinary-course wages and benefits for CURRENT
+      employees continue.
+    page: 4
+    paragraph: "8(a)"
+    quote: "(but not including any payments to former employees or retirees in respect of the SuRP and the RHBP, as such terms are defined in the Haché Affidavit, or termination or severance payments, which are hereby stayed)"
+    note: "Retirees stop being paid; active staff keep being paid. Buried in a parenthesis."
+  - id: F8
+    fact: "Normal-course Pension Plan contributions continue to be remitted, until further order of the Court."
+    page: 5
+    paragraph: "10(a)"
+    quote: "until further order of this Court, all outstanding and future normal course contributions to or payments in respect of the Pension Plan"
+  - id: F9
+    fact: "The Applicant is directed to make no payments to pre-filing creditors — expressly including in respect of the INTEREST RATE SWAP transactions."
+    page: 6
+    paragraph: "11(a)"
+    quote: "(including for greater certainty in respect of the interest rate swap transactions)"
+  - id: F10
+    fact: "The initial Stay Period runs until and including 11 February 2021."
+    page: 6
+    paragraph: 13
+    quote: "that until and including February 11, 2021, or such later date as this Court may subsequently order (the \"Stay Period\")"
+  - id: F11
+    fact: "The Directors' Charge is granted on the Property, not to exceed $2,000,000."
+    page: 9
+    paragraph: 21
+    quote: "a charge (the \"Directors' Charge\") on the Property, which charge shall not exceed an aggregate amount of $2,000,000"
+  - id: F12
+    fact: "The Administration Charge is granted on the Property, not to exceed $400,000."
+    page: 12
+    paragraph: 31
+    quote: "a charge (the \"Administration Charge\") on the Property, which charge shall not exceed an aggregate amount of $400,000"
+  - id: F13
+    fact: "Charge priority: FIRST the Administration Charge ($400,000), SECOND the Directors' Charge ($2,000,000)."
+    page: 12
+    paragraph: 32
+    quote: "First – Administration Charge (to the maximum amount of $400,000); and Second –Directors' Charge (to the maximum amount of $2,000,000)."
+  - id: F14
+    fact: >
+      Board Counsel's fees paid by the Applicant after the date of the order are capped at $250,000
+      plus HST, pending further order.
+    page: 12
+    paragraph: 29
+    quote: "the fees and disbursement of Board Counsel paid by the Applicant from and after the date of this Order shall not exceed the aggregate amount of $250,000, plus HST, pending further Order of the Court."
+  - id: F15
+    fact: >
+      The directors' indemnity does NOT extend to obligations incurred through gross negligence or
+      wilful misconduct.
+    page: 9
+    paragraph: 20
+    quote: "except to the extent that, with respect to any officer, director or member of the Board, the obligation or liability was incurred as a result of the director's or officer's gross negligence or wilful misconduct."
+  - id: F16
+    fact: >
+      Directors and officers only get the benefit of the Directors' Charge to the extent they lack
+      insurance coverage, or it is insufficient; no insurer may be subrogated to the charge.
+    page: 9
+    paragraph: 22
+    quote: "no insurer shall be entitled to be subrogated to or claim the benefit of the Directors' Charge"
+  - id: F17
+    fact: >
+      The Monitor must publish notice in the Globe & Mail and the Sudbury Star, and notify every
+      known creditor with a claim over $1,000 — EXCLUDING individual employees, former employees
+      with pension entitlements, and retirees.
+    page: 13
+    paragraph: 39
+    quote: "send, in the prescribed manner, a notice to every known creditor who has a claim against the Applicant of more than $1,000 (excluding any individual employees, former employees with pension and/or retirement savings or benefits plan entitlements, and retirees and other beneficiaries who have entitlements under any pension or retirement savings plan)"
+    note: "Pensioners are creditors — and are expressly carved out of the creditor notice."
+  - id: F18
+    fact: "Confidential Exhibits 'EEE' and 'FFF' of the Haché Affidavit are SEALED and shall not form part of the public record."
+    page: 15
+    paragraph: 44
+    quote: "THIS COURT ORDERS that Confidential Exhibits \"EEE\" and \"FFF\" of the Haché Affidavit are hereby sealed pending further order of the Court, and shall not form part of the public record."
+  - id: F19
+    fact: "The Monitor shall not take possession of the Property and takes no part in managing the Business."
+    page: 10
+    paragraph: 25
+    quote: "THIS COURT ORDERS that the Monitor shall not take possession of the Property of the Applicant"
+  - id: F20
+    fact: "A case website is ordered established at www.ey.com/ca/Laurentian."
+    page: 14
+    paragraph: 40
+    quote: "This Court further orders that a Case Website shall be established in accordance with the Protocol with the following URL: www.ey.com/ca/Laurentian."
+  - id: F21
+    fact: "The Order is effective as of 12:01 a.m. Eastern Time on 1 February 2021 and is enforceable without entry and filing."
+    page: 16
+    paragraph: 49
+    quote: "this Order and all of its provisions are effective as of 12:01 a.m. Eastern Time on the date of this Order, and is enforceable without any need for entry and filing."
+  - id: F22
+    fact: >
+      The Monitor is protected from environmental liability — nothing requires it to take
+      possession of contaminated property under the Canadian Environmental Protection Act, the
+      Ontario Environmental Protection Act, the Ontario Water Resources Act or the Occupational
+      Health and Safety Act.
+    page: 11
+    paragraph: 26
+    quote: "nothing herein contained shall require the Monitor to occupy or to take control, care, charge, possession or management … of any of the Property that might be environmentally contaminated"
+
+contradictions: []
+
+# OCR HAZARDS — the point of this document in the benchmark.
+# These are scanned-page features that a text-extraction or OCR pass can plausibly mangle. When
+# scoring, check these FIRST: if a condition misses a fact anchored to one of these, establish
+# whether the OCR surfaced the text at all before charging it to the extractor.
+ocr_hazards:
+  - id: H1
+    hazard: "A red Superior Court of Justice seal is stamped over the left margin of page 1, overlapping the case-title text."
+    page: 1
+    risk: "OCR may drop, garble, or hallucinate characters where the seal overlaps the printed text."
+  - id: H2
+    hazard: >
+      The court file number is TYPED INTO BLANK RULED LINES on the form: "Court File No.
+      CV-21-___656040___-00CL". The digits sit between underscores/rules.
+    pages: [1, 17]
+    risk: >
+      OCR commonly renders the rules as characters or drops them, producing variants like
+      "CV-21-656040-00CL" or "CV-21- 656040 -00CL". This is the likely origin of the format
+      variance seen in the First Report. An extractor that resolves all variants to ONE court-file
+      entity is doing the right thing; one that creates several is not.
+  - id: H3
+    hazard: "A handwritten wet signature of Chief Justice G.B. Morawetz appears above his printed name."
+    page: 16
+    risk: "OCR may emit nothing, or noise characters, where the signature is. The printed name below it should still be recoverable."
+  - id: H4
+    hazard: >
+      A bilingual court registry stamp: "ENTERED AT / INSCRIT À TORONTO — ON / BOOK NO: — LE / DANS
+      LE REGISTRE NO:", with the date "FEB 0 1 2021" and handwritten registrar initials after
+      "PER / PAR:".
+    page: 16
+    risk: >
+      Two languages interleaved, a date with irregular spacing ("FEB 0 1 2021"), and handwriting.
+      A high-value target: this stamp is the proof the order was actually entered.
+  - id: H5
+    hazard: "THE BACKSHEET (page 17) IS ROTATED 90 DEGREES — the entire page reads sideways."
+    page: 17
+    risk: >
+      THE SINGLE BIGGEST HAZARD IN THE CORPUS. If the OCR does not auto-rotate, page 17 yields
+      nothing or gibberish — and page 17 is the ONLY place in this document where the applicant's
+      law firm and its four named lawyers appear. A condition that returns no counsel for this
+      document has almost certainly hit a rotation failure, not a reasoning failure. Check the chew
+      output for page 17 before scoring this against any extractor.
+  - id: H6
+    hazard: "Email addresses and LSO numbers on the sideways backsheet (djmiller@tgf.ca, LSO# 344393P, etc.)."
+    page: 17
+    risk: "Alphanumeric strings with punctuation, rotated. Compounding H5. Expect character-level errors even if rotation is handled."
+
+must_not_miss:
+  - id: M1
+    item: >
+      The backsheet: Thornton Grout Finnigan LLP, 3200–100 Wellington Street West, TD West Tower,
+      Toronto-Dominion Centre, Toronto ON M5K 1K7 — D.J. Miller (LSO# 344393P), Mitchell W.
+      Grossell (LSO# 69993I), Andrew Hanrahan (LSO# 78003K), Derek Harland (LSO# 79504N).
+      Lawyers for the Applicant.
+    page: 17
+    location: backsheet — ROTATED 90°
+    why: >
+      Last page, rotated, and the only place the applicant's counsel is named. This is the
+      highest-value must-not-miss item in the corpus precisely because it sits behind an OCR
+      rotation failure. See ocr_hazards H5.
+
+  - id: M2
+    item: >
+      The registry stamp proving entry: "ENTERED AT / INSCRIT À TORONTO", "FEB 0 1 2021", with
+      handwritten registrar initials.
+    page: 16
+    location: court registry stamp, below the signature
+    why: "Bilingual, handwritten, stamped. The evidence the order took effect. See H4."
+
+  - id: M3
+    item: "The signature block: CHIEF JUSTICE G.B. MORAWETZ, with a wet signature above the printed name."
+    page: 16
+    location: signature block
+    why: "Signature blocks are the first casualty of both extraction and OCR."
+
+  - id: M4
+    item: >
+      Segregated Funds — established from and after 1 DECEMBER 2020 — do not form part of the
+      Applicant's Property, and the Charges cannot reach them.
+    pages: [3, 13]
+    paragraph: "7, 38"
+    why: >
+      Stated in two places 10 pages apart, and it is the court's answer to the co-mingling problem.
+      The 1 December 2020 date is the tell: LU only began segregating restricted money two months
+      before filing.
+
+  - id: M5
+    item: >
+      Payments to retirees and former employees under the SuRP and RHBP, and all termination and
+      severance payments, are STAYED — inside a parenthesis in a paragraph about paying employees.
+    page: 4
+    paragraph: "8(a)"
+    why: >
+      The paragraph reads as "we will keep paying everyone"; the parenthesis says retirees and
+      severance are cut off. Inverting this inverts the meaning of the order.
+
+  - id: M6
+    item: >
+      The creditor-notice carve-out: employees, former employees with pension entitlements and
+      retirees are EXCLUDED from the notice to known creditors.
+    page: 13
+    paragraph: 39
+    why: >
+      A parenthetical exclusion determining who was told they were a creditor. Buried mid-sentence
+      in a service-and-notice paragraph.
+
+  - id: M7
+    item: "Confidential Exhibits 'EEE' and 'FFF' of the Haché Affidavit are sealed from the public record."
+    page: 15
+    paragraph: 44
+    why: >
+      A two-line sealing provision. It tells a journalist exactly which exhibits to fight for —
+      the single most actionable line in the document for a reporter.
+
+  - id: M8
+    item: "Board Counsel's fees are capped at $250,000 plus HST."
+    page: 12
+    paragraph: 29
+    why: "A discrete dollar cap at the end of a long paragraph about professional fees."
+
+  - id: M9
+    item: >
+      The Directors' Charge does not cover gross negligence or wilful misconduct, and directors get
+      its benefit only where insurance does not respond.
+    page: 9
+    paragraph: "20, 22"
+    why: "The limits on the indemnity — the part that would matter if anyone were later found at fault."
+
+  - id: M10
+    item: >
+      The stay expressly captures the INTEREST RATE SWAP transactions ("for greater certainty").
+    page: 6
+    paragraph: "11(a)"
+    why: >
+      A parenthetical that connects to the $24.7M swap termination obligation in doc 3 and the
+      $340K/month outflow in doc 2. Three documents, one thread, and this is the quietest mention.
+
+  - id: M11
+    item: "The SGA is a 'Non-Applicant Stay Party' — protected by the stay without being an applicant."
+    page: 2
+    paragraph: 3
+    why: >
+      An unusual CCAA device, and the reason the students' association and its $8.5M loan sit
+      inside the proceeding. A short paragraph under its own heading, early, where extractors are
+      still processing boilerplate.

--- a/tests/documents/keys/initial-order-2021-02-01.yaml
+++ b/tests/documents/keys/initial-order-2021-02-01.yaml
@@ -20,7 +20,6 @@ document:
   expected_skill_rationale: >
     A CCAA initial order. `court-documents` explicitly redirects: "for bankruptcy or
     receivership orders use `bankruptcy`".
-  ingest_order: 2
   role_in_benchmark: >
     The OCR arm. A clean-PDF corpus flatters every model; this document is where the pipeline
     actually meets a scanned court document with a seal, a wet signature, a registry stamp and a

--- a/tests/documents/keys/pension-order-2021-03-17.yaml
+++ b/tests/documents/keys/pension-order-2021-03-17.yaml
@@ -17,6 +17,11 @@ document:
   doc_type: court order
   date: 2021-03-17
   court_file: CV-21-00656040-00CL
+  expected_skill: bankruptcy
+  expected_skill_rationale: >
+    A court order made within a court-supervised restructuring, which the `bankruptcy`
+    description covers; `court-documents` redirects insolvency orders away from itself.
+  ingest_order: 4
   role_in_benchmark: >
     A short, sharp document for contrast. Low page count, high density of named parties and
     two precise dollar/ratio figures — a condition that degrades here is degrading on easy mode.

--- a/tests/documents/keys/pension-order-2021-03-17.yaml
+++ b/tests/documents/keys/pension-order-2021-03-17.yaml
@@ -21,7 +21,6 @@ document:
   expected_skill_rationale: >
     A court order made within a court-supervised restructuring, which the `bankruptcy`
     description covers; `court-documents` redirects insolvency orders away from itself.
-  ingest_order: 4
   role_in_benchmark: >
     A short, sharp document for contrast. Low page count, high density of named parties and
     two precise dollar/ratio figures — a condition that degrades here is degrading on easy mode.
@@ -118,9 +117,11 @@ entities:
     type: organization
     role: >
       Court-appointed monitor. NOTE — Ernst & Young is NOT named anywhere in this document; the
-      document says only "the Monitor". An extraction that outputs "Ernst & Young" here is
-      importing knowledge from another document (fine if the vault digest supplied it) or
-      hallucinating (not fine). Worth watching which.
+      document says only "the Monitor". Under #381 the extractor reads each document in isolation,
+      so the CORRECT extraction here is "the Monitor" — resolving it to Ernst & Young is the
+      finalizer reconciliation pass's job, not the extractor's. An extraction that outputs
+      "Ernst & Young" for this document is therefore either a lucky guess or a hallucination (there
+      is no vault state feeding it), and should be scored as ungrounded, not as a credited match.
     page: 3
 
 relationships:

--- a/tests/documents/keys/pension-order-2021-03-17.yaml
+++ b/tests/documents/keys/pension-order-2021-03-17.yaml
@@ -1,0 +1,363 @@
+# Answer key — corpus-v1, document 6
+#
+# Drafted from the SOURCE PDF (not from a pipeline extraction, not from chewed text).
+# Frozen before any condition runs; reused unchanged across all four conditions.
+# See tests/documents/CORPUS-v1.md and issue #361.
+#
+# Scoring note: `quote` is the verbatim span supporting each fact, and exists so the judge can
+# award the three grounding tiers (verbatim / credited normalization / ungrounded) rather than
+# exact-match. `aliases` exist for the same reason — "LU" for "Laurentian University of Sudbury"
+# is a credited normalization, not a miss.
+
+document:
+  file: "Pension Order Morawetz CJ- March 17 2021(as stamped by Court).PDF"
+  sha256: 40df3314772023baee9c229d62d23336e99f08012a94ec3ca6c72418a94bc8df
+  pages: 5
+  text_layer: born-digital
+  doc_type: court order
+  date: 2021-03-17
+  court_file: CV-21-00656040-00CL
+  role_in_benchmark: >
+    A short, sharp document for contrast. Low page count, high density of named parties and
+    two precise dollar/ratio figures — a condition that degrades here is degrading on easy mode.
+
+entities:
+  - name: Laurentian University of Sudbury
+    type: organization
+    aliases: ["LU", "Laurentian University", "Laurentian"]
+    role: Applicant; sponsor and administrator of the Pension Plan
+    page: 1
+
+  - name: G.B. Morawetz
+    type: person
+    aliases: ["Chief Justice Morawetz", "The Honourable Chief Justice Morawetz"]
+    role: Chief Justice; issued the order
+    page: 1
+
+  - name: Ontario Superior Court of Justice (Commercial List)
+    type: organization
+    role: issuing court
+    page: 1
+
+  - name: Robert Haché
+    type: person
+    aliases: ["Dr. Robert Haché"]
+    role: affiant; the "Initial Haché Affidavit" sworn 30 January 2021
+    page: 1
+
+  - name: Bobbie-Jo Brinkman
+    type: person
+    role: affiant; affidavit sworn 8 March 2021
+    page: 1
+
+  - name: Derek Harland
+    type: person
+    role: >
+      Appears twice in two capacities — deponent of the Affidavit of Service sworn 10 March 2021
+      (p. 2) AND counsel at Thornton Grout Finnigan LLP on the backsheet (p. 5).
+    page: 2
+
+  - name: Caleb Leduc
+    type: person
+    role: Interim CV Applicant; appeared
+    page: 1
+  - name: Brady Zapalski
+    type: person
+    role: Interim CV Applicant; appeared
+    page: 1
+  - name: Ann Pegoraro
+    type: person
+    role: Interim CV Applicant; appeared
+    page: 1
+  - name: William Oxley
+    type: person
+    role: Interim CV Applicant; appeared
+    page: 1
+  - name: Sheila McGillis
+    type: person
+    role: Interim CV Applicant; appeared
+    page: 1
+
+  - name: Thornton Grout Finnigan LLP
+    type: organization
+    aliases: ["TGF"]
+    role: Lawyers for the Applicant
+    page: 5
+
+  - name: D.J. Miller
+    type: person
+    role: counsel for LU (LSO# 344393P)
+    page: 5
+  - name: Mitchell W. Grossell
+    type: person
+    role: counsel for LU (LSO# 69993I)
+    page: 5
+  - name: Andrew Hanrahan
+    type: person
+    role: counsel for LU (LSO# 78003K)
+    page: 5
+
+  - name: Financial Services Regulatory Authority of Ontario
+    type: organization
+    aliases: ["FSRA", "Financial Services Regulatory Authority"]
+    role: pension regulator; actuarial valuation filed with it in December 2020
+    page: 2
+
+  - name: Pension Benefits Guarantee Fund
+    type: organization
+    aliases: ["PBGF"]
+    role: fund to which LU owes assessment fees
+    page: 3
+
+  - name: the Monitor
+    type: organization
+    role: >
+      Court-appointed monitor. NOTE — Ernst & Young is NOT named anywhere in this document; the
+      document says only "the Monitor". An extraction that outputs "Ernst & Young" here is
+      importing knowledge from another document (fine if the vault digest supplied it) or
+      hallucinating (not fine). Worth watching which.
+    page: 3
+
+relationships:
+  - subject: Laurentian University of Sudbury
+    predicate: sponsor and administrator of
+    object: the Pension Plan
+    page: 2
+  - subject: G.B. Morawetz
+    predicate: issued
+    object: the Pension Order
+    page: 4
+  - subject: Thornton Grout Finnigan LLP
+    predicate: counsel for
+    object: Laurentian University of Sudbury
+    page: 5
+  - subject: Derek Harland
+    predicate: lawyer at
+    object: Thornton Grout Finnigan LLP
+    page: 5
+  - subject: Robert Haché
+    predicate: affiant for
+    object: Laurentian University of Sudbury
+    page: 1
+  - subject: Laurentian University of Sudbury
+    predicate: owes assessment fees to
+    object: Pension Benefits Guarantee Fund
+    page: 3
+  - subject: Laurentian University of Sudbury
+    predicate: filed actuarial valuation with
+    object: Financial Services Regulatory Authority of Ontario
+    page: 2
+
+# 10–20 material facts, each with page + verbatim support.
+facts:
+  - id: F1
+    fact: "The order was made Wednesday, 17 March 2021 by Chief Justice Morawetz."
+    page: 1
+    quote: "THE HONOURABLE CHIEF JUSTICE MORAWETZ ) WEDNESDAY, THE 17th DAY OF MARCH, 2021"
+
+  - id: F2
+    fact: "The motion was brought by LU under the Companies' Creditors Arrangement Act (CCAA)."
+    page: 1
+    quote: "THIS MOTION, brought by Laurentian University of Sudbury (\"LU\") pursuant to the Companies' Creditors Arrangement Act, R.S.C. 1985, c. C-36, as amended"
+
+  - id: F3
+    fact: "The motion was heard by videoconference via Zoom in Toronto because of the COVID-19 pandemic."
+    page: 1
+    quote: "was heard this day by videoconference via Zoom in Toronto, Ontario due to the COVID-19 pandemic"
+
+  - id: F4
+    fact: "The Transfer Ratio is set at 65.8%."
+    page: 2
+    quote: "shall be permitted to transfer commuted values from the Pension Plan based on a transfer ratio equal to 65.8% (the \"Transfer Ratio\")"
+    note: >
+      The headline number. 65.8% means a member taking a commuted value transfer receives roughly
+      two-thirds of it — the plan is badly underfunded. Any condition that misses this figure has
+      missed the point of the document.
+
+  - id: F5
+    fact: >
+      The 65.8% ratio comes from the most recently filed actuarial valuation report, effective
+      1 January 2020 and filed with FSRA in December 2020.
+    page: 2
+    quote: "being the transfer ratio contained in the most recently filed actuarial valuation report for the Pension Plan (effective as of January 1, 2020 and filed with the Financial Services Regulatory Authority of Ontario in December 2020)"
+
+  - id: F6
+    fact: >
+      Interim CV Applicants are those who received a retirement/termination statement and election
+      form indicating they may elect a 100% commuted value transfer, and for whom the transfer has
+      not yet been made.
+    page: 2
+    quote: "for any individual who has received a retirement or termination statement and election form from LU indicating that he or she may elect to receive a 100% commuted value transfer from the Pension Plan and for whom such transfers have not yet been made (the \"Interim CV Applicants\")"
+
+  - id: F7
+    fact: >
+      Interim CV Applicants get a re-election form and must elect in writing within 30 days of
+      notice of the order.
+    page: 2
+    quote: "shall be given a re-election form, which form must be submitted in writing to LU within 30 days of notice of this Order"
+
+  - id: F8
+    fact: >
+      An Interim CV Applicant who does not elect within 30 days is DEEMED TO HAVE WITHDRAWN the
+      transfer application and retains only a deferred pension.
+    page: 2
+    quote: "shall be deemed to have withdrawn their application for a transfer of their commuted value and shall retain their entitlement to a deferred pension from the Pension Plan"
+    note: "Silence forfeits the transfer. A consequential default rule, easy to skim past."
+
+  - id: F9
+    fact: >
+      The PBGF Assessment Payment is $842,018.34, due 30 March 2021, for the pre-filing period
+      1 July 2019 to 30 June 2020.
+    page: 3
+    quote: "the payment due on March 30, 2021 in the amount of $842,018.34 in respect of LU's pro rata portion of assessment fees payable to the Pension Benefits Guarantee Fund relating to the Pension Plan for the pre-filing period of July 1, 2019 to June 30, 2020"
+
+  - id: F10
+    fact: "The PBGF Assessment Payment is stayed and suspended."
+    page: 3
+    quote: "is stayed and suspended in accordance with paragraph 12 of the Amended and Restated Initial Order of this Court dated February 11, 2021"
+
+  - id: F11
+    fact: >
+      There is a SECOND, separate Incremental PBGF Assessment Payment covering the earlier
+      pre-filing period 1 July 2018 to 30 June 2019, triggered by the December 2020 filing of a new
+      actuarial valuation. It is also stayed. Its amount is NOT stated in the document.
+    page: 3
+    quote: "any incremental amount owing by LU in respect of its pro rata portion of assessment fees payable to the Pension Benefits Guarantee Fund relating to the Pension Plan for the pre-filing period of July 1, 2018 to June 30, 2019 due to the filing in December 2020 of a new actuarial valuation report"
+    note: >
+      Two payments, not one — and only the first is quantified. An extraction that reports a single
+      stayed PBGF payment of $842,018.34 has silently dropped the second.
+
+  - id: F12
+    fact: >
+      The stay flows from paragraph 12 of the Amended and Restated Initial Order dated
+      11 February 2021.
+    page: 3
+    quote: "in accordance with paragraph 12 of the Amended and Restated Initial Order of this Court dated February 11, 2021"
+    note: >
+      Dates the Amended and Restated Initial Order to 11 Feb 2021 — ten days after the 1 Feb 2021
+      Initial Order (corpus document 4). A cross-document link worth catching.
+
+  - id: F13
+    fact: >
+      No LU director, officer, employee, agent, advisor or consultant incurs any obligation or
+      liability as a result of the stay.
+    page: 3
+    quote: "none of LU or any of its directors, officers, employees, agents, advisors or consultants shall incur any obligation or liability as a result of the stay and suspension"
+
+  - id: F14
+    fact: >
+      Despite the stay, FSRA is expressly NOT precluded from asserting a claim against LU for
+      either PBGF payment.
+    page: 3
+    quote: "nothing in this Order shall preclude the Financial Services Regulatory Authority from asserting a claim against LU in respect of the PBGF Assessment Payment or the Incremental PBGF Assessment Payment"
+    note: >
+      The carve-out to F10/F13, and the last sentence of a paragraph that otherwise reads as
+      blanket protection. A model that reports "the payments are stayed and no claim can be made"
+      has inverted this.
+
+  - id: F15
+    fact: >
+      Future adjustments to the Transfer Ratio are to be made under the Pension Benefits Act (PBA)
+      or by further order of the court.
+    page: 3
+    quote: "any future adjustments to the applicable Transfer Ratio for the purpose of commuted value transfers shall be established in accordance with the PBA, or by further Order of this Court"
+
+  - id: F16
+    fact: >
+      The court requests the aid and recognition of any court, tribunal, regulatory or
+      administrative body in Canada or the United States.
+    page: 3
+    quote: "THIS COURT HEREBY REQUESTS the aid and recognition of any court, tribunal, regulatory or administrative body, having jurisdiction in Canada or in the United States of America"
+
+  - id: F17
+    fact: >
+      Five Interim CV Applicants appeared: Caleb Leduc, Brady Zapalski, Ann Pegoraro, William Oxley
+      and Sheila McGillis. No one appeared for the remaining Interim CV Applicants.
+    page: 1
+    quote: "the following Interim CV Applicants, Caleb Leduc, Brady Zapalski, Ann Pegoraro, William Oxley and Sheila McGillis, with no one appearing for any other person on the service list or the remaining Interim CV Applicants"
+
+  - id: F18
+    fact: >
+      The court read: the Notice of Motion dated 8 March 2021; the Initial Haché Affidavit sworn
+      30 January 2021; the Affidavit of Bobbie-Jo Brinkman sworn 8 March 2021; and the Second Report
+      of the Monitor dated 11 March 2021.
+    page: 1
+    quote: "ON READING the Notice of Motion of LU dated March 8, 2021, the affidavit of Dr. Robert Haché sworn January 30, 2021 and the Exhibits thereto (the \"Initial Haché Affidavit\") … the Affidavit of Bobbie-Jo Brinkman sworn March 8, 2021 and the Exhibits thereto and the Second Report of the Monitor dated March 11, 2021"
+
+  - id: F19
+    fact: "LU is both sponsor AND administrator of the Pension Plan."
+    page: 2
+    quote: "LU, in its capacity as an Applicant herein and as sponsor and administrator of the Pension Plan"
+    note: >
+      LU administers the plan whose transfer ratio it is asking the court to apply to its own
+      members. Not a conflict the document flags, but the dual role is stated.
+
+# No internal contradiction in this document. The scored contradiction pair is documents 1 and 2
+# (see CORPUS-v1.md). Recorded explicitly so a condition that INVENTS a contradiction here is
+# scored as a false positive rather than passing unnoticed.
+contradictions: []
+
+# Buried items — things a hurried reader (or a budget-constrained extractor) drops first.
+# Scored separately from `facts`: this is where cheap conditions degrade first.
+must_not_miss:
+  - id: M1
+    item: "The signature block: CHIEF JUSTICE G.B. MORAWETZ."
+    page: 4
+    location: signature block
+    why: "Page 4 is a 252-character orphan page. Easy to skip entirely."
+
+  - id: M2
+    item: >
+      The backsheet naming counsel: Thornton Grout Finnigan LLP, 3200–100 Wellington Street West,
+      Toronto; D.J. Miller (LSO# 344393P), Mitchell W. Grossell (LSO# 69993I), Andrew Hanrahan
+      (LSO# 78003K), Derek Harland (LSO# 79504N).
+    page: 5
+    location: backsheet (final page)
+    why: >
+      Last page, no prose, pure metadata — the classic dropped page. It is also the only place the
+      applicant's law firm is named.
+
+  - id: M3
+    item: "The Incremental PBGF Assessment Payment — a second stayed payment, amount not stated."
+    page: 3
+    location: body of paragraph 6, after the quantified figure
+    why: >
+      Sits behind the $842,018.34 in the same sentence. Extractions reliably capture the number and
+      drop the unquantified second payment.
+
+  - id: M4
+    item: >
+      The FSRA carve-out: the stay does not preclude FSRA from asserting a claim.
+    page: 3
+    location: final sentence of paragraph 7
+    why: "Reverses the paragraph it sits in. Dropping it inverts the meaning of the order."
+
+  - id: M5
+    item: >
+      The 30-day deemed-withdrawal rule: an Interim CV Applicant who does not re-elect in writing
+      loses the commuted value transfer and keeps only a deferred pension.
+    page: 2
+    location: end of paragraph 4, crossing the page 2/3 boundary
+    why: >
+      The consequence clause runs across a page break — precisely where section-chunked extraction
+      loses text.
+
+  - id: M6
+    item: >
+      Derek Harland appears in two capacities: deponent of the Affidavit of Service (p. 2) and
+      counsel at TGF (p. 5).
+    pages: [2, 5]
+    location: recital + backsheet
+    why: >
+      Requires joining the front and back of the document. A per-section extractor sees the two
+      mentions in different chunks and will usually emit two unlinked entities, or one.
+
+  - id: M7
+    item: >
+      The five named Interim CV Applicants (Leduc, Zapalski, Pegoraro, Oxley, McGillis) — real
+      pensioners, named in the recital.
+    page: 1
+    location: recital, mid-sentence
+    why: >
+      Buried in a long procedural sentence about service. These are the human beings the 65.8%
+      ratio is being applied to; an extractor tuned to institutions will drop them.

--- a/tests/documents/keys/prefiling-report-monitor.yaml
+++ b/tests/documents/keys/prefiling-report-monitor.yaml
@@ -1,0 +1,425 @@
+# Answer key — corpus-v1, document 2 — CONTRADICTION SIDE B
+#
+# Drafted from the SOURCE PDF. Frozen before any condition runs.
+#
+# This is one half of the scored contradiction pair. The other half is
+# Annual-Financial-Report-19-20.pdf (document 1). NEITHER DOCUMENT MENTIONS THE OTHER — the
+# extractor has to notice the conflict by comparing against the vault digest, which is the
+# machinery under test. See CORPUS-v1.md.
+
+document:
+  file: "Laurentian Pre-Filing Report of the Proposed Monitor.pdf"
+  sha256: c5e89ac26f89d571136b9231f6cb943bcdd61199cfd4b622745f85489a480dcb
+  pages: 47
+  text_layer: born-digital
+  doc_type: monitor's report (pre-filing), CCAA
+  date: 2021-01-30
+  author: Ernst & Young Inc. (Proposed Monitor)
+  court_file: "not yet assigned — cover page reads 'Court File No. __________'"
+  role_in_benchmark: "Contradiction side B; entity-rich (affiliates, lenders, pension plans)."
+
+entities:
+  - name: Ernst & Young Inc.
+    type: organization
+    aliases: ["EY", "the Proposed Monitor", "the Monitor"]
+    role: proposed CCAA Monitor; licensed insolvency trustee under s.2 of the BIA
+    page: 3
+  - name: Laurentian University of Sudbury
+    type: organization
+    aliases: ["LU", "the Applicant"]
+    role: CCAA applicant; incorporated 28 March 1960 under the Laurentian Act
+    page: 1
+  - name: Stikeman Elliott LLP
+    type: organization
+    role: independent counsel to the Proposed Monitor
+    page: 4
+  - name: Robert Haché
+    type: person
+    aliases: ["Dr. Haché", "Dr. Robert Haché"]
+    role: President and Vice-Chancellor of LU; affiant; also CHAIR of the NOSM board
+    page: 3
+  - name: Royal Bank of Canada
+    type: organization
+    aliases: ["RBC"]
+    role: primary banking relationship; operating accounts; $250,000 revolving demand facility
+    page: 31
+  - name: Desjardins
+    type: organization
+    role: line of credit; $14.4M drawn as at 30 April 2020
+    page: 26
+  - name: TD Canada Trust
+    type: organization
+    aliases: ["TD"]
+    role: blocked account for debt service; lender to the SGA ($8.5M student centre loan)
+    page: 31
+  - name: Bank of Montreal
+    type: organization
+    aliases: ["BMO"]
+    role: blocked account for debt service
+    page: 31
+  - name: SEI Private Trust Company
+    type: organization
+    role: investment account custodian
+    page: 24
+  - name: RBC Dominion Securities Inc.
+    type: organization
+    role: investment account custodian
+    page: 24
+  - name: Northern Ontario School of Medicine
+    type: organization
+    aliases: ["NOSM"]
+    role: not-for-profit; LU and Lakehead are its two members; Haché chairs its board
+    page: 7
+  - name: Lakehead University
+    type: organization
+    aliases: ["Lakehead"]
+    role: co-member of NOSM
+    page: 7
+  - name: University of Sudbury
+    type: organization
+    aliases: ["SU"]
+    role: federated university; founded 1913 as Collège du Sacré-Coeur
+    page: 7
+  - name: Thorneloe University
+    type: organization
+    aliases: ["Thorneloe"]
+    role: federated university; Anglican Church of Canada roots
+    page: 8
+  - name: Huntington University
+    type: organization
+    aliases: ["Huntington"]
+    role: federated university; founded 1960
+    page: 8
+  - name: SNOLab
+    type: organization
+    aliases: ["Sudbury Neutrino Observatory Laboratory", "SNOLAB"]
+    role: >
+      Underground lab in Vale's Creighton mine; trust of five institutions (LU, Carleton, Queen's,
+      Alberta, Montréal); LU's proportionate share is 20%; LU processes payroll for ~128 employees.
+    page: 9
+  - name: MIRARCO
+    type: organization
+    aliases: ["Mining Innovation Rehabilitation and Applied Research Corporation"]
+    role: mining research arm; LU is sole member; consolidated in LU's statements; 19 employees
+    page: 10
+  - name: Centre for Excellence in Mining Innovation
+    type: organization
+    aliases: ["CEMI"]
+    role: affiliate; participating employer in the DB Pension Plan
+    page: 6
+  - name: Students General Association
+    type: organization
+    aliases: ["SGA"]
+    role: owes TD $8,500,000 under a 10 April 2018 letter agreement for a new student centre
+    page: 28
+  - name: Laurentian University Faculty Association
+    type: organization
+    aliases: ["LUFA"]
+    role: faculty union; relationship with LU described as "currently strained"
+    page: 39
+  - name: Université de Hearst
+    type: organization
+    role: its President is a non-voting member of LU's Senate
+    page: 5
+
+relationships:
+  - subject: Ernst & Young Inc.
+    predicate: proposed Monitor of
+    object: Laurentian University of Sudbury
+    page: 1
+  - subject: Stikeman Elliott LLP
+    predicate: independent counsel to
+    object: Ernst & Young Inc.
+    page: 4
+  - subject: Robert Haché
+    predicate: President and Vice-Chancellor of
+    object: Laurentian University of Sudbury
+    page: 5
+  - subject: Robert Haché
+    predicate: Chair of the board of
+    object: Northern Ontario School of Medicine
+    page: 7
+  - subject: Laurentian University of Sudbury
+    predicate: primary employer under the DB Pension Plan covering
+    object: Federated Universities, SNOLab, MIRARCO, CEMI
+    page: 14
+  - subject: Students General Association
+    predicate: owes $8.5M to
+    object: TD Canada Trust
+    page: 28
+  - subject: Laurentian University of Sudbury
+    predicate: leases NOSM's Sudbury buildings to
+    object: Northern Ontario School of Medicine
+    page: 7
+  - subject: Laurentian University of Sudbury
+    predicate: holds ~$14M of endowments designated for
+    object: Northern Ontario School of Medicine
+    page: 7
+
+facts:
+  - id: F1
+    fact: "LU IS INSOLVENT and, absent the relief sought, will not have sufficient liquidity to meet payroll in February."
+    page: 31
+    paragraph: 165
+    quote: "LU is insolvent and absent the relief sought in the Initial Order, will not have sufficient funding / liquidity to meet payroll in February."
+    note: "CONTRADICTION SIDE B. The single most important sentence in the corpus."
+  - id: F2
+    fact: >
+      The Monitor attributes the crisis to "the pattern of recurring deficits over a number of
+      years", exacerbated by recent revenue pressures — NOT to the pandemic.
+    page: 39
+    paragraph: 206
+    quote: "the pattern of recurring deficits over a number of years, exacerbated by recent significant pressures on revenue described earlier in this report, has brought the Applicant to the point where it has an immediate and dramatic liquidity crisis"
+    note: "Reinforces the contradiction with document 1's COVID-attribution."
+  - id: F3
+    fact: >
+      Restricted funds were CO-MINGLED. All receipts — operating, research grants, restricted
+      donations — flowed into the same Operating Accounts. There were no separate bank accounts
+      set up to receive and hold restricted funds.
+    page: 31
+    paragraph: 167
+    quote: "There were no separate bank accounts set up to receive and hold restricted funds. All funds available in the Operating Accounts were utilized prior to drawing on lines of credit."
+  - id: F4
+    fact: >
+      LU does not hold enough money to cover its restricted-fund obligations — it spent money it
+      was holding for someone else.
+    page: 32
+    paragraph: 168
+    quote: "the funds held by LU at the current time are insufficient to cover obligations in connection with these restricted funds"
+  - id: F5
+    fact: >
+      In December 2020 the practice was brought to the President's attention and the Board ordered
+      three new Segregated Accounts created (Unspent Research Grant Account, Restricted Funds
+      Account, RHBP Account) — weeks before the CCAA filing.
+    page: 32
+    paragraph: 169
+    quote: "In December 2020, LU's cash management practices were brought to the attention of LU's President and the matter was discussed with the Board. The Board instructed management to amend its practice and immediately create three new bank accounts"
+  - id: F6
+    fact: "As at 29 January 2021: ~$13.3M in operating accounts and ~$3.3M in the Segregated Accounts."
+    page: 32
+    paragraph: 174
+    quote: "the Applicant has an estimated aggregate cash balance in its operating accounts of approximately $13.3 million. In addition, it has an estimated aggregate cash balance in the Segregated Accounts (described above) of $3.3 million."
+  - id: F7
+    fact: "LU has insufficient cash to fund operations through February 2021 or beyond; the previously relied-upon lines of credit are no longer available."
+    page: 33
+    paragraph: 175
+    quote: "the Applicant currently has insufficient cash to fund operations through the month of February or beyond"
+  - id: F8
+    fact: >
+      13-week cash flow forecast (30 Jan – 30 Apr 2021): receipts ~$29.5M, disbursements ~$58.5M,
+      net cash outflow ~$29.0M.
+    page: 34
+    paragraph: 184
+    quote: "estimated total combined receipts of approximately $29.5 million … Estimated total combined disbursements are forecast to be approximately $58.5 million … This results in projected net cash outflow (net of Segregated Account activity) of approximately $29.0 million."
+  - id: F9
+    fact: "At 30 April 2020 LU held ~$52.8 million in endowments; investment accounts totalled $54.7 million."
+    page: 24
+    paragraph: 120
+    quote: "At April 30, 2020, the balance in these investment accounts was $54.7 million … The majority of this amount is designated to support the $52.8 million in endowments held by LU"
+    note: >
+      Matches document 1's stated $52.8M endowment exactly. The endowment figure is NOT the
+      contradiction — the *narrative* is. An extractor that flags these two as conflicting has
+      produced a FALSE POSITIVE.
+  - id: F10
+    fact: "LU had minimal cash at 30 April 2020 — ~$2.6M cash and $1.9M short-term investments."
+    page: 24
+    paragraph: 118
+    quote: "As at April 30, 2020, LU had minimal cash on hand – approximately $2.6 million in cash and $1.9 million in short-term investments."
+  - id: F11
+    fact: "Net assets fell $32.9 million, from $69.6 million in FY2014-15."
+    page: 29
+    paragraph: 154
+    quote: "Net assets have decreased by $32.9 million from $69.6 million in fiscal year 2014-2015"
+    note: "Dates the decline to 2014-15 — six years before COVID."
+  - id: F12
+    fact: >
+      DB Pension Plan: solvency ratio 85.4%, going-concern deficiency ~$4.5M, per the 1 January
+      2020 actuarial valuation (updated December 2020).
+    page: 14
+    paragraph: 89
+    quote: "the DB Pension Plan had a solvency ratio of 85.4%, representing a going concern deficiency of approximately $4.5 million"
+  - id: F13
+    fact: >
+      DB Pension Plan membership: 406 individuals collecting a lifetime pension, 981 active
+      contributing members, ~500 with deferred status.
+    page: 14
+    paragraph: 88
+    quote: "There are currently 406 individuals collecting a lifetime pension from the DB Pension Plan. There are 981 active members currently contributing to the DB Pension Plan but not yet collecting a benefit. In addition, approximately 500 members have deferred status"
+  - id: F14
+    fact: >
+      Pension current service contributions were set at $16,188,000 annually (~$1,349,000 monthly),
+      plus a special payment of $505,000 annually (~$42,083 monthly) to address the deficiency.
+    page: 15
+    paragraph: 90
+    quote: "the DB Pension Plan current service contributions for the next three years would be set at $16,188,000, annually, payable in monthly instalment of approximately $1,349,000"
+  - id: F15
+    fact: "LU administers three plans: the DB Pension Plan, the SuRP (supplementary, UNFUNDED), and the RHBP (retirement health benefits)."
+    page: 14
+    paragraph: 86
+    quote: "LU administers three employee pension and benefit plans: (i) a registered defined benefit pension plan (the \"DB Pension Plan\"); (ii) a supplementary unfunded retirement plan (the \"SuRP\") and (iii) a retirement health benefits plan (the \"RHBP\")."
+  - id: F16
+    fact: "LU's interest rate swaps produced a net cash OUTFLOW of approximately $340,000 per month."
+    page: 28
+    paragraph: 147
+    quote: "The net impact of these interest rate swap transactions has been a net cash outflow from LU of approximately $340,000 monthly."
+  - id: F17
+    fact: "LU drew $14.4 million on the Desjardins line of credit as at 30 April 2020."
+    page: 26
+    paragraph: 126
+    quote: "As at April 30, 2020, LU had drawn $14.4 million against the Desjardins Line of Credit."
+  - id: F18
+    fact: "LU holds approximately $14 million in endowments designated for future NOSM student scholarships."
+    page: 7
+    paragraph: 39
+    quote: "LU holds approximately $14 million in endowments designated to fund future scholarships for qualifying NOSM students."
+  - id: F19
+    fact: >
+      Federated Funding Formula: LU distributes a share of provincial grants and tuition to the
+      Federated Universities, less a service fee of 15% of the grant and tuition revenues
+      distributed. Amended 1 May 2019 in a way that DECREASED funding to them.
+    page: 9
+    paragraph: 51
+    quote: "an offsetting charge for service fees charged by LU to the Federated Universities … (calculated as 15% of grant and tuition revenues distributed to the Federated Universities)"
+  - id: F20
+    fact: "LU's Board has 21 voting and 9 non-voting members, with FOUR voting positions vacant. The Senate has 77 voting and 6 non-voting members."
+    page: 5
+    paragraph: 23
+    quote: "The Board is currently comprised of 21 voting members and 9 non-voting members. Four voting member positions are vacant."
+  - id: F21
+    fact: "The Monitor recommends a court-appointed mediator, preferably a sitting or recently retired judge, on an urgent basis; the LU–LUFA relationship is 'currently strained'."
+    page: 39
+    paragraph: 208
+    quote: "The Proposed Monitor notes the relationship between the Applicant and LUFA is currently strained."
+
+contradictions:
+  - id: C1
+    type: cross-document
+    scored: true
+    against: "Annual-Financial-Report-19-20.pdf (corpus document 1)"
+    this_document_claims: >
+      LU is insolvent and cannot meet February payroll (¶165, p. 31); the cause is "the pattern of
+      recurring deficits over a number of years" (¶206, p. 39); net assets have fallen $32.9M since
+      FY2014-15 (¶154).
+    other_document_claims: >
+      LU was "on track" with an anticipated "small deficit of $0.9 million"; the actual $5.4M
+      operating deficit was $5.2M "related to the COVID-19 outbreak"; LU "continues to trace its
+      path to sustainability."
+    why_it_matters: >
+      Weeks apart. A university claiming a $0.9M planned deficit, blaming the pandemic, and
+      tracing a "path to sustainability" — then unable to make payroll. Neither document cites the
+      other, so the extractor must notice the conflict via the entity digest. Both sides are
+      explicit positive claims, so it can fire without proving a negative.
+
+must_not_miss:
+  - id: M1
+    item: >
+      The Monitor's reliability caveat: it quotes Haché's own affidavit saying LU "has experienced
+      a number of challenges with the limited team and resources in the Finance department", and
+      concludes "the Information relied upon for purposes of this Report may be limited by these
+      challenges."
+    page: 3
+    paragraph: 8
+    location: Terms of Reference and Disclaimer
+    why: >
+      The Monitor is telling the Court, on page 3, that LU's own numbers may not be trustworthy.
+      Buried in boilerplate disclaimer language that extractors are trained to skip.
+
+  - id: M2
+    item: >
+      The Haché affidavit is described as "sworn January 30, 2020" — a year before the report's own
+      date of January 30, 2021 (elsewhere, and in the Pension Order, it is 2021).
+    page: 3
+    paragraph: 8
+    location: Terms of Reference
+    why: >
+      A DATE ERROR IN THE SOURCE. Recorded here so scoring can tell the difference between an
+      extractor faithfully reporting the document's stated (wrong) date — which is CORRECT
+      extraction — and one silently "fixing" it to 2021. Both behaviours are interesting; neither
+      should be scored as a miss.
+
+  - id: M3
+    item: "The co-mingling of restricted funds, and the December 2020 creation of three Segregated Accounts."
+    pages: [31, 32]
+    paragraph: "167–173"
+    location: Cash Management section
+    why: >
+      The core governance failure in the entire Laurentian story — restricted research grants and
+      donations spent on operations. It appears in the middle of a procedural section titled "Cash
+      Management", which reads like plumbing.
+
+  - id: M4
+    item: "LU's proportionate share of SNOLab's assets, liabilities and obligations is 20%."
+    page: 10
+    paragraph: 53
+    why: "A quantified off-balance-sheet exposure to a national physics facility, in one clause."
+
+  - id: M5
+    item: "Dr. Haché, LU's President, serves as CHAIR of NOSM's board."
+    page: 7
+    paragraph: 36
+    why: >
+      The president of the insolvent university chairs the board of the related party it owes money
+      to and holds $14M of endowments for. Stated once, in passing.
+
+  - id: M6
+    item: "The interest rate swaps bled ~$340,000 per month in net cash outflow."
+    page: 28
+    paragraph: 147
+    why: >
+      ~$4M a year, and the swap termination later cost $24.7M (see doc 3). One sentence at the end
+      of a technical subsection.
+
+  - id: M7
+    item: >
+      The SGA owes TD $8,500,000 under a letter agreement dated 10 April 2018 for a new student
+      centre — the debt LU guaranteed.
+    page: 28
+    paragraph: 144
+    why: "Names the counterparty, amount and instrument date. Buried in the debt schedule."
+
+  - id: M8
+    item: "The SuRP is a supplementary retirement plan that is UNFUNDED."
+    page: 14
+    paragraph: 86
+    why: "One word — 'unfunded' — inside a list item. It is an entire unsecured liability class."
+
+  - id: M9
+    item: "Stikeman Elliott LLP acts as independent counsel to the Proposed Monitor."
+    page: 4
+    paragraph: 13
+    why: "A one-sentence paragraph. The Monitor's own law firm, easy to drop."
+
+  - id: M10
+    item: >
+      Pension membership: 406 collecting, 981 active, ~500 deferred — roughly 1,900 people whose
+      retirement depends on an 85.4%-solvent plan.
+    page: 14
+    paragraph: 88
+    why: "The human scale of the pension exposure, given only as three numbers in one paragraph."
+
+  - id: M11
+    item: >
+      The Barrie satellite campus has been closed since 2019; LU is one of twenty public
+      universities in Ontario.
+    page: 6
+    paragraph: 26
+    why: "Prior retrenchment, mentioned once in a scene-setting paragraph."
+
+  - id: M12
+    item: >
+      The furlough days negotiated in summer 2020 gave LU a one-time cash benefit of just $450,000.
+    page: 20
+    paragraph: 83
+    why: >
+      The scale of the cost-cutting versus the scale of the hole — $450K against a $29M quarterly
+      outflow. Easy to drop as trivia; it is the point.
+
+  - id: M13
+    item: >
+      The Federated Funding Formula's 15% service fee, and its 1 May 2019 amendment that decreased
+      funding to the Federated Universities.
+    pages: [9, 30]
+    paragraph: "51, 163(iv)"
+    why: >
+      LU was already squeezing the federated universities two years before disclaiming them
+      entirely. Requires joining a definition on p. 9 with a cost-cutting list on p. 30.

--- a/tests/documents/keys/prefiling-report-monitor.yaml
+++ b/tests/documents/keys/prefiling-report-monitor.yaml
@@ -16,6 +16,11 @@ document:
   date: 2021-01-30
   author: Ernst & Young Inc. (Proposed Monitor)
   court_file: "not yet assigned — cover page reads 'Court File No. __________'"
+  expected_skill: bankruptcy
+  expected_skill_rationale: >
+    The catalog names this document type verbatim: "trustee's or monitor's report ... CCAA or
+    other court-supervised restructuring proceeding".
+  ingest_order: 1
   role_in_benchmark: "Contradiction side B; entity-rich (affiliates, lenders, pension plans)."
 
 entities:

--- a/tests/documents/keys/prefiling-report-monitor.yaml
+++ b/tests/documents/keys/prefiling-report-monitor.yaml
@@ -3,9 +3,9 @@
 # Drafted from the SOURCE PDF. Frozen before any condition runs.
 #
 # This is one half of the scored contradiction pair. The other half is
-# Annual-Financial-Report-19-20.pdf (document 1). NEITHER DOCUMENT MENTIONS THE OTHER — the
-# extractor has to notice the conflict by comparing against the vault digest, which is the
-# machinery under test. See CORPUS-v1.md.
+# Annual-Financial-Report-19-20.pdf (document 1). NEITHER DOCUMENT MENTIONS THE OTHER — catching
+# the conflict requires comparing claims across documents, which is the finalizer's reconciliation
+# pass (#381), the machinery under test. See CORPUS-v1.md.
 
 document:
   file: "Laurentian Pre-Filing Report of the Proposed Monitor.pdf"
@@ -20,7 +20,6 @@ document:
   expected_skill_rationale: >
     The catalog names this document type verbatim: "trustee's or monitor's report ... CCAA or
     other court-supervised restructuring proceeding".
-  ingest_order: 1
   role_in_benchmark: "Contradiction side B; entity-rich (affiliates, lenders, pension plans)."
 
 entities:
@@ -312,8 +311,9 @@ contradictions:
     why_it_matters: >
       Weeks apart. A university claiming a $0.9M planned deficit, blaming the pandemic, and
       tracing a "path to sustainability" — then unable to make payroll. Neither document cites the
-      other, so the extractor must notice the conflict via the entity digest. Both sides are
-      explicit positive claims, so it can fire without proving a negative.
+      other, so catching it requires comparing claims across documents — the finalizer's
+      reconciliation pass (#381). Both sides are explicit positive claims, so it can fire without
+      proving a negative.
 
 must_not_miss:
   - id: M1


### PR DESCRIPTION
Everything needed to run the #361 / #215 extraction benchmark, short of the paid runs themselves: the six frozen-pending answer keys, the run protocol, and a step-by-step operator guide. Builds on the corpus frozen in #378.

## What's in here

- **Six answer keys** (`tests/documents/keys/*.yaml`) — one per corpus document. 92 entities, 42 relationships, 126 material facts (each with a page and a verbatim quote), 72 separately-scored buried items, and 5 cross-document contradictions.
- **`keys/README.md`** — the schema, the scoring traps, the run protocol, and the freeze step.
- **`tests/documents/BENCHMARKING.md`** — a step-by-step operator guide for the runs.

**Not frozen yet.** Freezing waits on Tom's review; a key with a bad fact in it corrupts all four conditions at once and nothing downstream catches it. Freeze command is in the guide.

## How the keys were drafted

- **From the source PDFs** — never from a pipeline extraction, so the key does not inherit the pipeline's blind spots. The scanned Initial Order was read **visually, not OCR'd first**, for the same reason one stage earlier; it carries an `ocr_hazards` section instead (most importantly, page 17 is rotated 90° and is the only place counsel is named — a condition returning no counsel has hit a rotation failure, not a reasoning failure).
- **The dense document's buried-item list was built against a mechanical inventory** — all 27 note headings enumerated programmatically with page numbers — so an item cannot be silently absent from the key just because the drafting model overlooked it (the correlation risk #361 names).

## Scoring traps recorded deliberately

- Documents 1 and 2 **agree** the endowment is \$52.8M. Flagging that as a contradiction is a false positive.
- Both Monitor's reports misdate the Haché affidavit to "January 30, **2020**" (the Initial Order shows 2021), and the First Report drops the leading zeros from the court file number. Faithfully extracting a wrong value is *correct* extraction — neither is a miss.
- Empty `contradictions` lists are meaningful: an invented contradiction scores as a false positive.

## Updated for #381 (merged in #382)

#381 made extraction stateless and moved entity resolution and contradiction detection into the finalizer's reconciliation pass. The keys and protocol were updated to match:

- **Dropped the `--concurrency 1` mandate and the fixed ingest order** — extraction is now a pure function of the document, so neither affects output. The obsolete `ingest_order` field is gone from every key.
- **Re-attributed the metrics** — fact recall and `must_not_miss` remain extractor metrics; entity-duplicate count and the C1/C2 contradictions are now **finalizer** metrics. The finalizer model must not be silently left at the Haiku default for the DeepSeek arm.
- **Contradictions are scored from the `[!contradiction]` callouts** reconciliation writes into entity notes (label + both values + both doc slugs + both pages), not the briefing's flagged count.

## The benchmarking guide

`BENCHMARKING.md` covers all three ingest model stages (classifier / extractor / finalizer) across Claude tiers and DeepSeek, plus the effort knob where it applies. Method: isolate one stage at a time against a fixed baseline.

- **Extractor sweep** — full ingests, model × effort, finalizer fixed. The dominant cost (~\$20, Opus- and Sonnet-heavy).
- **Finalizer sweep** — extractor fixed at a cheap `deepseek:deepseek-v4-flash` (a messier fixed extraction gives reconciliation more to discriminate on; re-finalizing a finished vault is not possible — #384). ~\$1.
- **Classifier** — a smoke test only; corpus-v1 spans two skills, too few to rank models.

Records the knobs that do not exist (Haiku has no effort; the classifier has no effort; DeepSeek "effort" is the `-thinking` toggle), the two-pass skill split, and the `deepseek:` backend prefix. Every run gated behind the free `ingest --estimate`.

## Issues surfaced while building this

- **#381** — extraction consumed vault state, making contradiction detection and entity dedup depend silently on `--concurrency` and ingest order. Fixed in #382; this branch is rebased on it.
- **#384** — a clean ingest consumes the fragment queue, so the finalizer can't be cheaply re-run on a fixed extraction.
- **#380** — local models for any pipeline stage (source protection + cost).

Refs #361, #215.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
