### PR TITLE
Capture claude-agent-sdk harness timing in per-call usage telemetry

### DIFF
--- a/src/watchdog/cmd/usage.py
+++ b/src/watchdog/cmd/usage.py
@@ -15,7 +15,7 @@ import json
 import sys
 from pathlib import Path
 
-from watchdog.cmd.base import _resolve_vault
+from watchdog.cmd.base import _DIM, _RESET, _resolve_vault
 from watchdog.pipeline.orchestrate import usage_files
 
 # task name -> stage bucket, matching --classifier-model/--extractor-model/--finalizer-model.
@@ -142,11 +142,20 @@ def _print_stage(calls: list[dict]) -> dict:
         trunc_name = (name[:name_w - 1] + "…") if len(name) > name_w else name
         trunc_detail = (detail[:detail_w - 1] + "…") if len(detail) > detail_w else detail
         retry_note = f"  ×{attempts}" if attempts > 1 else ""
+        # The claude-agent-sdk harness's own timing (#402): time actually spent in API requests,
+        # vs. this row's wall-clock Latency figure — a large gap is the harness backing off
+        # internally (throttled), not the model being slow. Only present for that backend, so
+        # trail it after the fixed columns rather than widening Latency for every row.
+        api_note = ""
+        if c.get("api_ms") is not None:
+            turns = c.get("num_turns")
+            turns_note = f", {turns} turns" if turns and turns != 1 else ""
+            api_note = f"  {_DIM}· api {_fmt_secs(c['api_ms'] / 1000)}{turns_note}{_RESET}"
         print(
             f"  {trunc_name:<{name_w}}  {trunc_detail:<{detail_w}}  "
             f"{effort:<{effort_w}}  {auth:<{auth_w}}  "
             f"{_fmt(c['input_tokens']):>8}  {_fmt(c['cache_read_tokens']):>8}  {_fmt(c['cache_write_tokens']):>8}  "
-            f"{_fmt(c['output_tokens']):>7}  {_fmt_secs(latency):>8}  ${cost:>6.4f}{retry_note}"
+            f"{_fmt(c['output_tokens']):>7}  {_fmt_secs(latency):>8}  ${cost:>6.4f}{retry_note}{api_note}"
         )
         totals["input_tokens"] += c["input_tokens"]
         totals["output_tokens"] += c["output_tokens"]

