### PR TITLE
#403 phase 2: batch-wide exact-name fold, pre-commit

### DIFF
--- a/src/watchdog/pipeline/orchestrate.py
+++ b/src/watchdog/pipeline/orchestrate.py
@@ -1318,10 +1318,64 @@ def _load_results(vault: Path) -> list:
 # ── Commit pass (#403 phase 1) ───────────────────────────────────────────────────────────────
 #
 # Extraction stages its output (postflight.run) instead of writing to the vault; this pass
-# replays the existing writer (write_vault.run, unmodified) over every staged-but-uncommitted
-# artifact, sorted by sha for determinism (see D126), before any post-ingest model call. It runs
-# at the top of `finalize`, so it covers all three entry paths that call it: the tail of
-# `watchdog ingest`, a standalone `watchdog finalize`, and a resumed run after a rate-limit stop.
+# runs a deterministic exact-name entity fold over every staged-but-uncommitted artifact
+# (`_batch_exact_fold`, #403 phase 2), then replays the writer (write_vault.run) over each one in
+# the same sorted order, before any post-ingest model call. It runs at the top of `finalize`, so
+# it covers all three entry paths that call it: the tail of `watchdog ingest`, a standalone
+# `watchdog finalize`, and a resumed run after a rate-limit stop.
+
+def _batch_exact_fold(vault: Path, shas: list[str]) -> None:
+    """Fold exact-name entity duplicates across a batch of staged extractions, before any of
+    them commits to the vault (#403 phase 2).
+
+    Documents extract in parallel from a pre-flight snapshot taken at launch, so two documents
+    referencing the same real-world entity can coin different ids (e.g. 'ernst-and-young-inc'
+    vs 'ernst-young-inc'). This used to be reconciled by `write_vault._reconcile_entity_ids`
+    running per-document inside the registry lock, against a fresh read of the live registry —
+    the one place that saw entities written by concurrent extraction tasks earlier in the batch.
+    Now that commit is a separate, serial pass (phase 1), the same cross-document visibility is
+    available up front: walk the given `shas` in order (the caller passes them pre-sorted, see
+    D126) over a throwaway in-memory registry copy, reconciling each document's entities against
+    it with the same `_reconcile_entity_ids` and then folding that document's (already-
+    reconciled) entities into the copy with the same `_new_entity`/`_merge_entity` used at real
+    commit time — so later documents in the batch match against earlier ones exactly as they did
+    under the old per-document call. The real registry on disk is never touched here; the commit
+    pass still does the actual writes. Mutates each staged `.watchdog/extracted/<sha>.json` in
+    place (id remaps, alias appends, role-target remaps) so the commit pass that follows replays
+    already-folded entities.
+
+    `_add_reverse_role` is deliberately not simulated — it only appends roles onto entities
+    already in the registry copy and never mints a new id, so it cannot affect name/type/alias
+    matching for any later document.
+    """
+    from watchdog.pipeline.write_vault import _merge_entity, _new_entity, _reconcile_entity_ids
+
+    # Freshly parsed from disk, so this is already an in-memory copy independent of the real
+    # registry file — mutating it below (reconcile/merge) can never write through to disk.
+    entities_path = vault / ".watchdog" / "registry" / "entities.json"
+    pseudo_reg: dict = (
+        json.loads(entities_path.read_text(encoding="utf-8")) if entities_path.exists() else {}
+    )
+
+    extracted_dir = vault / ".watchdog" / "extracted"
+    for sha in shas:
+        artifact_path = extracted_dir / f"{sha}.json"
+        artifact = json.loads(artifact_path.read_text(encoding="utf-8"))
+        entities = artifact.get("entities") or []
+
+        _reconcile_entity_ids(entities, pseudo_reg)
+
+        for entity in entities:
+            eid = entity["id"]
+            if eid in pseudo_reg:
+                _merge_entity(pseudo_reg[eid], entity, sha)
+            else:
+                pseudo_reg[eid] = _new_entity(entity, sha)
+
+        artifact_path.write_text(
+            json.dumps(artifact, ensure_ascii=False, indent=2), encoding="utf-8"
+        )
+
 
 def _pending_commits(vault: Path) -> list[str]:
     """Every sha with a durable extraction artifact (`.watchdog/extracted/<sha>.json`) that is
@@ -1395,6 +1449,7 @@ def _commit_pending(vault: Path) -> dict:
     shas = _pending_commits(vault)
     if not shas:
         return {"committed": 0, "written": {}}
+    _batch_exact_fold(vault, shas)
     _say(f"{_DIM}→  committing {len(shas)} document{'s' if len(shas) != 1 else ''} "
          f"to the vault…{_RESET}")
     tmp_dir = vault / ".watchdog" / "tmp"

--- a/src/watchdog/pipeline/write_vault.py
+++ b/src/watchdog/pipeline/write_vault.py
@@ -136,15 +136,20 @@ def _reconcile_entity_ids(incoming_entities: list[dict], entities_reg: dict) -> 
 
     Documents extract in parallel from a pre-flight snapshot taken at launch, so two
     documents referencing the same real-world entity can coin different ids (e.g.
-    'ernst-and-young-inc' vs 'ernst-young-inc'). write_vault runs inside the registry
-    lock with a fresh read of entities_reg — the one place that sees entities written
-    by concurrent extraction tasks earlier in the batch — so we reconcile here: any incoming
-    *new* entity whose normalized (name, type) matches an existing one is remapped to
-    that existing id, routing it through the merge path instead of creating a duplicate.
+    'ernst-and-young-inc' vs 'ernst-young-inc'). Any incoming *new* entity whose normalized
+    (name, type) matches an existing one is remapped to that existing id, routing it through
+    the merge path instead of creating a duplicate.
 
     The type half of the key is canonicalized (#335) so a real-world entity labelled with
     drifting near-synonyms across documents (``company`` vs ``financialinstitution``) still
     reconciles instead of forking into a second folder — see entity_type.canonical_type.
+
+    As of #403 phase 2 this is no longer called per-document inside write_vault's registry
+    lock; it is driven by `orchestrate._batch_exact_fold`, a deterministic pre-commit pass over
+    every staged extraction in a batch, sorted-sha order (D126), against a throwaway in-memory
+    registry copy that accumulates as the pass walks the batch. The original cross-worker-race
+    rationale for reconciling inside the lock no longer applies — the batch pass runs serially,
+    before any commit. The function itself is unchanged and still used, just called from there.
     """
     norm_index: dict[tuple[str, str], str] = {}
     for eid, entry in entities_reg.items():
