### PR TITLE
Add watchdog ingest --no-finalize: hold extraction fixed, finalize later

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -180,7 +180,9 @@ sleeps until `RateLimitError.resets_at` (plus a buffer; a fixed fallback when th
 report one — only `claude-agent-sdk` does) before looping again, until the queue drains and
 finalize completes. The sleep is chunked under the 30-minute staleness window, refreshing the held
 lock's `started_at` after each chunk, so a wait that outlasts it doesn't make a live run look
-abandoned. Opt-in only — without the flag, a rate limit stops the batch exactly as before.
+abandoned. Opt-in only — without the flag, a rate limit stops the batch exactly as before. The
+loop's only exit condition is a rate limit *during extraction*; with `--no-finalize` (§5) finalize
+never runs at all, so `--wait` simply stops once the queue drains, same as normal.
 
 ---
 
@@ -328,6 +330,16 @@ docs) is logged to `.watchdog/registry/ingest.log` and
 cleaned via `abort.run` (`pipeline/abort.py`) — staging/section temp removed, queue file
 moved to `.watchdog/queue/_failed/`, registry untouched. One bad document never sinks the
 batch; move the queue file back from `_failed/` to retry.
+
+**Extract-only (`--no-finalize`, #384).** `orchestrate.run(..., skip_finalize=True)` returns as
+soon as extraction finishes, at the single point (shared by the concurrent per-document loop and
+the claude-batch collect path, §5) that would otherwise call `finalize` — post-ingest (§8, §8.5,
+§9) never runs, and nothing is cleared, so `has_pending_finalization(vault)` stays True on exactly
+what a normal interrupted run would leave behind. That lets a later `watchdog finalize
+--finalizer-model <model>` run against a fixed extraction, including against several copies of the
+vault to compare finalizer candidates without re-paying extraction's cost each time. Re-running
+`finalize` idempotently over a batch it has already completed is explicitly out of scope; run it
+once per vault (or vault copy).
 
 ---
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -29,7 +29,7 @@ Investigation names tab-complete in zsh and bash once `watchdog setup` has run.
 | `watchdog fetch <url…>` | Download one or more URLs (or a links file) into `_INCOMING/` — see [below](#watchdog-fetch). |
 | `watchdog chew` | Convert everything in `_INCOMING/` into extracted text queued for ingest — see [below](#watchdog-chew). |
 | `watchdog ingest` | Extract all queued documents into the vault — see [below](#watchdog-ingest). |
-| `watchdog finalize` | Complete the post-ingest step (merging duplicate entities, flagging contradictions between documents, entity synthesis, timeline, briefing) for a batch that was interrupted after extraction; takes the same `--finalizer-model` and `--finalizer-effort` overrides as ingest. |
+| `watchdog finalize` | Complete the post-ingest step (merging duplicate entities, flagging contradictions between documents, entity synthesis, timeline, briefing) for a batch that was interrupted after extraction, or deliberately staged with `watchdog ingest --no-finalize`; takes the same `--finalizer-model` and `--finalizer-effort` overrides as ingest. |
 | `watchdog requeue` | Move documents quarantined in `queue/_failed/` back into the active queue, ready for the next `watchdog ingest`. |
 | `watchdog context [name]` | Open Claude Code with the context-seeding skill, which reads `_CONTEXT/`, interviews you, and writes `context.md`; `--model` picks `sonnet`, `opus`, or `haiku` (default: `sonnet`). |
 | `watchdog watch [name]` | Watch `_INCOMING/` and chew files automatically as they arrive. |
@@ -55,11 +55,21 @@ Each model flag takes a Claude tier (`haiku`, `sonnet`, `opus`) or a `backend:mo
 - `--classify-pages N` — leading pages shown to the classifier (default: 5); more pages classify ambiguous documents better.
 - `--skill NAME` — pin one record skill for every document, skipping classification; pass a skill name or a path to a skill file, or use `--skill` with no value to pick from a list. A document's own sidecar can pin a different skill for just that document — see [Skills](skills.md#reading-and-pinning-skills).
 - `--wait` — on a rate limit, sleep until it resets and resume automatically instead of stopping; for unattended overnight batches. It uses the reset time the provider reports, or a fixed fallback interval when it doesn't, and repeats until the queue drains. Not compatible with a `claude-batch` extractor model.
+- `--no-finalize` — stop after extraction; run post-processing later with `watchdog finalize`. Useful for comparing finalizer models against the same extraction without paying for it twice — see [Comparing finalizer models](#comparing-finalizer-models) below.
 - `--estimate` — print the token and cost estimate for the queue and exit; no lock, no confirmation, no extraction.
 
 **Resumability.** Pressing Ctrl+C, or hitting a rate limit without `--wait`, stops the batch cleanly: finished documents are saved and unfinished ones stay queued, so re-running `watchdog ingest` picks up where it left off. A document that genuinely fails extraction is set aside in `queue/_failed/`; the run reports how many, and `watchdog requeue` moves them back to retry.
 
-**Finalization.** Every ingest finishes with a post-ingest step — merging duplicate entities, flagging contradictions between documents, entity synthesis, timeline reconciliation, and the briefing. If that step is interrupted (for example, a rate limit hits after the documents extract), the batch is left finalizable: `watchdog status` flags it, and `watchdog finalize` completes it without re-extracting anything. If you start another `watchdog ingest` while a batch is pending, it asks what to do: **merge** the pending batch into the new run and finalize everything together, **finalize** it first and stop, or **discard** it.
+**Finalization.** Every ingest finishes with a post-ingest step — merging duplicate entities, flagging contradictions between documents, entity synthesis, timeline reconciliation, and the briefing. If that step is interrupted (for example, a rate limit hits after the documents extract), the batch is left finalizable: `watchdog status` flags it, and `watchdog finalize` completes it without re-extracting anything. If you start another `watchdog ingest` while a batch is pending, it asks what to do: **merge** the pending batch into the new run and finalize everything together, **finalize** it first and stop, or **discard** it. Passing `--no-finalize` leaves a batch in this same finalizable state deliberately, instead of as a side effect of an interruption — see below.
+
+#### Comparing finalizer models
+
+Extraction is the expensive part of an ingest — the finalizer's few calls (reconciliation, synthesis, timeline, briefing) cost little by comparison. To try more than one finalizer model or effort level against the *same* extraction, without paying for extraction again each time:
+
+1. Run `watchdog ingest --no-finalize`. Documents extract and land in the vault as usual, but the run stops before post-processing — `watchdog status` will show the batch as pending finalization.
+2. Run `watchdog finalize --finalizer-model <model>` to try one candidate. Do this from inside the vault, or from a copy of the vault folder if you want to test several candidates against the identical extraction — each copy still has the same staged inputs, so pointing a different `--finalizer-model` at each copy compares them fairly.
+
+`watchdog finalize` does not yet support re-running cleanly over a batch it has already finalized — run it once per vault (or vault copy).
 
 ### watchdog chew
 

--- a/src/watchdog/cli.py
+++ b/src/watchdog/cli.py
@@ -433,6 +433,10 @@ def main() -> None:
                           help="On a rate limit, sleep until it resets and resume automatically "
                                "instead of stopping for you to re-run ingest. Not with a "
                                "claude-batch extractor model.")
+    p_ingest.add_argument("--no-finalize", action="store_true", default=False, dest="no_finalize",
+                          help="Stop after extraction; run post-processing later with "
+                               "watchdog finalize. Useful for comparing finalizer models against "
+                               "the same extraction without paying for it twice.")
     p_ingest.add_argument("--estimate", action="store_true",
                           help="Print a token/cost estimate for the queue and exit — no lock, no confirm, no extraction")
     p_ingest.set_defaults(func=cmd_ingest)

--- a/src/watchdog/cmd/base.py
+++ b/src/watchdog/cmd/base.py
@@ -138,6 +138,7 @@ _CMD_HELP: dict[str, dict] = {
             ("--classify-pages N",   "Pages shown to the document classifier for this run (default from watchdog configure: 5)"),
             ("--skill [NAME|PATH]",  "Pin a record skill (name or file path) for every document, skipping classification (no value = pick from the list)"),
             ("--wait",               "On a rate limit, sleep until it resets and resume automatically instead of stopping for you to re-run ingest. Not with a claude-batch extractor model"),
+            ("--no-finalize",        "Stop after extraction; run post-processing later with watchdog finalize"),
         ],
     },
     "context": {

--- a/src/watchdog/cmd/ingest.py
+++ b/src/watchdog/cmd/ingest.py
@@ -467,6 +467,7 @@ def cmd_ingest(args, *, confirm: bool = True, skip_preview: bool = False) -> Non
         sys.exit(f"\n  {_YELLOW}Error:{_RESET} --wait isn't supported with claude-batch — a batch "
                  f"already runs in the background; re-run {_CYAN}watchdog ingest{_RESET} later to "
                  f"collect it.\n")
+    no_finalize = getattr(args, "no_finalize", False)
 
     def _release_lock() -> None:
         (vault / ".watchdog" / "registry" / ".ingest-lock").unlink(missing_ok=True)
@@ -495,13 +496,17 @@ def cmd_ingest(args, *, confirm: bool = True, skip_preview: bool = False) -> Non
     lock_file = vault / ".watchdog" / "registry" / ".ingest-lock"
     try:
         summary = None
+        # This loop's only exit condition is `iter_summary["rate_limited"]`, which reflects a
+        # rate limit hit *during extraction* — finalize (skipped entirely when no_finalize is
+        # set) never sets it, so --wait + --no-finalize already stops as soon as the queue
+        # drains, with no special-casing needed here (#384).
         while True:
             iter_summary = asyncio.run(orchestrate.run(
                 vault, concurrency=concurrency, extract_model=extract_model, post_model=post_model,
                 classify_model=classify_model, classify_pages=classify_pages, pinned_skill=pinned_skill,
                 extract_effort=extract_effort, post_effort=post_effort,
                 extract_backend=extract_backend, post_backend=post_backend,
-                classify_backend=classify_backend, wait=wait))
+                classify_backend=classify_backend, wait=wait, skip_finalize=no_finalize))
             summary = _merge_summary(summary, iter_summary)
             if not (wait and iter_summary.get("rate_limited")):
                 break
@@ -573,6 +578,12 @@ def _print_ingest_summary(summary: dict) -> None:
               f"{_DIM} later to check on it and collect results.{_RESET}\n")
     elif cancelled:
         print(f"\n  {_DIM}Re-run {_RESET}{_CYAN}watchdog ingest{_RESET}{_DIM} to process the remaining documents.{_RESET}\n")
+    elif summary.get("finalize_skipped"):
+        print(f"\n  {_DIM}Extraction staged, post-processing skipped{_RESET} "
+              f"{_DIM}({_RESET}{_BOLD}{ext}{_RESET}{_DIM} document{'s' if ext != 1 else ''} on disk).{_RESET}")
+        print(f"  {_DIM}Finalize when ready — run it once for the vault as-is, or copy the vault "
+              f"folder to try more than one finalizer:{_RESET}")
+        print(f"  {_CYAN}watchdog finalize{_RESET}{_DIM} [--finalizer-model MODEL]{_RESET}\n")
     else:
         print(f"\n  {_DIM}Open a fresh Claude Code session to ask investigation questions.{_RESET}\n")
 

--- a/src/watchdog/pipeline/orchestrate.py
+++ b/src/watchdog/pipeline/orchestrate.py
@@ -1294,7 +1294,8 @@ async def run(vault: Path, *, concurrency: int = DEFAULT_CONCURRENCY,
               pinned_skill: str | None = None,
               extract_effort: str | None = None, post_effort: str | None = None,
               extract_backend: str | None = None, post_backend: str | None = None,
-              classify_backend: str | None = None, wait: bool = False) -> dict:
+              classify_backend: str | None = None, wait: bool = False,
+              skip_finalize: bool = False) -> dict:
     """Extract every queued document (bounded by `concurrency`), then post-ingest.
 
     `extract_model` drives extraction (whole-doc + section, and the sectioned-doc digest); `post_model` drives
@@ -1307,6 +1308,12 @@ async def run(vault: Path, *, concurrency: int = DEFAULT_CONCURRENCY,
     non-Claude backend's `*_model` is that provider's raw model id (D37).
     `wait` only changes the rate-limit notice text — the caller (`cmd_ingest`) owns the
     actual sleep-and-resume loop; this function always stops cleanly on a rate limit.
+    `skip_finalize` (#384) stops the run after extraction — post-ingest (reconciliation,
+    synthesis, timeline, briefing) is never called, and none of its inputs
+    (`entity-fragments/`, `result_*.json`, `notes_*.md`) are cleared. That leaves
+    `has_pending_finalization(vault)` True so a later `watchdog finalize` — possibly with a
+    different `--finalizer-model`, and possibly against a copy of the vault — can pick up
+    exactly where extraction left off.
     """
     queue_dir = vault / ".watchdog" / "queue"
     shas = [f.stem for f in sorted(queue_dir.glob("*.json"))] if queue_dir.exists() else []
@@ -1434,7 +1441,13 @@ async def run(vault: Path, *, concurrency: int = DEFAULT_CONCURRENCY,
                "quarantined": quarantined, **extra_summary}
     if not pinned_skill:
         _nudge_skill_pin(results)
-    if summary["extracted"] and not cancelled_flag:
+    if summary["extracted"] and not cancelled_flag and skip_finalize:
+        # Extract-only (#384): leave the post-ingest inputs on disk untouched — a later
+        # `watchdog finalize` (possibly on a vault copy, possibly with a different
+        # `--finalizer-model`) consumes them. `has_pending_finalization` is already True by
+        # this point (`_finish_extraction` persisted `result_*.json`/fragments per document).
+        summary["finalize_skipped"] = True
+    elif summary["extracted"] and not cancelled_flag:
         try:
             # Finalize over the persisted per-doc results on disk (not just this run's in-memory
             # ones) so a merged batch — a prior pending run kept via wipe_pending=False — is

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2145,6 +2145,73 @@ def test_cmd_ingest_no_wait_stops_on_rate_limit_without_looping(wdg_home, tmp_pa
     assert len(calls) == 1
     assert calls[0].get("wait") is False
 
+
+# ── cmd_ingest --no-finalize (#384) ──────────────────────────────────────────
+
+def test_cmd_ingest_no_finalize_threads_skip_finalize_to_orchestrate_run(wdg_home, tmp_path, monkeypatch, capsys):
+    """`--no-finalize` on the CLI reaches `orchestrate.run` as `skip_finalize=True`, and the
+    closing block tells the user how to finalize later instead of the usual "open a session"
+    line."""
+    from watchdog.cmd import auth as auth_module
+    from watchdog.cmd import ingest as ing
+    from watchdog.pipeline import orchestrate as orch_module
+
+    vault = _vault_with_queued_doc(tmp_path)
+    monkeypatch.chdir(vault)
+    monkeypatch.setattr(auth_module, "resolve_auth", lambda: {"mode": "api-key", "key": "sk-x"})
+    monkeypatch.setattr(orch_module, "has_pending_finalization", lambda v: False)
+
+    calls = []
+
+    async def fake_run(*a, **k):
+        calls.append(k)
+        return {"results": [{"sha256": "sha1", "filename": "a.pdf", "status": "ok", "entity_count": 1}],
+                "extracted": 1, "skipped": 0, "failed": 0, "cancelled": False,
+                "rate_limited": False, "stop_message": None, "rate_limit_resets_at": None,
+                "quarantined": 0, "finalize_skipped": True}
+    monkeypatch.setattr(orch_module, "run", fake_run)
+
+    ing.cmd_ingest(args(no_finalize=True), confirm=False)
+
+    assert len(calls) == 1
+    assert calls[0].get("skip_finalize") is True
+    out = capsys.readouterr().out
+    assert "watchdog finalize" in out
+    assert "Open a fresh Claude Code session" not in out
+
+
+def test_cmd_ingest_wait_and_no_finalize_stops_once_queue_drains(wdg_home, tmp_path, monkeypatch):
+    """`--wait` loops on a rate-limited *extraction*, not on finalize — with `--no-finalize`,
+    finalize never runs at all, so once the queue finishes extracting cleanly the loop must stop
+    after a single call rather than waiting for a finalize that will never happen."""
+    from watchdog.cmd import auth as auth_module
+    from watchdog.cmd import ingest as ing
+    from watchdog.pipeline import orchestrate as orch_module
+
+    vault = _vault_with_queued_doc(tmp_path)
+    monkeypatch.chdir(vault)
+    monkeypatch.setattr(auth_module, "resolve_auth", lambda: {"mode": "api-key", "key": "sk-x"})
+    monkeypatch.setattr(orch_module, "has_pending_finalization", lambda v: False)
+
+    calls = []
+
+    async def fake_run(*a, **k):
+        calls.append(k)
+        return {"results": [{"sha256": "sha1", "filename": "a.pdf", "status": "ok", "entity_count": 1}],
+                "extracted": 1, "skipped": 0, "failed": 0, "cancelled": False,
+                "rate_limited": False, "stop_message": None, "rate_limit_resets_at": None,
+                "quarantined": 0, "finalize_skipped": True}
+    monkeypatch.setattr(orch_module, "run", fake_run)
+    monkeypatch.setattr(ing, "_wait_for_rate_limit",
+                        lambda *a, **k: pytest.fail("must not wait — nothing rate-limited"))
+
+    ing.cmd_ingest(args(wait=True, no_finalize=True), confirm=False)
+
+    assert len(calls) == 1
+    assert calls[0].get("wait") is True
+    assert calls[0].get("skip_finalize") is True
+
+
 def test_cmd_ingest_prints_backup_hint_when_discard_snapshotted(wdg_home, tmp_path, monkeypatch, capsys):
     """#270: when ingest_setup.run() reports a backup_dir (the discard choice actually threw
     something away), cmd_ingest must print a restore hint."""

--- a/tests/test_orchestrate.py
+++ b/tests/test_orchestrate.py
@@ -1534,6 +1534,110 @@ def test_finalize_completes_an_interrupted_run(tmp_path, monkeypatch):
     assert orchestrate.has_pending_finalization(vault) is False
 
 
+def test_skip_finalize_stops_after_extraction_with_no_post_ingest_calls(tmp_path, monkeypatch):
+    """`--no-finalize` (#384): `orchestrate.run(..., skip_finalize=True)` extracts the queue but
+    never calls post-ingest — no reconciliation/synthesis/timeline-dedup/briefing model call —
+    and leaves the batch pending finalization, with the per-doc result and fragment inputs on
+    disk for a later `watchdog finalize`."""
+    vault = make_vault(tmp_path)
+    _queue_doc(vault, sha="aaa", filename="a.pdf")
+
+    calls = []
+
+    async def fake(*, task, prompt, schema, model=None, backend=None, max_retries=1, effort=None):
+        calls.append(task)
+        if task == "classify":
+            parsed = {"skill": "general-records.md"}
+        elif task == "extract":
+            parsed = _extraction(sha="aaa", filename="a.pdf")
+        else:
+            raise AssertionError(f"unexpected post-ingest call with skip_finalize=True: {task}")
+        return model_client.ModelResult(parsed=parsed, text="", model="m",
+                                        backend="claude-agent-sdk", auth_mode="subscription")
+    monkeypatch.setattr(orchestrate.model_client, "acomplete_json", fake)
+
+    summary = asyncio.run(orchestrate.run(vault, skip_finalize=True))
+
+    assert summary["extracted"] == 1
+    assert summary["finalize_skipped"] is True
+    assert "post_ingest" not in summary
+    assert calls == ["classify", "extract"]     # no entity-synthesis/timeline-dedup/briefing/reconcile
+    assert orchestrate.has_pending_finalization(vault) is True
+    assert (vault / ".watchdog" / "tmp" / "result_aaa.json").exists()
+    assert (vault / ".watchdog" / "tmp" / "entity-fragments" / "_queue.json").exists()
+
+
+def test_finalize_after_skip_finalize_consumes_staged_inputs(tmp_path, monkeypatch):
+    """The inputs an extract-only run (`skip_finalize=True`) leaves on disk are exactly what a
+    later, standalone `orchestrate.finalize()` needs — it completes synthesis + briefing from
+    them and clears them once done, the same as finishing an interrupted run (#384)."""
+    def _ext(sha, filename, fact):
+        return {
+            "document": {"sha256": sha, "filename": filename,
+                         "original_path": f"_INCOMING/{filename}",
+                         "title": filename, "document_type": "Filing",
+                         "date_of_document": "2024-01-15", "page_count": 1,
+                         "source": None, "obtained": None, "near_duplicate_of": None,
+                         "summary": "A filing.",
+                         "key_facts": [{"fact": fact, "page": 1, "basis": "stated",
+                                        "entities": ["acme-corp"]}]},
+            "entities": [{"id": "acme-corp", "name": "Acme Corp", "type": "Company",
+                          "aliases": [], "roles": []}],
+            "morgue_entity_id": "acme-corp", "morgue_document_type": "filing",
+            "scratchpad": "",
+        }
+
+    async def fake(*, task, prompt, schema, model=None, backend=None, max_retries=1, effort=None):
+        flat = _flat(prompt)
+        if task == "classify":
+            parsed = {"skill": "general-records.md"}
+        elif task == "extract":
+            parsed = _ext("sha-one", "doc-one.pdf", "Acme filed ONE") if "ONE" in flat \
+                else _ext("sha-two", "doc-two.pdf", "Acme filed TWO")
+        elif task == "entity-synthesis":
+            parsed = {"entity_syntheses": [{"entity_id": "acme-corp",
+                                            "summary": "Synthesized prose.", "analysis": ""}]}
+        elif task == "timeline-dedup":
+            parsed = {"groups": []}
+        elif task == "briefing":
+            parsed = {"investigation_status": "x", "what_was_ingested": ["doc-one.pdf", "doc-two.pdf"]}
+        else:
+            parsed = {}
+        return model_client.ModelResult(parsed=parsed, text="", model="m",
+                                        backend="claude-agent-sdk", auth_mode="subscription")
+    monkeypatch.setattr(orchestrate.model_client, "acomplete_json", fake)
+
+    vault = make_vault(tmp_path)
+    _queue_doc(vault, sha="sha-one", filename="doc-one.pdf", text="Acme filed ONE")
+    _queue_doc(vault, sha="sha-two", filename="doc-two.pdf", text="Acme filed TWO")
+
+    # Phase 1: extract-only.
+    summary = asyncio.run(orchestrate.run(vault, skip_finalize=True))
+    assert summary["extracted"] == 2
+    assert "post_ingest" not in summary
+    assert orchestrate.has_pending_finalization(vault) is True
+
+    # Phase 2: a standalone finalize (e.g. `watchdog finalize --finalizer-model ...`) consumes
+    # exactly the staged inputs — no re-extraction, no "extract" call this phase.
+    calls = []
+    orig_fake = fake
+
+    async def counting_fake(*, task, **kw):
+        calls.append(task)
+        return await orig_fake(task=task, **kw)
+    monkeypatch.setattr(orchestrate.model_client, "acomplete_json", counting_fake)
+
+    out = asyncio.run(orchestrate.finalize(vault, post_model="haiku"))
+
+    assert "extract" not in calls
+    assert out["synthesized"] == 1
+    assert "error" not in out
+    assert "Synthesized prose." in (vault / "entities" / "organization" / "acme-corp.md").read_text()
+    assert not (vault / ".watchdog" / "tmp" / "entity-fragments").exists()
+    assert not list((vault / ".watchdog" / "tmp").glob("result_*.json"))
+    assert orchestrate.has_pending_finalization(vault) is False
+
+
 def test_pending_finalization_uses_registry_appears_in_gate(tmp_path):
     """Entity count reflects the registry's `appears_in >= 2` gate (D26), not the fragment
     queue's `count`, which is only a touched-set marker post-D26."""


### PR DESCRIPTION
First half of #384 — the extract-only stop point. Idempotent re-finalize over an already-finalized batch is explicitly out of scope (deferred to the #403 two-phase-ingest design).

## What this does

- **`orchestrate.run(..., skip_finalize=True)`** returns after extraction at the single convergence point shared by the concurrent per-document loop and the claude-batch collect path — post-ingest never runs, nothing is cleared, so `has_pending_finalization(vault)` stays True on exactly the state a normal interrupted run leaves.
- **`watchdog ingest --no-finalize`** threads the flag through (argparse + the `_CMD_HELP` table that renders the real help output) and closes with a styled block telling the user extraction is staged and how to finalize.
- **`--wait` interaction verified**: the sleep-and-resume loop's only continuation condition is a rate limit during extraction, so `--wait --no-finalize` stops once the queue drains — documented inline and covered by a test.
- **Docs**: `docs/commands.md` documents the flag and adds a "Comparing finalizer models" walkthrough — run extraction once, then `watchdog finalize --finalizer-model <model>` per vault copy to compare candidates against the identical extraction (what the #361 benchmark needs, replacing the cheap-extractor workaround). ARCHITECTURE §5 records the stop point; §4's `--wait` paragraph gets the matching caveat.

One judgment call to note: `_update_graph_colours` lives in the same branch as finalize, so an extract-only run defers Obsidian graph colours for new entity-type folders until the eventual finalize — kept that way to stay strictly extract-only.

## Verification

- 1,479 tests pass; ruff clean (re-verified by the reviewing session, not just the authoring agent).
- New tests: extract-only makes no post-ingest model calls and preserves the staged inputs; the CLI flag threads through; `--wait --no-finalize` stops after one pass; a subsequent standalone `finalize()` consumes the staged inputs, writes the synthesis, and clears them.
- Mutation-checked: forcing finalize back on turned the orchestrate tests red; hardcoding the flag off turned the CLI tests red.

Written by a Sonnet subagent, reviewed by the main session.

Refs #384, #361, #403.

🤖 Generated with [Claude Code](https://claude.com/claude-code)