### PR TITLE
Silence GLiNER load-time stderr noise and make the live board resilient to it

### DIFF
--- a/src/watchdog/cmd/live.py
+++ b/src/watchdog/cmd/live.py
@@ -13,6 +13,7 @@ pass fully-formatted lines (including the 2-space indent and colour codes); the 
 truncates live rows to the terminal width so the redraw math stays one physical line per row.
 """
 
+import contextlib
 import os
 import re
 import shutil
@@ -126,6 +127,29 @@ class LiveRegion:
             if self.enabled:
                 self.stream.flush()
 
+    @contextlib.contextmanager
+    def capture_stderr(self):
+        """While active, fold writes to `sys.stderr` into this region's own scrollback
+        (`note`) instead of letting them land on the terminal directly (#419). The region's
+        redraw math assumes it owns the screen rows below its last render; a third-party
+        write (a library's warning, an unauthenticated-request notice) that lands directly on
+        the terminal shifts the cursor by lines `_rendered` doesn't know about, so the next
+        `_clear()` erases the wrong rows and leaves stale duplicate text on screen. Routing
+        those writes through `note()` keeps the region's own bookkeeping authoritative
+        regardless of what else writes to stderr mid-run. No-op when the region is disabled
+        (no TTY, so there's no cursor math to protect)."""
+        if not self.enabled:
+            yield
+            return
+        real_stderr = sys.stderr
+        tap = _StderrTap(self)
+        sys.stderr = tap
+        try:
+            yield
+        finally:
+            tap.flush()
+            sys.stderr = real_stderr
+
     # ── rendering ─────────────────────────────────────────────────────────────
 
     def _print(self, line: str) -> None:
@@ -151,3 +175,31 @@ class LiveRegion:
     def _emit_above(self, line: str) -> None:
         self._clear()
         self.stream.write(line + "\n")
+
+
+class _StderrTap:
+    """Write-only stream that lines-buffer foreign stderr writes and hands each complete line
+    to a `LiveRegion`'s `note()`, so they scroll into its permanent output instead of
+    corrupting its redraw math (#419, see `LiveRegion.capture_stderr`)."""
+
+    def __init__(self, region: LiveRegion):
+        self._region = region
+        self._buf = ""
+
+    def write(self, s: str) -> int:
+        if not s:
+            return 0
+        self._buf += s
+        while "\n" in self._buf:
+            line, self._buf = self._buf.split("\n", 1)
+            if line:
+                self._region.note(line)
+        return len(s)
+
+    def flush(self) -> None:
+        if self._buf:
+            self._region.note(self._buf)
+            self._buf = ""
+
+    def isatty(self) -> bool:
+        return False

--- a/src/watchdog/pipeline/harvest.py
+++ b/src/watchdog/pipeline/harvest.py
@@ -14,6 +14,8 @@ loads the optional local GLiNER NER model — import-guarded and wrapped so a mi
 any model failure degrades to an empty list rather than breaking ingest.
 """
 
+import contextlib
+import io
 import re
 import warnings
 
@@ -233,12 +235,19 @@ def _load_gliner():
         import os
         import truststore
         # The load prints hub progress bars to stderr even on a cache hit; ingest's terminal
-        # output is user-facing, so keep them out of it.
+        # output is user-facing, so keep them out of it. `from_pretrained` also emits a
+        # load-time UserWarning (resume_download deprecation) and an unauthenticated-requests
+        # notice via huggingface_hub's own logging — neither is a predict-time warning, so
+        # they slip past harvest_entities' own catch_warnings (#419). redirect_stderr catches
+        # both regardless of which mechanism raises them, same pattern as setup_cmd's model
+        # downloads.
         os.environ.setdefault("HF_HUB_DISABLE_PROGRESS_BARS", "1")
         truststore.inject_into_ssl()
         try:
             from gliner import GLiNER
-            _gliner_model = GLiNER.from_pretrained("urchade/gliner_multi-v2.1")
+            with warnings.catch_warnings(), contextlib.redirect_stderr(io.StringIO()):
+                warnings.simplefilter("ignore", UserWarning)
+                _gliner_model = GLiNER.from_pretrained("urchade/gliner_multi-v2.1")
         finally:
             truststore.extract_from_ssl()
     return _gliner_model

--- a/src/watchdog/pipeline/orchestrate.py
+++ b/src/watchdog/pipeline/orchestrate.py
@@ -1482,7 +1482,11 @@ async def run(vault: Path, *, concurrency: int = DEFAULT_CONCURRENCY,
             # finish-current-writes path — see that handler's comment for what differs.
             pass
         try:
-            await asyncio.gather(*tasks, return_exceptions=True)
+            # capture_stderr (#419): a dependency running in one of these tasks' worker
+            # threads (e.g. harvest's GLiNER load) can write straight to stderr mid-extraction;
+            # left alone that corrupts the board's redraw math, duplicating in-flight rows.
+            with _board.capture_stderr():
+                await asyncio.gather(*tasks, return_exceptions=True)
         finally:
             if handler_set:
                 loop.remove_signal_handler(signal.SIGINT)

--- a/tests/test_harvest.py
+++ b/tests/test_harvest.py
@@ -1,6 +1,9 @@
 """Tier 0 candidate harvest (#361/D123): deterministic regex spans + optional GLiNER entities."""
 
 import builtins
+import sys
+import types
+import warnings
 
 from watchdog.pipeline import harvest
 
@@ -185,6 +188,30 @@ def test_harvest_and_checklist_unaffected_by_missing_gliner(monkeypatch):
     text = _paged("Fees of $590 were charged.")
     cands = harvest.harvest(text) + harvest.harvest_entities(harvest.split_pages(text))
     assert harvest.format_checklist(cands) == "p.1: [money] $590"
+
+
+def test_load_gliner_suppresses_load_time_warnings_and_stderr(monkeypatch, capsys):
+    """`from_pretrained` emits a deprecation UserWarning and writes an unauthenticated-requests
+    notice straight to stderr on load (#419) — neither is a predict-time warning, so they slip
+    past harvest_entities' own catch_warnings. The live ingest board isn't resilient to
+    arbitrary foreign stderr, so this load path must stay silent by construction."""
+    class _FakeGLiNER:
+        @staticmethod
+        def from_pretrained(name):
+            warnings.warn("The `resume_download` argument is deprecated", UserWarning)
+            print("Warning: you are sending unauthenticated requests", file=sys.stderr)
+            return "fake-model"
+
+    monkeypatch.setitem(sys.modules, "gliner", types.SimpleNamespace(GLiNER=_FakeGLiNER))
+    monkeypatch.setattr(harvest, "_gliner_model", None)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        model = harvest._load_gliner()
+
+    assert model == "fake-model"
+    assert caught == []
+    assert capsys.readouterr().err == ""
 
 
 # ── real-corpus regression fixtures (#361 benchmark misses) ────────────────────────────────

--- a/tests/test_live.py
+++ b/tests/test_live.py
@@ -2,6 +2,7 @@
 
 import io
 import re
+import sys
 import threading
 
 from watchdog.cmd.live import LiveRegion, _truncate
@@ -168,3 +169,59 @@ def test_concurrent_finishes_keep_every_line_intact():
     for i in range(n):
         assert f"DONE-{i}" in out                 # no finished line lost to a torn write
     assert r._rows == {} and r._order == []       # every row settled, none orphaned
+
+
+# ── capture_stderr (#419) ──────────────────────────────────────────────────────────
+
+def test_capture_stderr_routes_foreign_writes_into_scrollback(monkeypatch):
+    """A third-party write to stderr (e.g. a dependency's warning) while the region is
+    active must land through `note()` — above the region, with the region re-rendered below
+    it — instead of writing straight to the terminal and corrupting the redraw math."""
+    s = _Stream(tty=True)
+    r = LiveRegion(s, enabled=True)
+    r.update("a", "row-A")
+    with r.capture_stderr():
+        print("foreign warning line", file=sys.stderr)
+    out = _CURSOR_RE.sub("", s.getvalue())
+    lines = out.rstrip("\n").split("\n")
+    assert "foreign warning line" in lines
+    assert lines[-1] == "row-A"                    # region re-rendered below the foreign line
+
+
+def test_capture_stderr_restores_real_stderr_on_exit():
+    s = _Stream(tty=True)
+    r = LiveRegion(s, enabled=True)
+    real = sys.stderr
+    with r.capture_stderr():
+        assert sys.stderr is not real
+    assert sys.stderr is real
+
+
+def test_capture_stderr_restores_real_stderr_on_exception():
+    s = _Stream(tty=True)
+    r = LiveRegion(s, enabled=True)
+    real = sys.stderr
+    try:
+        with r.capture_stderr():
+            raise ValueError("boom")
+    except ValueError:
+        pass
+    assert sys.stderr is real
+
+
+def test_capture_stderr_flushes_partial_line_without_trailing_newline():
+    s = _Stream(tty=True)
+    r = LiveRegion(s, enabled=True)
+    with r.capture_stderr():
+        sys.stderr.write("no newline at all")
+    out = _CURSOR_RE.sub("", s.getvalue())
+    assert "no newline at all" in out.rstrip("\n").split("\n")
+
+
+def test_capture_stderr_is_noop_when_region_disabled():
+    s = _Stream(tty=False)
+    r = LiveRegion(s, enabled=False)
+    real = sys.stderr
+    with r.capture_stderr():
+        assert sys.stderr is real                  # disabled region never swaps stderr
+    assert sys.stderr is real


### PR DESCRIPTION
## Summary
- `_load_gliner`'s `from_pretrained` call leaked a `resume_download` deprecation `UserWarning` and an unauthenticated-requests notice past the existing predict-time guards — neither is a predict-time warning, so `harvest_entities`' own `catch_warnings` never caught them. Now wrapped in `warnings.catch_warnings()` + `contextlib.redirect_stderr(io.StringIO())`, the same pattern `setup_cmd.py` already uses for model downloads.
- Added `LiveRegion.capture_stderr()`, which routes any foreign write to `sys.stderr` through the region's own `note()` scrollback instead of letting it land directly on the terminal and shift the cursor by lines the region's redraw math doesn't know about (the cause of the duplicated in-flight rows observed in #414's review). Wired into `orchestrate.py` around the concurrent extraction `gather()`, so the fix generalizes to any future stderr-writing dependency, not just GLiNER.

Closes #419.

## Test plan
- [x] `~/.local/pipx/venvs/watchdog-intel/bin/pytest` — 1541 passed
- [x] `pipx run ruff check src tests` — clean
- [x] New tests for both fixes verified to fail (red) when the fix is reverted

🤖 Generated with [Claude Code](https://claude.com/claude-code)