@@ -860,8 +865,9 @@ def run(extraction_path: Path, vault_path: Path, neardup_file: Path | None = Non
 
         # ── 1. Update entity registry ─────────────────────────────────────────
 
-        # Reconcile near-duplicate slugs coined by concurrent extraction tasks before merging.
-        _reconcile_entity_ids(incoming_entities, entities_reg)
+        # Near-duplicate slugs coined by concurrent extraction tasks are already reconciled by
+        # this point — the batch-wide pre-commit fold (#403 phase 2, orchestrate._batch_exact_fold)
+        # ran over the staged extraction JSON before any commit began.
         # Roles arrive as target_id only; re-inflate target_name/target_type deterministically.
         _resolve_role_targets(incoming_entities, entities_reg)
 

--- a/tests/test_orchestrate.py
+++ b/tests/test_orchestrate.py
@@ -12,7 +12,7 @@ from watchdog import model_client
 from watchdog.cmd import auth as auth_module
 from watchdog.pipeline import batch_extract, orchestrate, schemas, timeline
 
-from tests.test_write_vault import make_vault
+from tests.test_write_vault import make_extraction, make_vault
 
 _flat = model_client._flatten_prompt   # extract/section prompts are content-block lists (A1)
 
@@ -2557,3 +2557,201 @@ def test_commit_pass_writes_morgue_markdown_from_surviving_queue_file(tmp_path, 
     md_files = list((vault / "morgue").rglob("*.md"))
     assert len(md_files) == 1
     assert "The quick brown fox." in md_files[0].read_text(encoding="utf-8")
+
+
+# ── #403 phase 2: batch-wide exact-name fold before commit ──────────────────────────────────
+#
+# The fold that used to run per-document inside write_vault.run's registry lock
+# (write_vault._reconcile_entity_ids) is now a single pass over every staged-but-uncommitted
+# extraction, run once up front by _commit_pending (orchestrate._batch_exact_fold). These tests
+# used to drive the fold via two `write_vault.run()` calls directly (tests/test_write_vault.py);
+# now they stage two extraction artifacts under `.watchdog/extracted/` — as extraction itself
+# would leave them — and drive the commit pass that folds and then writes them.
+
+def _stage_extracted(vault, tmp_path, sha, filename, overrides=None):
+    """Write a staged extraction artifact (`.watchdog/extracted/<sha>.json`), the on-disk form
+    `_pending_commits`/`_commit_pending` consume — built from test_write_vault's extraction
+    fixture so the document/entity shape stays identical to what real extraction produces.
+    `tmp_path` just needs to be a scratch dir distinct per call (make_extraction always writes
+    to `<tmp_path>/extraction.json`)."""
+    overrides = dict(overrides or {})
+    doc_overrides = {"sha256": sha, "filename": filename, "original_path": f"_INCOMING/{filename}"}
+    doc_overrides.update(overrides.pop("document", {}))
+    overrides["document"] = doc_overrides
+    (tmp_path).mkdir(parents=True, exist_ok=True)
+    src = make_extraction(tmp_path, overrides)
+    dest_dir = vault / ".watchdog" / "extracted"
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    dest = dest_dir / f"{sha}.json"
+    dest.write_text(src.read_text(encoding="utf-8"), encoding="utf-8")
+    return dest
+
+
+def _stage_company(vault, tmp_path, sha, filename, eid, name, entity_type="Company"):
+    return _stage_extracted(vault, tmp_path, sha, filename, overrides={
+        "entities": [{
+            "id": eid, "name": name, "type": entity_type,
+            "aliases": [], "summary": None, "timeline_events": [], "roles": [],
+        }],
+        "morgue_entity_id": eid,
+        "morgue_document_type": "annual-report",
+    })
+
+
+def test_parallel_slug_variants_reconciled(tmp_path):
+    """Two docs coining different slugs for the same entity must collapse to one, folded before
+    either commits (sha-a < sha-b, so sha-a's slug is the one that survives, per D126)."""
+    vault = make_vault(tmp_path)
+    (vault / "_INCOMING" / "doc-a.pdf").write_text("dummy")
+    (vault / "_INCOMING" / "doc-b.pdf").write_text("dummy")
+
+    # First-sorted-sha wins the slug; the other coins a near-duplicate id + name variant.
+    _stage_company(vault, tmp_path / "a", "sha-a", "doc-a.pdf",
+                   "ernst-and-young-inc", "Ernst & Young Inc.")
+    _stage_company(vault, tmp_path / "b", "sha-b", "doc-b.pdf",
+                   "ernst-young-inc", "Ernst and Young Inc")
+
+    orchestrate._commit_pending(vault)
+
+    entities = json.loads((vault / ".watchdog" / "registry" / "entities.json").read_text())
+    assert "ernst-and-young-inc" in entities
+    assert "ernst-young-inc" not in entities          # reconciled away, not a duplicate
+    ey = entities["ernst-and-young-inc"]
+    assert "sha-a" in ey["appears_in"] and "sha-b" in ey["appears_in"]
+    assert "Ernst and Young Inc" in ey["aliases"]     # variant folded in as alias
+
+
+def test_reconcile_remaps_role_target_in_same_document(tmp_path):
+    """A role pointing at a reconciled entity in the same extraction is remapped too."""
+    vault = make_vault(tmp_path)
+    (vault / "_INCOMING" / "doc-a.pdf").write_text("dummy")
+    (vault / "_INCOMING" / "doc-b.pdf").write_text("dummy")
+
+    # Doc A establishes the canonical company slug.
+    _stage_company(vault, tmp_path / "a", "sha-a", "doc-a.pdf",
+                   "ernst-and-young-inc", "Ernst & Young Inc.")
+
+    # Doc B re-coins the company under a different slug AND references it from a person.
+    _stage_extracted(vault, tmp_path / "b", "sha-b", "doc-b.pdf", overrides={
+        "entities": [
+            {"id": "jane-doe", "name": "Jane Doe", "type": "Person",
+             "aliases": [], "summary": None, "timeline_events": [],
+             "roles": [{
+                 "relationship": "Partner at", "target_id": "ernst-young-inc",
+                 "target_type": "Company", "target_name": "Ernst and Young Inc",
+                 "page": 1, "basis": "stated", "date_range": None,
+             }]},
+            {"id": "ernst-young-inc", "name": "Ernst and Young Inc", "type": "Company",
+             "aliases": [], "summary": None, "timeline_events": [], "roles": []},
+        ],
+        "morgue_entity_id": "jane-doe",
+        "morgue_document_type": "filing",
+    })
+
+    orchestrate._commit_pending(vault)
+
+    entities = json.loads((vault / ".watchdog" / "registry" / "entities.json").read_text())
+    # Person's role now points at the canonical slug, not the orphaned one.
+    role = entities["jane-doe"]["roles"][0]
+    assert role["target_id"] == "ernst-and-young-inc"
+    # Reverse role landed on the canonical company entity.
+    assert any(r["target_id"] == "jane-doe" for r in entities["ernst-and-young-inc"]["roles"])
+
+
+def test_reconcile_matches_against_existing_alias(tmp_path):
+    """A new slug matching an existing entity's *alias* (not its name) reconciles."""
+    vault = make_vault(tmp_path)
+    (vault / "_INCOMING" / "doc-a.pdf").write_text("dummy")
+    (vault / "_INCOMING" / "doc-b.pdf").write_text("dummy")
+
+    # Doc A establishes the entity with an alias.
+    _stage_extracted(vault, tmp_path / "a", "sha-a", "doc-a.pdf", overrides={
+        "entities": [{"id": "ibm", "name": "IBM", "type": "Company",
+                      "aliases": ["International Business Machines"], "summary": None,
+                      "timeline_events": [], "roles": []}],
+        "morgue_entity_id": "ibm", "morgue_document_type": "annual-report",
+    })
+
+    # Doc B coins a new slug whose name matches the *alias* above.
+    _stage_company(vault, tmp_path / "b", "sha-b", "doc-b.pdf",
+                   "international-business-machines", "International Business Machines")
+
+    orchestrate._commit_pending(vault)
+
+    entities = json.loads((vault / ".watchdog" / "registry" / "entities.json").read_text())
+    assert "international-business-machines" not in entities   # reconciled onto the alias match
+    assert "sha-b" in entities["ibm"]["appears_in"]
+
+
+def test_reconcile_does_not_merge_across_types(tmp_path):
+    """Same normalized name but different entity types must stay separate."""
+    vault = make_vault(tmp_path)
+    (vault / "_INCOMING" / "doc-a.pdf").write_text("dummy")
+    (vault / "_INCOMING" / "doc-b.pdf").write_text("dummy")
+
+    # A Person and a Company that normalize to the same key.
+    _stage_extracted(vault, tmp_path / "a", "sha-a", "doc-a.pdf", overrides={
+        "entities": [{"id": "morgan-person", "name": "Morgan", "type": "Person",
+                      "aliases": [], "summary": None, "timeline_events": [], "roles": []}],
+        "morgue_entity_id": "morgan-person", "morgue_document_type": "filing",
+    })
+    _stage_company(vault, tmp_path / "b", "sha-b", "doc-b.pdf", "morgan-company", "Morgan")
+
+    orchestrate._commit_pending(vault)
+
+    entities = json.loads((vault / ".watchdog" / "registry" / "entities.json").read_text())
+    assert "morgan-person" in entities and "morgan-company" in entities  # type-scoped, not merged
+
+
+def test_drifting_type_synonyms_reconcile_to_one_entity(tmp_path):
+    """#335: the same real-world entity labelled with drifting near-synonyms across two
+    documents (``Company`` in one, ``Financial Institution`` in the next) must reconcile onto
+    a single id/folder instead of forking — both collapse to the ``organization`` bucket, so
+    the reconciliation key matches where free-text types used to miss."""
+    vault = make_vault(tmp_path)
+    (vault / "_INCOMING" / "doc-a.pdf").write_text("dummy")
+    (vault / "_INCOMING" / "doc-b.pdf").write_text("dummy")
+
+    # Doc A: the bank labelled a plain "Company".
+    _stage_company(vault, tmp_path / "a", "sha-a", "doc-a.pdf",
+                   "td-bank", "Toronto-Dominion Bank")
+
+    # Doc B: same bank, a different slug AND a drifting type label the old code would have forked.
+    _stage_company(vault, tmp_path / "b", "sha-b", "doc-b.pdf",
+                   "toronto-dominion-bank", "Toronto-Dominion Bank",
+                   entity_type="Financial Institution")
+
+    orchestrate._commit_pending(vault)
+
+    entities = json.loads((vault / ".watchdog" / "registry" / "entities.json").read_text())
+    assert "td-bank" in entities
+    assert "toronto-dominion-bank" not in entities        # reconciled, not forked (#335)
+    td = entities["td-bank"]
+    assert "sha-a" in td["appears_in"] and "sha-b" in td["appears_in"]
+    assert td["type"] == "organization"                   # stored type is the canonical bucket
+
+
+def test_batch_fold_collapses_staged_duplicates_before_commit(tmp_path):
+    """The fold itself, isolated from the commit: two staged artifacts naming the same entity
+    under different (normalized-identical) names/ids must carry one canonical id — the
+    earliest-sha document's — in the staged JSON on disk *before* `_batch_exact_fold` returns,
+    i.e. before either has been committed to the vault."""
+    vault = make_vault(tmp_path)
+    (vault / "_INCOMING" / "doc-a.pdf").write_text("dummy")
+    (vault / "_INCOMING" / "doc-b.pdf").write_text("dummy")
+
+    _stage_company(vault, tmp_path / "a", "sha-a", "doc-a.pdf",
+                   "ernst-and-young-inc", "Ernst & Young Inc.")
+    _stage_company(vault, tmp_path / "b", "sha-b", "doc-b.pdf",
+                   "ernst-young-inc", "Ernst and Young Inc")
+
+    orchestrate._batch_exact_fold(vault, ["sha-a", "sha-b"])
+
+    # Nothing committed yet — the registry is untouched.
+    assert not json.loads((vault / ".watchdog" / "registry" / "entities.json").read_text())
+
+    staged_a = json.loads((vault / ".watchdog" / "extracted" / "sha-a.json").read_text())
+    staged_b = json.loads((vault / ".watchdog" / "extracted" / "sha-b.json").read_text())
+    assert staged_a["entities"][0]["id"] == "ernst-and-young-inc"   # untouched — it's the winner
+    assert staged_b["entities"][0]["id"] == "ernst-and-young-inc"   # remapped onto the winner
+    assert "Ernst and Young Inc" in staged_b["entities"][0]["aliases"]   # variant name preserved

--- a/tests/test_write_vault.py
+++ b/tests/test_write_vault.py
@@ -1383,27 +1383,10 @@ def _company_extraction(dirpath, sha, filename, eid, name):
     })
 
 