--- a/src/watchdog/model_client.py
+++ b/src/watchdog/model_client.py
@@ -319,7 +319,22 @@ async def _agent_query(prompt: str, model: str, env: dict | None,
             if name == "ResultMessage":
                 out["text"] = getattr(message, "result", "") or ""
                 out["cost_usd"] = getattr(message, "total_cost_usd", None)
-                out["usage"] = getattr(message, "usage", None)
+                # `usage` is normally a dict, but never trust a third-party shape enough to crash
+                # on it — fall back to a fresh dict so the harness-timing fields below always land.
+                raw_usage = getattr(message, "usage", None)
+                usage = dict(raw_usage) if isinstance(raw_usage, dict) else {}
+                # Harness-level timing (#402): `duration_api_ms` is time actually spent in API
+                # requests, vs. the message's own wall-clock `duration_ms` — the gap is
+                # backoff/wait the harness did internally. `num_turns` is the internal request
+                # count for the session. Together they let a throttled call (long gap, i.e. many
+                # turns) be told apart from a genuinely slow one after the fact.
+                api_ms = getattr(message, "duration_api_ms", None)
+                if api_ms is not None:
+                    usage["duration_api_ms"] = api_ms
+                num_turns = getattr(message, "num_turns", None)
+                if num_turns is not None:
+                    usage["num_turns"] = num_turns
+                out["usage"] = usage or None
                 is_error = bool(getattr(message, "is_error", False))
                 api_status = getattr(message, "api_error_status", None)
             elif name in ("RateLimitEvent", "RateLimitInfo"):

--- a/src/watchdog/pipeline/orchestrate.py
+++ b/src/watchdog/pipeline/orchestrate.py
@@ -83,11 +83,17 @@ def _record_usage(task: str, *, model: str, backend: str, usage: dict | None,
     — both surfaced per call by `watchdog usage` (#319). `end_ts` is the call's completion time
     (epoch seconds); paired with `latency_s` it gives each call a [start, end] interval, so
     `watchdog usage` can report wall-clock elapsed per stage — the real time a concurrently-run
-    stage took — alongside the summed per-call time (#317 follow-up)."""
+    stage took — alongside the summed per-call time (#317 follow-up).
+
+    `api_ms`/`num_turns` (#402) are the `claude-agent-sdk` harness's own timing — time actually
+    spent in API requests vs. the call's wall-clock `latency_s`, and the internal request count.
+    They're only added to the record when `usage` carries them, so records for every other
+    backend stay exactly as they were — a large `latency_s` − `api_ms` gap is the signature of
+    the harness throttling/backing off internally rather than the model itself being slow."""
     if _usage is None:
         return
     u = usage or {}
-    _usage.append({
+    record = {
         "task": task, "model": model, "backend": backend,
         "input_tokens": u.get("input_tokens", u.get("prompt_tokens", 0)) or 0,
         "output_tokens": u.get("output_tokens", u.get("completion_tokens", 0)) or 0,
@@ -95,7 +101,12 @@ def _record_usage(task: str, *, model: str, backend: str, usage: dict | None,
         "cache_write_tokens": u.get("cache_creation_input_tokens", 0) or 0,
         "cost_usd": cost_usd, "attempts": attempts, "latency_s": latency_s, "effort": effort,
         "auth_mode": auth_mode, "filename": filename, "detail": detail, "end_ts": time.time(),
-    })
+    }
+    if u.get("duration_api_ms") is not None:
+        record["api_ms"] = u["duration_api_ms"]
+    if u.get("num_turns") is not None:
+        record["num_turns"] = u["num_turns"]
+    _usage.append(record)
 
 
 async def _call_model(*, task, prompt, schema, model=None, backend=None,

--- a/tests/test_model_client.py
+++ b/tests/test_model_client.py
@@ -709,12 +709,18 @@ def _result_message(**attrs):
 
 
 def _patch_agent_query(monkeypatch, message):
-    import claude_agent_sdk
+    """Stands in for the real `claude_agent_sdk` package via `sys.modules`, so these tests don't
+    require it installed — CI's test job deliberately excludes heavy SDK deps (see ci.yml)."""
+    import sys
+    import types
 
     async def fake_query(prompt, options):
         yield message
 
-    monkeypatch.setattr(claude_agent_sdk, "query", fake_query)
+    fake_module = types.ModuleType("claude_agent_sdk")
+    fake_module.query = fake_query
+    fake_module.ClaudeAgentOptions = lambda **kwargs: kwargs
+    monkeypatch.setitem(sys.modules, "claude_agent_sdk", fake_module)
 
 
 def test_agent_query_captures_harness_timing_into_usage(monkeypatch):

--- a/tests/test_model_client.py
+++ b/tests/test_model_client.py
@@ -687,6 +687,71 @@ def test_merge_usage_does_not_add_booleans():
     assert mc._merge_usage({"cache_hit": 3}, {"cache_hit": True}) == {"cache_hit": 3}
 
 
+def test_merge_usage_sums_agent_sdk_timing_fields():
+    # #402: duration_api_ms/num_turns are plain numeric fields once inside the usage dict, so a
+    # continuation round's harness timing accumulates the same way token counts do — deliberate,
+    # not an accident of the generic dict-merge (arguably correct: the total call spent that much
+    # time across both API requests, and made that many internal turns in total).
+    a = {"input_tokens": 10, "duration_api_ms": 500, "num_turns": 1}
+    b = {"input_tokens": 3, "duration_api_ms": 200, "num_turns": 2}
+    assert mc._merge_usage(a, b) == {"input_tokens": 13, "duration_api_ms": 700, "num_turns": 3}
+
+
+# ── agent-SDK harness timing (#402) ─────────────────────────────────────────────
+
+def _result_message(**attrs):
+    """A stand-in for `claude_agent_sdk.ResultMessage` — `_agent_query` only dispatches on
+    `type(message).__name__`, so a dynamically-named plain object works fine."""
+    defaults = dict(result="", total_cost_usd=None, usage=None, is_error=False,
+                    api_error_status=None, duration_api_ms=None, num_turns=None, content=None)
+    defaults.update(attrs)
+    return type("ResultMessage", (), defaults)()
+
+
+def _patch_agent_query(monkeypatch, message):
+    import claude_agent_sdk
+
+    async def fake_query(prompt, options):
+        yield message
+
+    monkeypatch.setattr(claude_agent_sdk, "query", fake_query)
+
+
+def test_agent_query_captures_harness_timing_into_usage(monkeypatch):
+    msg = _result_message(result='{"name": "Acme"}', total_cost_usd=0.02,
+                          usage={"input_tokens": 10}, duration_api_ms=1234, num_turns=3)
+    _patch_agent_query(monkeypatch, msg)
+    out = asyncio.run(mc._agent_query("p", "model", None))
+    assert out["usage"] == {"input_tokens": 10, "duration_api_ms": 1234, "num_turns": 3}
+
+
+def test_agent_query_timing_present_even_without_token_usage(monkeypatch):
+    # The SDK's `usage` dict is optional but duration_api_ms/num_turns are not (#402) — the
+    # harness timing must still surface even when there's no token-usage dict to piggyback on.
+    msg = _result_message(result="{}", usage=None, duration_api_ms=500, num_turns=1)
+    _patch_agent_query(monkeypatch, msg)
+    out = asyncio.run(mc._agent_query("p", "model", None))
+    assert out["usage"] == {"duration_api_ms": 500, "num_turns": 1}
+
+
+def test_agent_query_usage_normalizes_non_dict_shape_without_crashing(monkeypatch):
+    # Defensive normalization: a weird (non-dict, non-None) `usage` shape must not crash the
+    # call — it's discarded rather than trusted, and harness timing still lands.
+    msg = _result_message(result="{}", usage="not-a-dict", duration_api_ms=42, num_turns=2)
+    _patch_agent_query(monkeypatch, msg)
+    out = asyncio.run(mc._agent_query("p", "model", None))
+    assert out["usage"] == {"duration_api_ms": 42, "num_turns": 2}
+
+
+def test_agent_query_usage_stays_none_when_nothing_present(monkeypatch):
+    # No token usage and no timing (e.g. an older SDK build) — usage stays None, matching the
+    # pre-#402 contract, rather than becoming a spurious empty dict.
+    msg = _result_message(result="{}", usage=None, duration_api_ms=None, num_turns=None)
+    _patch_agent_query(monkeypatch, msg)
+    out = asyncio.run(mc._agent_query("p", "model", None))
+    assert out["usage"] is None
+
+
 @pytest.mark.parametrize("task, backend, model, expected", [
     ("extract", "deepseek", "deepseek-v4-flash-thinking", mc._DEEPSEEK_THINKING_MAX_TOKENS),
     ("extract", "deepseek", "deepseek-v4-flash", 16000),     # non-thinking → normal task ceiling

--- a/tests/test_orchestrate.py
+++ b/tests/test_orchestrate.py
@@ -1106,6 +1106,44 @@ def test_usage_telemetry_persisted_after_ingest(tmp_path, monkeypatch):
     assert round(summary["usage"]["cost_usd"], 4) == round(0.01 * n_calls, 4)
 
 
+def test_record_usage_carries_agent_sdk_harness_timing():
+    """#402: a `claude-agent-sdk` usage dict carrying `duration_api_ms`/`num_turns` (harness
+    timing) surfaces as `api_ms`/`num_turns` on the persisted call record — the signal that
+    tells a throttled call (long gap between wall-clock latency and API time) apart from a
+    genuinely slow one."""
+    orchestrate._usage = []
+    try:
+        orchestrate._record_usage(
+            "extract", model="claude-sonnet-4-6", backend="claude-agent-sdk",
+            usage={"input_tokens": 100, "output_tokens": 20,
+                  "duration_api_ms": 12345, "num_turns": 3},
+            cost_usd=0.01, latency_s=60.0)
+        assert len(orchestrate._usage) == 1
+        record = orchestrate._usage[0]
+        assert record["api_ms"] == 12345
+        assert record["num_turns"] == 3
+    finally:
+        orchestrate._usage = None
+
+
+def test_record_usage_omits_harness_timing_keys_for_other_backends():
+    """A raw-API backend's usage dict has no `duration_api_ms`/`num_turns` — the persisted
+    record must not grow `api_ms`/`num_turns` keys (even as null) for it, so existing
+    `usage-<ts>.json` consumers see byte-identical records to before #402."""
+    orchestrate._usage = []
+    try:
+        orchestrate._record_usage(
+            "extract", model="claude-sonnet-4-6", backend="claude-api",
+            usage={"input_tokens": 100, "output_tokens": 20},
+            cost_usd=0.01, latency_s=1.0)
+        assert len(orchestrate._usage) == 1
+        record = orchestrate._usage[0]
+        assert "api_ms" not in record
+        assert "num_turns" not in record
+    finally:
+        orchestrate._usage = None
+
+
 def test_log_md_ingest_entry_includes_usage_line(tmp_path, monkeypatch):
     """F5/#222: the log.md entry for an ingest carries the run's token/cost totals, the
     user-facing half of A2's telemetry."""

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -12,14 +12,21 @@ from watchdog.cmd.usage import cmd_usage
 
 def _call(task="extract", filename="doc.pdf", detail="pages 1–1", model="claude-sonnet-4-6",
           cost_usd=0.01, input_tokens=100, output_tokens=20, latency_s=1.5,
-          effort=None, auth_mode="api-key", attempts=1, end_ts=None):
-    return {
+          effort=None, auth_mode="api-key", attempts=1, end_ts=None, api_ms=None, num_turns=None):
+    call = {
         "task": task, "model": model, "backend": "claude-api",
         "input_tokens": input_tokens, "output_tokens": output_tokens,
         "cache_read_tokens": 0, "cache_write_tokens": 0,
         "cost_usd": cost_usd, "attempts": attempts, "latency_s": latency_s, "effort": effort,
         "auth_mode": auth_mode, "filename": filename, "detail": detail, "end_ts": end_ts,
     }
+    # api_ms/num_turns (#402) are only present on claude-agent-sdk records — omitted here by
+    # default so a plain _call() matches a real raw-API record with no such keys at all.
+    if api_ms is not None:
+        call["api_ms"] = api_ms
+    if num_turns is not None:
+        call["num_turns"] = num_turns
+    return call
 
 
 def _build_vault(tmp_path: Path, *, runs: dict[str, list[dict]], documents=None) -> Path:
@@ -81,6 +88,45 @@ def test_cmd_usage_shows_auth_mode_and_retry_marker(tmp_path, monkeypatch, capsy
     assert "Auth" in out
     assert "sub" in out and "key" in out
     assert "×3" in out   # the retried call is flagged inline
+
+
+def test_cmd_usage_shows_api_time_alongside_latency_when_present(tmp_path, monkeypatch, capsys):
+    """#402: a claude-agent-sdk call's harness timing (api_ms/num_turns) surfaces next to the
+    wall-clock Latency figure — a large latency-vs-api gap is the throttling signature this
+    exists to reveal. A call with no api_ms (e.g. a raw-API backend) shows nothing extra."""
+    vault = _build_vault(tmp_path, runs={
+        "usage-2026-01-01T00-00-00": [
+            _call(filename="throttled.pdf", latency_s=2621.0, api_ms=726_000, num_turns=5),
+            _call(filename="plain.pdf", latency_s=10.0),
+        ],
+    })
+    monkeypatch.chdir(vault)
+
+    cmd_usage(_args())
+
+    out = capsys.readouterr().out
+    assert "api 12.1m" in out       # 726_000ms == 12.1 minutes
+    assert "5 turns" in out
+    throttled_line = next(line for line in out.splitlines() if "throttled.pdf" in line)
+    plain_line = next(line for line in out.splitlines() if "plain.pdf" in line)
+    assert "api" in throttled_line
+    assert "api" not in plain_line   # no harness timing on this call — nothing appended
+
+
+def test_cmd_usage_omits_turns_note_when_a_single_turn(tmp_path, monkeypatch, capsys):
+    """A single-turn call is the healthy baseline — noting `1 turns` on every row would just be
+    noise, so the turns count is only appended when it deviates from 1."""
+    vault = _build_vault(tmp_path, runs={
+        "usage-2026-01-01T00-00-00": [_call(filename="healthy.pdf", api_ms=5000, num_turns=1)],
+    })
+    monkeypatch.chdir(vault)
+
+    cmd_usage(_args())
+
+    out = capsys.readouterr().out
+    row = next(line for line in out.splitlines() if "healthy.pdf" in line)
+    assert "api 5.0s" in row
+    assert "turns" not in row
 
 
 def test_cmd_usage_shows_wall_clock_elapsed_for_concurrent_stage(tmp_path, monkeypatch, capsys):


### PR DESCRIPTION
Closes #402.

Diagnosing #398 showed a 47-page document extracting at ~12 output-tok/s while a peer call in the same run did ~59 — same model, backend, and effort — with cache-read exactly 2× cache-write, implying internal harness retries/backoff. Nothing in `usage-<ts>.json` recorded what the CLI session did inside the call, so a throttled call and a genuinely slow one were indistinguishable after the fact.

## What this does

- **`model_client._agent_query`** captures `duration_api_ms` and `num_turns` from the agent SDK's `ResultMessage` and merges them into the returned usage dict (defensively normalized — a non-dict usage shape is discarded rather than crashed on; `usage` stays `None` when nothing at all is present, matching the prior contract).
- **`orchestrate._record_usage`** persists them as `api_ms` / `num_turns` on the call record **only when present** — records for every other backend are byte-identical to before.
- **`watchdog usage`** appends a dim trailing note to the per-call detail row (`· api 12.1m, 5 turns`), following the existing `×N` retry-marker pattern. A large Latency-vs-api gap is the throttling signature this exists to reveal.

## Verification

- 1,484 tests pass; ruff clean (both re-verified by the reviewing session, not just the authoring agent).
- New tests cover capture (incl. timing-without-token-usage and non-dict normalization), record presence/absence per backend, `_merge_usage` accumulation across continuation rounds, and display on/off.
- Mutation-checked: dropping the capture, the record keys, or the display each turned the corresponding tests red.

Written by a Sonnet subagent, reviewed by the main session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)