### PR TITLE
Bundle of watchdog ingest CLI output fixes (#411)

### DIFF
--- a/src/watchdog/cmd/base.py
+++ b/src/watchdog/cmd/base.py
@@ -603,6 +603,11 @@ def _print_cmd_help(cmd: str) -> None:
         usage_parts.append(f"[{name}]" if optional else f"<{name}>")
     if opts:
         usage_parts.append("[options]")
+    # Pad every arg/opt name to the widest one actually in this command's help — a fixed 18
+    # broke alignment as soon as a flag+metavar ran longer than that (e.g. "--classifier-model
+    # M" is 21 chars), leaving its description crammed one space after the flag while shorter
+    # ones sat in a neat column (#411).
+    width = max([len(a[0]) for a in arg_defs] + [len(flag) for flag, _ in opts] + [len("--help")])
     print(f"\n  {info.get('desc', '')}")
     print()
     print(f"  {_DIM}Usage:  {' '.join(usage_parts)}{_RESET}")
@@ -613,12 +618,12 @@ def _print_cmd_help(cmd: str) -> None:
             name, desc = a[0], a[1]
             optional = len(a) > 2 and a[2]
             note = "  (optional)" if optional else ""
-            print(f"    {_CYAN}{name:<18}{_RESET} {desc}{note}")
+            print(f"    {_CYAN}{name:<{width}}{_RESET} {desc}{note}")
     print()
     print(f"  {_BOLD}Options{_RESET}")
     for flag, desc in opts:
-        print(f"    {_CYAN}{flag:<18}{_RESET} {desc}")
-    print(f"    {_CYAN}{'--help':<18}{_RESET} Show this message and exit")
+        print(f"    {_CYAN}{flag:<{width}}{_RESET} {desc}")
+    print(f"    {_CYAN}{'--help':<{width}}{_RESET} Show this message and exit")
     notes = info.get("notes", [])
     if notes:
         print()

--- a/src/watchdog/cmd/ingest.py
+++ b/src/watchdog/cmd/ingest.py
@@ -108,16 +108,23 @@ def _effective_extract_backend(extract_backend: str | None, auth_mode: str) -> s
 
 
 def _format_models_line(classify_backend, classify_model, extract_backend, extract_model,
-                        post_backend, post_model) -> str:
+                        post_backend, post_model, extract_effort=None, post_effort=None) -> str:
     """Which model runs each ingest stage — printed alongside the cost estimate before an
     ingest starts, so a run under a non-default provider (#325) is obvious up front instead of
-    the older generic 'Using the configured provider(s).' notice."""
+    the older generic 'Using the configured provider(s).' notice. Stage names are padded to a
+    common width so the model values line up in a column (#411); classify has no effort knob
+    (D36), so only the extractor/finalizer rows can carry an "(effort: …)" suffix."""
     def label(backend, model):
         return f"{backend}:{model}" if backend else model
-    stages = (("classifier", classify_backend, classify_model),
-              ("extractor", extract_backend, extract_model),
-              ("finalizer", post_backend, post_model))
-    return "\n".join(f"  {_DIM}{name}{_RESET} {_CYAN}{label(b, m)}{_RESET}" for name, b, m in stages)
+    stages = (("classifier", classify_backend, classify_model, None),
+              ("extractor", extract_backend, extract_model, extract_effort),
+              ("finalizer", post_backend, post_model, post_effort))
+    width = max(len(name) for name, *_ in stages)
+    lines = []
+    for name, b, m, effort in stages:
+        suffix = f" {_DIM}(effort: {effort}){_RESET}" if effort else ""
+        lines.append(f"  {_DIM}{name:<{width}}{_RESET} {_CYAN}{label(b, m)}{_RESET}{suffix}")
+    return "\n".join(lines)
 
 
 def _preview_ingest(vault: Path, args) -> tuple[str, str] | None:
@@ -142,11 +149,14 @@ def _preview_ingest(vault: Path, args) -> tuple[str, str] | None:
         getattr(args, "finalizer_model", None), config.get("finalizer_model"), default="haiku")
     classify_backend, classify_model = _resolve_stage(
         getattr(args, "classifier_model", None), config.get("classifier_model"), default="haiku")
+    extract_effort = _effort(getattr(args, "extractor_effort", None), config.get("extractor_effort"))
+    post_effort = _effort(getattr(args, "finalizer_effort", None), config.get("finalizer_effort"))
 
     auth_mode = resolve_auth()["mode"] if extract_backend is None else None
     est = cost_estimate(vault, queue_files, _effective_extract_backend(extract_backend, auth_mode))
     models_line = _format_models_line(classify_backend, classify_model,
-                                      extract_backend, extract_model, post_backend, post_model)
+                                      extract_backend, extract_model, post_backend, post_model,
+                                      extract_effort, post_effort)
     return _format_cost_estimate(est), models_line
 
 
@@ -258,7 +268,8 @@ def _offer_ingest(args, vault: Path) -> None:
     if interactive.pick(["Ingest now", "Not now"], 0, title="Ingest now?") == 0:
         cmd_ingest(args, confirm=False, skip_preview=True)
     else:
-        print(f"\n  Run:  {_CYAN}watchdog ingest{_RESET}\n")
+        # No leading blank line here — pick()'s own close-out already leaves one (#411).
+        print(f"  Run:  {_CYAN}watchdog ingest{_RESET}\n")
 
 
 def _wait_seconds(resets_at: int | None) -> tuple[int, bool]:
@@ -637,22 +648,22 @@ def cmd_ingest(args, *, confirm: bool = True, skip_preview: bool = False) -> Non
             bits.append(f"{p['entities']} entit{'ies' if p['entities'] != 1 else 'y'} to synthesize")
         detail = f" {_DIM}({', '.join(bits)}){_RESET}" if bits else ""
         print(f"\n  {_YELLOW}A previous batch is pending finalization{_RESET}{detail}{_DIM}.{_RESET}")
-        print(f"  {_DIM}A new ingest resets it — what would you like to do?{_RESET}\n")
-        print(f"    {_BOLD}m{_RESET}  merge it into this ingest {_DIM}— extract the new docs, then finalize everything together{_RESET}")
-        print(f"    {_BOLD}f{_RESET}  finalize it now, then stop {_DIM}— ingest the new docs afterward{_RESET}")
-        print(f"    {_BOLD}d{_RESET}  discard it and ingest only the new docs")
-        try:
-            choice = input(f"\n  Choice? [{_BOLD}m{_RESET}] ").strip().lower()
-        except (EOFError, KeyboardInterrupt):
-            print()
+        print(f"  {_DIM}A new ingest resets it — what would you like to do?{_RESET}")
+        choice = interactive.pick(
+            [f"Merge it into this ingest {_DIM}— extract the new docs, then finalize everything together{_RESET}",
+             f"Finalize it now, then stop {_DIM}— ingest the new docs afterward{_RESET}",
+             "Discard it and ingest only the new docs"],
+            0, title="Pending batch")
+        if choice is interactive.CANCELLED:
             return
-        if choice in ("f", "finalize"):
+        if choice == 1:                        # finalize now, then stop
             out = _run_finalize(vault, post_model, post_effort, post_backend)
             if not (out.get("error") or out.get("briefing_error")):
                 print(f"  {_DIM}Now run {_RESET}{_CYAN}watchdog ingest{_RESET}{_DIM} for the queued documents.{_RESET}\n")
             return
-        if choice in ("d", "discard"):
+        if choice == 2:                        # discard
             wipe_pending = True
+            print(f"  {_DIM}Discarding the pending batch — ingesting only the new documents.{_RESET}")
         else:                                  # default: merge (non-destructive)
             wipe_pending = False
             print(f"  {_DIM}Merging the pending batch into this ingest.{_RESET}")
@@ -693,7 +704,7 @@ def cmd_ingest(args, *, confirm: bool = True, skip_preview: bool = False) -> Non
         est = cost_estimate(vault, result["queue_files"], _effective_extract_backend(extract_backend, a["mode"]))
         print(f"\n{_format_cost_estimate(est)}")
         print(_format_models_line(classify_backend, classify_model, extract_backend, extract_model,
-                                  post_backend, post_model))
+                                  post_backend, post_model, extract_effort, post_effort))
     elif batch_pending:
         print(f"\n  {_DIM}Checking on a pending batch extraction…{_RESET}")
 
@@ -737,7 +748,8 @@ def cmd_ingest(args, *, confirm: bool = True, skip_preview: bool = False) -> Non
     if confirm:
         if interactive.pick(["Ingest now", "Not now"], 0, title="Ingest now?") != 0:
             _release_lock()
-            print(f"\n  When ready, run:  {_CYAN}watchdog ingest{_RESET}\n")
+            # No leading blank line — pick()'s own close-out already leaves one (#411).
+            print(f"  When ready, run:  {_CYAN}watchdog ingest{_RESET}\n")
             return
 
     import asyncio
@@ -745,15 +757,30 @@ def cmd_ingest(args, *, confirm: bool = True, skip_preview: bool = False) -> Non
     log_path = vault / "log.md"
     if not log_path.exists():
         log_path.write_text(_render_template("log.md"))
+
+    # The block below is what a user sees right as extraction starts — reached either straight
+    # from this function's own "Ingest now?" pick() (confirm=True) or via _offer_ingest's pick()
+    # in the caller (confirm=False); either way a picker just closed and already left one blank
+    # line, so the first of these notices must not add its own leading "\n" on top of it (#411).
+    said_since_pick = False
+
+    def _say_since_pick(msg: str) -> None:
+        nonlocal said_since_pick
+        print((f"\n{msg}" if said_since_pick else msg))
+        said_since_pick = True
+
     if force:
-        print(f"\n  {_YELLOW}--force{_RESET}{_DIM}: re-extracting even where a cached extraction "
-              f"or a committed vault note already exists.{_RESET}")
+        _say_since_pick(f"  {_YELLOW}--force{_RESET}{_DIM}: re-extracting even where a cached "
+                        f"extraction or a committed vault note already exists.{_RESET}")
+    if no_finalize:
+        _say_since_pick(f"  {_DIM}--no-finalize: stopping after extraction — run {_RESET}"
+                        f"{_CYAN}watchdog finalize{_RESET}{_DIM} later to complete the batch.{_RESET}")
     if extract_backend == "claude-batch":
-        print(f"\n  {_DIM}claude-batch: sectioned documents (if any) extract via claude-api now; "
-              f"the rest submit as one batch and finish later.{_RESET}")
+        _say_since_pick(f"  {_DIM}claude-batch: sectioned documents (if any) extract via claude-api now; "
+                        f"the rest submit as one batch and finish later.{_RESET}")
     else:
-        print(f"\n  {_DIM}Extracting (≤{concurrency} parallel) — the model is called only for reasoning; "
-              f"the pipeline runs in Python.{_RESET}")
+        _say_since_pick(f"  {_DIM}Extracting (≤{concurrency} parallel) — the model is called only for "
+                        f"reasoning; the pipeline runs in Python.{_RESET}")
         print(f"  {_YELLOW}Large documents can take several minutes each{_RESET}{_DIM} — a long pause on a "
               f"row is normal, not a stall.{_RESET}")
         print(f"  {_DIM}Press {_RESET}{_CYAN}Ctrl+C{_RESET}{_DIM} to stop; finished documents are kept.{_RESET}\n")

--- a/src/watchdog/pipeline/orchestrate.py
+++ b/src/watchdog/pipeline/orchestrate.py
@@ -344,12 +344,31 @@ def _pages_text(pages: list[dict]) -> str:
     )
 
 
-def _candidates_checklist(text: str) -> str:
+def _candidates_checklist(text: str, *, vault: Path | None = None, sha: str | None = None,
+                          filename: str | None = None, flow: str = "") -> str:
     """Tier 0 candidate harvest (#361/D123): deterministic spans (money, figure, percent,
     date, docket) plus optional local-NER entities, rendered as the per-page checklist injected
     into the extraction prompt. `text` carries the same `<!-- PAGE N -->` markers as `_pages_text`
-    output (whole-document or one section's), so this works for both extraction paths."""
+    output (whole-document or one section's), so this works for both extraction paths.
+
+    `vault`/`sha`/`filename`/`flow`, when given, mark this step on the document's live in-flight
+    row before it runs and log its result to ingest.log after (#411) — GLiNER's local model load
+    + inference (`harvest_entities`) is the one step that can silently run for minutes on a long
+    document; without this the row just sat on "extracting…" the whole time, with no sign
+    anything was happening. Callers pass these only from the two hot, per-document extraction
+    paths (`_simple_extract`, `_extract_sectioned`) — the rarer batch-repair/submit paths omit
+    them and get the old silent behaviour, since they have no live per-document row today."""
+    if sha is not None:
+        tty = f"{_DIM}→  {filename}  {flow}{' · ' if flow else ''}harvesting candidates…{_RESET}"
+        plain = f"{_DIM}→  {filename}  harvesting candidates…{_RESET}"
+        if _board is not None:
+            _board.update(sha, f"  {tty}", f"  {plain}")
+        else:
+            _say(plain)
     candidates = harvest.harvest(text) + harvest.harvest_entities(harvest.split_pages(text))
+    if sha is not None and vault is not None:
+        n = len(candidates)
+        _log(vault, f"HARVEST {filename}: {n} candidate{'s' if n != 1 else ''}")
     return harvest.format_checklist(candidates)
 
 
@@ -501,9 +520,17 @@ async def _simple_extract(vault, sha, pf, skill_text, brief, model, skill_label,
                           effort=None, backend=None):
     """Whole-document extraction, with one repair attempt if post-flight rejects."""
     text = _pages_text(pf["pages"])
+    page_count = pf.get("page_count") or len(pf["pages"])
+    filename = pf["filename"]
+    flow = f"{page_count}p · {skill_label}"
     # GLiNER inference over every page can take minutes on a long document — run it off the
     # event loop so it doesn't stall every other concurrent document.
-    candidates = await asyncio.to_thread(_candidates_checklist, text)
+    candidates = await asyncio.to_thread(
+        _candidates_checklist, text, vault=vault, sha=sha, filename=filename, flow=flow)
+    # Restore the row to "extracting…" now that harvesting is done and the model call is next.
+    if _board is not None:
+        _board.update(sha, f"  {_DIM}→  {filename}  {flow} · extracting…{_RESET}",
+                      f"  {_DIM}→  {filename}  extracting…{_RESET}")
     base = prompts.build_extract_prompt(
         pages_text=text,
         skill_text=skill_text, sidecar=pf.get("sidecar"), brief=brief,
@@ -511,7 +538,6 @@ async def _simple_extract(vault, sha, pf, skill_text, brief, model, skill_label,
         file_metadata=pf.get("file_metadata", {}), processing=pf.get("processing", {}),
         candidates=candidates,
     )
-    page_count = pf.get("page_count") or len(pf["pages"])
     cost, errors, extraction, scratchpad = 0.0, [], {}, ""
     for _ in range(2):
         p = base if not errors else _append_repair_note(base, errors)
@@ -604,7 +630,13 @@ async def _extract_sectioned(vault, sha, pf, skill_text, plan, model, skill_labe
     for sec in sections:
         sec_text = (vault / sec["pages_path"]).read_text(encoding="utf-8")
         # Off the event loop — see the comment in `_simple_extract`.
-        candidates = await asyncio.to_thread(_candidates_checklist, sec_text)
+        candidates = await asyncio.to_thread(
+            _candidates_checklist, sec_text, vault=vault, sha=sha, filename=pf["filename"],
+            flow=sec["label"])
+        # Restore the row to "extracting…" now that harvesting is done and the model call is next.
+        if _board is not None:
+            _board.update(sha, f"  {_DIM}→  {pf['filename']}  {sec['label']} · extracting…{_RESET}",
+                          f"  {_DIM}→  {pf['filename']}  extracting…{_RESET}")
         prompt = prompts.build_section_prompt(
             pages_text=sec_text,
             skill_text=skill_text, carry_forward=carry, section_label=sec["label"],
@@ -765,13 +797,14 @@ async def _extract_document(vault: Path, sha: str, brief: str | None,
 
     if not ok:
         return _fail(vault, sha, filename, "post-flight rejected: " + "; ".join(errors[:3]))
-    return _finish_extraction(vault, sha, filename, extraction, scratchpad, cost, pf, warnings)
+    return _finish_extraction(vault, sha, filename, extraction, scratchpad, cost, pf, warnings,
+                              skill_label=skill_label)
 
 
 
 def _finish_extraction(vault: Path, sha: str, filename: str, extraction: dict, scratchpad: str,
-                       cost: float, pf: dict,
-                       warnings: list[str] | None = None) -> dict:
+                       cost: float, pf: dict, warnings: list[str] | None = None,
+                       skill_label: str | None = None) -> dict:
     """Shared tail once an extraction has passed post-flight: settle-print, warnings, log,
     persist `result_<sha>.json`. Used by both the synchronous per-document path
     (`_extract_document`) and the batch-collect path (`_finish_batch_item`, #214) so a
@@ -781,6 +814,10 @@ def _finish_extraction(vault: Path, sha: str, filename: str, extraction: dict, s
     printed here — after the OK line, not when post-flight ran — so they're tucked visually
     under this document's own row instead of landing wherever a concurrently-extracting
     document happened to be at the time (#333 follow-up).
+
+    `skill_label` (#411), when given, is the classified/pinned record skill — shown alongside the
+    page count and entity count so the completion line answers "what kind of document was this,
+    and how big" without a separate lookup.
 
     The queue file is deliberately *not* removed here any more (#403 phase 1): the vault has not
     been written yet at this point (post-flight only staged the extraction), and
@@ -794,10 +831,12 @@ def _finish_extraction(vault: Path, sha: str, filename: str, extraction: dict, s
     for stale in (vault / ".watchdog" / "tmp").glob(f"section_{sha}_*.md"):
         stale.unlink(missing_ok=True)
     n_entities = len(extraction.get("entities", []))
+    page_count = pf.get("page_count") or len(pf.get("pages", []))
+    type_bit = f" · {skill_label}" if skill_label else ""
     _settle(sha, f"  {_GREEN}OK{_RESET}  {filename}  "
-            f"{_DIM}{n_entities} entit{'ies' if n_entities != 1 else 'y'}{_RESET}  "
+            f"{_DIM}{page_count}p · {n_entities} entit{'ies' if n_entities != 1 else 'y'}{type_bit}{_RESET}  "
             f"{_CYAN}documents/{_doc_slug(filename)}{_RESET}")
-    _log(vault, f"OK {filename}: {n_entities} entities")
+    _log(vault, f"OK {filename}: {page_count}p, {n_entities} entities{type_bit}")
     for msg in (warnings or []):
         _say(f"   {_YELLOW}⚠{_RESET}  {_DIM}{msg}{_RESET}")
         _log(vault, f"WARN {filename}: {msg}")
@@ -891,7 +930,8 @@ async def _finish_batch_item(vault: Path, sha: str, item: dict | None, skill_tex
     ok, errors, warnings = _write_postflight(vault, sha, extraction)
     if not ok:
         return _fail(vault, sha, filename, "post-flight rejected: " + "; ".join(errors[:3]))
-    return _finish_extraction(vault, sha, filename, extraction, scratchpad, cost, pf, warnings)
+    return _finish_extraction(vault, sha, filename, extraction, scratchpad, cost, pf, warnings,
+                              skill_label=skill_label)
 
 
 
@@ -1829,6 +1869,21 @@ async def run(vault: Path, *, concurrency: int = DEFAULT_CONCURRENCY,
         # are already written to the vault; unfinished ones keep their queue file for resume.
         tasks[:] = [asyncio.ensure_future(_guarded(s)) for s in shas]
 
+        async def _tick_elapsed() -> None:
+            """Keep a pinned "elapsed MM:SS" row at the bottom of the live region while
+            extraction runs (#411) — a long pause on a dense document (minutes, not seconds,
+            #398) otherwise reads as a stall rather than normal progress."""
+            start = time.monotonic()
+            while True:
+                await asyncio.sleep(1)
+                elapsed = int(time.monotonic() - start)
+                _board.update("__elapsed__", f"  {_DIM}elapsed {elapsed // 60:02d}:{elapsed % 60:02d}{_RESET}",
+                              pin=True)
+
+        # Only on a real TTY — LiveRegion.update() falls back to plain append-only printing
+        # when disabled, which would spam a new line every second into logs/CI output.
+        timer_task = asyncio.ensure_future(_tick_elapsed()) if _board.enabled else None
+
         def _on_interrupt() -> None:
             if cancelled.is_set():
                 return
@@ -1854,6 +1909,12 @@ async def run(vault: Path, *, concurrency: int = DEFAULT_CONCURRENCY,
             with _board.capture_stderr():
                 await asyncio.gather(*tasks, return_exceptions=True)
         finally:
+            if timer_task is not None:
+                timer_task.cancel()
+                try:
+                    await timer_task
+                except asyncio.CancelledError:
+                    pass
             if handler_set:
                 loop.remove_signal_handler(signal.SIGINT)
             # Close the live region: extraction is done, so post-processing (sequential) and the


### PR DESCRIPTION
## Summary

Addresses all of the bundled `watchdog ingest` output fixes in #411:

- Drop the leftover blank line after the "Ingest now?" picker closes, matching the fix already applied to `watchdog setup` (#395)
- Replace the pending-finalization `m`/`f`/`d` text prompt with the arrow-key picker, merge still the default
- Note `--no-finalize` at the top of the ingest cycle when set (`--skip-briefing` isn't handled — that's #410, not implemented yet)
- Show a "harvesting candidates…" row (and log it to `ingest.log`) while GLiNER/harvest runs, instead of leaving the document parked on "extracting…" with no sign anything is happening
- Align the classifier/extractor/finalizer models block into a column and note reasoning effort when set
- Add page count and record-skill type to each document's OK line (terminal + log)
- Add a live "elapsed MM:SS" row to the extraction live region (TTY-only) so a long run doesn't read as a stall
- Fix `watchdog <cmd> -h`'s flag/description alignment, which broke once a flag+metavar ran past the old hardcoded 18-char column width

## Test plan

- [x] `pipx run ruff check src tests` — clean
- [x] Full suite: `pytest tests/` — 1592 passed, 2 skipped, 0 failed
- [x] Manual end-to-end run (mocked model) confirming the new harvest step, OK line, and log entries render correctly
- [x] Manual `watchdog ingest -h` check confirming column alignment

No `docs/`, `ARCHITECTURE.md`, or `DECISIONS.md` updates — everything here is terminal-output polish to existing behavior, not a new flag, config key, default, or workflow step.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01NBhgVWA2xdTUPz7R3Y3NGg