-def test_parallel_slug_variants_reconciled(tmp_path):
-    """Two docs coining different slugs for the same entity must collapse to one."""
-    vault = make_vault(tmp_path)
-    (vault / "_INCOMING" / "doc-a.pdf").write_text("dummy")
-    (vault / "_INCOMING" / "doc-b.pdf").write_text("dummy")
-    dir_a, dir_b = tmp_path / "a", tmp_path / "b"
-    dir_a.mkdir()
-    dir_b.mkdir()
-
-    # First subagent wins the slug; second coins a near-duplicate id + name variant.
-    run(_company_extraction(dir_a, "sha-a", "doc-a.pdf",
-                            "ernst-and-young-inc", "Ernst & Young Inc."), vault)
-    run(_company_extraction(dir_b, "sha-b", "doc-b.pdf",
-                            "ernst-young-inc", "Ernst and Young Inc"), vault)
-
-    entities = json.loads((vault / ".watchdog" / "registry" / "entities.json").read_text())
-    assert "ernst-and-young-inc" in entities
-    assert "ernst-young-inc" not in entities          # reconciled away, not a duplicate
-    ey = entities["ernst-and-young-inc"]
-    assert "sha-a" in ey["appears_in"] and "sha-b" in ey["appears_in"]
-    assert "Ernst and Young Inc" in ey["aliases"]     # variant folded in as alias
+# Cross-document exact-name reconciliation (test_parallel_slug_variants_reconciled and friends)
+# moved to tests/test_orchestrate.py's "#403 phase 2" section — as of that phase the fold is a
+# batch-wide pre-commit pass (orchestrate._batch_exact_fold), not something write_vault.run does
+# per document, so it's no longer exercisable via two bare `run()` calls here.
 
 
 def test_distinct_same_type_entities_not_merged(tmp_path):
@@ -1421,136 +1404,6 @@ def test_distinct_same_type_entities_not_merged(tmp_path):
     entities = json.loads((vault / ".watchdog" / "registry" / "entities.json").read_text())
     assert "acme-corp" in entities
     assert "globex-corp" in entities
-
-
-def test_reconcile_remaps_role_target_in_same_document(tmp_path):
-    """A role pointing at a reconciled entity in the same extraction is remapped too."""
-    vault = make_vault(tmp_path)
-    (vault / "_INCOMING" / "doc-a.pdf").write_text("dummy")
-    (vault / "_INCOMING" / "doc-b.pdf").write_text("dummy")
-    dir_a, dir_b = tmp_path / "a", tmp_path / "b"
-    dir_a.mkdir()
-    dir_b.mkdir()
-
-    # Doc A establishes the canonical company slug.
-    run(_company_extraction(dir_a, "sha-a", "doc-a.pdf",
-                            "ernst-and-young-inc", "Ernst & Young Inc."), vault)
-
-    # Doc B re-coins the company under a different slug AND references it from a person.
-    run(make_extraction(dir_b, overrides={
-        "document": {"sha256": "sha-b", "filename": "doc-b.pdf",
-                     "original_path": "_INCOMING/doc-b.pdf"},
-        "entities": [
-            {"id": "jane-doe", "name": "Jane Doe", "type": "Person",
-             "aliases": [], "summary": None, "analysis": None, "timeline_events": [],
-             "roles": [{
-                 "relationship": "Partner at", "target_id": "ernst-young-inc",
-                 "target_type": "Company", "target_name": "Ernst and Young Inc",
-                 "page": 1, "basis": "stated", "date_range": None,
-             }]},
-            {"id": "ernst-young-inc", "name": "Ernst and Young Inc", "type": "Company",
-             "aliases": [], "summary": None, "analysis": None,
-             "timeline_events": [], "roles": []},
-        ],
-        "morgue_entity_id": "jane-doe",
-        "morgue_document_type": "filing",
-    }), vault)
-
-    entities = json.loads((vault / ".watchdog" / "registry" / "entities.json").read_text())
-    # Person's role now points at the canonical slug, not the orphaned one.
-    role = entities["jane-doe"]["roles"][0]
-    assert role["target_id"] == "ernst-and-young-inc"
-    # Reverse role landed on the canonical company entity.
-    assert any(r["target_id"] == "jane-doe" for r in entities["ernst-and-young-inc"]["roles"])
-
-
-def test_reconcile_matches_against_existing_alias(tmp_path):
-    """A new slug matching an existing entity's *alias* (not its name) reconciles."""
-    vault = make_vault(tmp_path)
-    (vault / "_INCOMING" / "doc-a.pdf").write_text("dummy")
-    (vault / "_INCOMING" / "doc-b.pdf").write_text("dummy")
-    dir_a, dir_b = tmp_path / "a", tmp_path / "b"
-    dir_a.mkdir()
-    dir_b.mkdir()
-
-    # Doc A establishes the entity with an alias.
-    run(make_extraction(dir_a, overrides={
-        "document": {"sha256": "sha-a", "filename": "doc-a.pdf", "original_path": "_INCOMING/doc-a.pdf"},
-        "entities": [{"id": "ibm", "name": "IBM", "type": "Company",
-                      "aliases": ["International Business Machines"], "summary": None, "analysis": None,
-                      "timeline_events": [], "roles": []}],
-        "morgue_entity_id": "ibm", "morgue_document_type": "annual-report",
-    }), vault)
-
-    # Doc B coins a new slug whose name matches the *alias* above.
-    run(_company_extraction(dir_b, "sha-b", "doc-b.pdf",
-                            "international-business-machines", "International Business Machines"), vault)
-
-    entities = json.loads((vault / ".watchdog" / "registry" / "entities.json").read_text())
-    assert "international-business-machines" not in entities   # reconciled onto the alias match
-    assert "sha-b" in entities["ibm"]["appears_in"]
-
-
-def test_reconcile_does_not_merge_across_types(tmp_path):
-    """Same normalized name but different entity types must stay separate."""
-    vault = make_vault(tmp_path)
-    (vault / "_INCOMING" / "doc-a.pdf").write_text("dummy")
-    (vault / "_INCOMING" / "doc-b.pdf").write_text("dummy")
-    dir_a, dir_b = tmp_path / "a", tmp_path / "b"
-    dir_a.mkdir()
-    dir_b.mkdir()
-
-    # A Person and a Company that normalize to the same key.
-    run(make_extraction(dir_a, overrides={
-        "document": {"sha256": "sha-a", "filename": "doc-a.pdf", "original_path": "_INCOMING/doc-a.pdf"},
-        "entities": [{"id": "morgan-person", "name": "Morgan", "type": "Person",
-                      "aliases": [], "summary": None, "analysis": None,
-                      "timeline_events": [], "roles": []}],
-        "morgue_entity_id": "morgan-person", "morgue_document_type": "filing",
-    }), vault)
-    run(_company_extraction(dir_b, "sha-b", "doc-b.pdf", "morgan-company", "Morgan"), vault)
-
-    entities = json.loads((vault / ".watchdog" / "registry" / "entities.json").read_text())
-    assert "morgan-person" in entities and "morgan-company" in entities  # type-scoped, not merged
-
-
-def test_drifting_type_synonyms_reconcile_to_one_entity(tmp_path):
-    """#335: the same real-world entity labelled with drifting near-synonyms across two
-    documents (``Company`` in one, ``Financial Institution`` in the next) must reconcile onto
-    a single id/folder instead of forking — both collapse to the ``organization`` bucket, so
-    the reconciliation key matches where free-text types used to miss."""
-    vault = make_vault(tmp_path)
-    (vault / "_INCOMING" / "doc-a.pdf").write_text("dummy")
-    (vault / "_INCOMING" / "doc-b.pdf").write_text("dummy")
-    dir_a, dir_b = tmp_path / "a", tmp_path / "b"
-    dir_a.mkdir()
-    dir_b.mkdir()
-
-    # Doc A: the bank labelled a plain "Company".
-    run(make_extraction(dir_a, overrides={
-        "document": {"sha256": "sha-a", "filename": "doc-a.pdf", "original_path": "_INCOMING/doc-a.pdf"},
-        "entities": [{"id": "td-bank", "name": "Toronto-Dominion Bank", "type": "Company",
-                      "aliases": [], "summary": None, "analysis": None,
-                      "timeline_events": [], "roles": []}],
-        "morgue_entity_id": "td-bank", "morgue_document_type": "annual-report",
-    }), vault)
-
-    # Doc B: same bank, a different slug AND a drifting type label the old code would have forked.
-    run(make_extraction(dir_b, overrides={
-        "document": {"sha256": "sha-b", "filename": "doc-b.pdf", "original_path": "_INCOMING/doc-b.pdf"},
-        "entities": [{"id": "toronto-dominion-bank", "name": "Toronto-Dominion Bank",
-                      "type": "Financial Institution",
-                      "aliases": [], "summary": None, "analysis": None,
-                      "timeline_events": [], "roles": []}],
-        "morgue_entity_id": "toronto-dominion-bank", "morgue_document_type": "annual-report",
-    }), vault)
-
-    entities = json.loads((vault / ".watchdog" / "registry" / "entities.json").read_text())
-    assert "td-bank" in entities
-    assert "toronto-dominion-bank" not in entities        # reconciled, not forked (#335)
-    td = entities["td-bank"]
-    assert "sha-a" in td["appears_in"] and "sha-b" in td["appears_in"]
-    assert td["type"] == "organization"                   # stored type is the canonical bucket
 
 
 def test_canonical_type_drives_entity_folder(tmp_path):


### PR DESCRIPTION
Phase 2 of the #403 two-phase-ingest refactor.

## What
Move the deterministic exact-name entity fold out of `write_vault.run`'s per-document registry lock and into a single pass over the staged extraction JSON — `orchestrate._batch_exact_fold` — run once before the serial commit pass.

The fold walks the sorted-sha batch (∪ the existing registry) over a throwaway in-memory registry copy, reconciling each document's entities with the same `_reconcile_entity_ids` and folding each doc's reconciled entities into the copy via the same `_new_entity`/`_merge_entity` used at real commit. That reproduces the old per-document behaviour exactly — including which id wins for a given `(normalized-name, canonical-type)` key (earliest sha, or a pre-existing registry id). It rewrites each `.watchdog/extracted/<sha>.json` in place, so the commit pass replays already-folded entities and the vault write happens once.

The per-document `_reconcile_entity_ids` call inside `write_vault.run` is removed; the function itself stays (now driven by the batch pass).

## Why
Not better dedup — the output is byte-identical. The point is to make the **staged JSON the fully-resolved surface** that reconcile (phase 3) and synthesis (phase 4) will read, and to move resolution ahead of the commit so the vault mutates once. As a bonus, the staged JSON is now the clean, resolved per-document scoring surface benchmarks have lacked.

## Behaviour-identical
`tests/test_golden_vault.py` passes **unchanged, no regeneration** — the golden-vault parity net confirms observable vault output is the same.

## Tests
- The reconcile unit tests move from `test_write_vault` (which drove the fold via two bare `write_vault.run` calls, no longer possible) to `test_orchestrate`, exercising the real commit path over staged artifacts — same names, same assertions.
- New `test_batch_fold_collapses_staged_duplicates_before_commit`: stages two duplicate-entity artifacts, runs `_batch_exact_fold`, asserts both staged files carry the single canonical id (earliest sha) with the variant folded into aliases, before any commit.
- Full suite: 1550 passed. Ruff clean. Mutation-checked (neutering `_batch_exact_fold` reddens the folding tests).

## Deferred
ARCHITECTURE/DECISIONS/docs recording and the I7 invariant are batched into phase 5, per the roadmap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)