### PR TITLE
Add websites-html skill for web pages and HTML captures

### DIFF
--- a/docs/skills.md
+++ b/docs/skills.md
@@ -1,6 +1,6 @@
 # Skills
 
-Watchdog ships with domain knowledge for 32 document types — corporate filings, court documents, land registries, campaign finance returns, and more. This page explains what a skill is, how documents get matched to one, the full catalogue, and how to add your own. Read it if you want to know what Watchdog actually knows about your documents.
+Watchdog ships with domain knowledge for 33 document types — corporate filings, court documents, land registries, campaign finance returns, and more. This page explains what a skill is, how documents get matched to one, the full catalogue, and how to add your own. Read it if you want to know what Watchdog actually knows about your documents.
 
 ## What a skill is
 
@@ -72,6 +72,7 @@ Skills are jurisdiction-agnostic by default: universal principles come first, wi
 | [`dns-whois`](../src/watchdog/skills/records/dns-whois.md) | WHOIS records, DNS data, IP allocation, SSL certificate transparency logs |
 | [`news-clippings`](../src/watchdog/skills/records/news-clippings.md) | News articles, press releases, wire stories, corrections, retractions |
 | [`audio-video`](../src/watchdog/skills/records/audio-video.md) | YouTube transcripts, podcast transcripts, earnings calls, press conference recordings |
+| [`websites-html`](../src/watchdog/skills/records/websites-html.md) | Corporate and organizational websites, profile pages, forum posts, social media, blogs, marketplace and job listings, archived snapshots |
 
 ## Reading and pinning skills
 

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -72,7 +72,7 @@ Skills are jurisdiction-agnostic by default: universal principles come first, wi
 | [`dns-whois`](../src/watchdog/skills/records/dns-whois.md) | WHOIS records, DNS data, IP allocation, SSL certificate transparency logs |
 | [`news-clippings`](../src/watchdog/skills/records/news-clippings.md) | News articles, press releases, wire stories, corrections, retractions |
 | [`audio-video`](../src/watchdog/skills/records/audio-video.md) | YouTube transcripts, podcast transcripts, earnings calls, press conference recordings |
-| [`websites-html`](../src/watchdog/skills/records/websites-html.md) | Corporate and organizational websites, profile pages, forum posts, social media, blogs, marketplace and job listings, archived snapshots |
+| [`websites-html`](../src/watchdog/skills/records/websites-html.md) | Any HTML file or downloaded website page — both its presentation content and its underlying markup (tracking IDs, hidden elements, outbound links) |
 
 ## Reading and pinning skills
 

--- a/src/watchdog/skills/records/websites-html.md
+++ b/src/watchdog/skills/records/websites-html.md
@@ -1,20 +1,19 @@
 ---
-description: an HTML file or a downloaded/captured website page, of any kind
+description: an HTML file or a downloaded/captured website page
 ---
 # Domain knowledge — Websites and HTML pages
 
-This skill is loaded by Watchdog for any HTML document or captured website page — not only pages deposited into `_INCOMING/` by `watchdog research` or `watchdog fetch`, but any website page that enters the vault by any means. It does not cover news articles, wire stories, or press releases (see `news-clippings`), WHOIS/DNS/infrastructure records (see `dns-whois`), or audio/video transcripts (see `audio-video`) — those document types are owned by their own skills even when the underlying file is HTML.
+This skill is loaded by Watchdog for any HTML document or captured website page, including those deposited into `_INCOMING/` by `watchdog research` or `watchdog fetch`. It does not cover news articles, wire stories, or press releases (see `news-clippings`), WHOIS/DNS/infrastructure records (see `dns-whois`), or audio/video transcripts (see `audio-video`) — those document types are owned by their own skills even when the underlying file is HTML.
 
-An HTML document carries two layers a reporter can read: the **presentation content** (the text, images, and structure a visitor sees) and the **markup and code beneath it** (tags, scripts, comments, embedded identifiers, links). The second layer is at least as revealing as the first and is easy to skip past — this skill weights both.
+An HTML document carries two layers a reporter can read: the **presentation content** (the text, images, and structure a visitor sees) and the **markup and code beneath it** (tags, scripts, comments, embedded identifiers, links). The second layer can be revealing and is easy to skip over — this skill explores both.
 
 ---
 
 ## Document types covered
 
-- Any HTML file or web page, of any subject or purpose
+- Any HTML file or web page
 - Rendered (full browser/Chromium) or plain sanitized-fetch captures of a website
 - Archived or cached snapshots of a web page (Wayback Machine, archive.today, search-engine cache)
-- Website pages added to the vault by any means, not only through `watchdog research`/`watchdog fetch`
 
 ---
 
@@ -45,7 +44,7 @@ An HTML document carries two layers a reporter can read: the **presentation cont
 
 - **Analytics and tracking identifiers** — a Google Analytics measurement ID (`G-XXXXXXX`/`UA-XXXXXXXX`), a Google Tag Manager container ID (`GTM-XXXXXXX`), a Meta/Facebook Pixel ID, or any other tracking snippet's account ID is a stable identifier the page's markup carries whether or not the visible content mentions it. Record every such ID exactly as it appears. **The same ID appearing on two pages presented as unrelated sites or organizations is one of the strongest links available** — capture it and compare against the entity digest and against IDs seen on other captured pages.
 - **Platform or CMS fingerprint** — a `<meta name="generator">` tag, a template-specific path (`/wp-content/`, `/wp-json/`, a Substack or Squarespace asset URL, a Shopify CDN path), or boilerplate class names reveal what software built the site. Record the platform as stated; a claimed enterprise operation running on a template starter site, or two "independent" sites sharing an identical, uncommon template fingerprint, is worth flagging.
-- **Hidden or non-rendered content** — an element whose inline style or class sets it to not display (`display:none`, `visibility:hidden`, zero height/width, off-screen positioning), a hidden `<input>` field carrying a value, or text present in the markup that a visitor would never see. Record the hidden content verbatim and where it sits in the page; content authored for a reader but hidden from one (or authored for a search engine or bot but hidden from a human, i.e. cloaking) is itself a fact worth capturing, not something to explain away.
+- **Hidden or non-rendered content** — an element whose styling or class sets it to not display (`display:none`, `visibility:hidden`, zero height/width, off-screen positioning), a hidden `<input>` field carrying a value, or text present in the markup that a visitor would never see. Record the hidden content verbatim and where it sits in the page; content authored for a reader but hidden from one (or authored for a search engine or bot but hidden from a human, i.e. cloaking) is itself a fact worth capturing, not something to explain away.
 - **Outbound links across domains** — collect every hyperlink's destination domain. A page's outbound-link pattern (which domains it sends visitors to) can reveal an affiliate network, a syndication relationship, an advertising partner, or a shared operator behind pages that otherwise look unrelated. Record the set of external domains linked; a link target that recurs across pages already in the digest is a match worth flagging.
 - **HTML comments and leftover markup** — text inside `<!-- -->` comments is invisible to a visitor but present in the source: developer notes, TODOs, an earlier draft of a claim, or content commented out rather than deleted. Record any comment with substantive content.
 - **Meta tags that contradict the visible page** — a `robots` meta tag or header set to `noindex`/`nofollow` means the page's operator asked search engines not to surface it; combined with content that reads as intended for public visibility, this is worth recording as a stated fact about how the page was configured. Likewise record a `canonical` link element that points to a different URL than the one captured — it names what the page's own markup claims is the authoritative version.
@@ -95,8 +94,6 @@ An HTML document carries two layers a reporter can read: the **presentation cont
 3. **Organization → Place**: Address shown on the page
 4. **Website/Domain → Organization**: Stated or implied operator of the site (cross-reference the `dns-whois` skill for the registrant of the underlying domain)
 5. **Website → Website**: Outbound link to another domain (partner, affiliate, syndication, or advertising relationship)
-
-Use `→` notation. Include the relationship type after the colon.
 
 ---
 

--- a/src/watchdog/skills/records/websites-html.md
+++ b/src/watchdog/skills/records/websites-html.md
@@ -1,0 +1,127 @@
+---
+description: a captured web page — a corporate or organizational website, personal or professional profile, government agency page, online directory, forum post, social media post, blog, marketplace or job listing, or an archived/Wayback Machine snapshot of any of these
+---
+# Domain knowledge — Websites and HTML pages
+
+This skill is loaded by Watchdog when the document is a general web page captured via `watchdog research` or `watchdog fetch` — a corporate or organizational website, a personal or professional profile, a government agency page, an online directory, a forum post, a social media post, a blog, or a marketplace or job listing. It does not cover news articles, wire stories, or press releases (see `news-clippings`), WHOIS/DNS/infrastructure records (see `dns-whois`), or audio/video transcripts (see `audio-video`) — those document types are owned by their own skills even when captured through the same web-research pipeline.
+
+---
+
+## Document types covered
+
+- Corporate and organizational websites (About, Team, Contact, Products/Services pages)
+- Personal or professional profile and bio pages
+- Government or public-body web pages that are not themselves a filing, report, or transcript
+- Online directories and registries rendered as web pages (chamber-of-commerce listings, professional directories, business registries with a web front end)
+- Forum posts, message boards, and comment sections
+- Social media posts and profile pages
+- Blogs (personal, corporate, or advocacy — non-journalistic)
+- Marketplace and e-commerce listings
+- Job postings
+- Archived or cached snapshots of any of the above (Wayback Machine, archive.today, search-engine cache)
+
+---
+
+## Fields to extract
+
+| Field | What to look for |
+|-------|-----------------|
+| **Page title / headline** | The page's own title, as rendered or in its `<title>`/heading |
+| **Site or organization name** | The website's or account's stated owner or operator |
+| **URL** | The source URL — carried in the sidecar's `source` field |
+| **Page type** | About, Team, Contact, Product/Service, Forum post, Profile, Listing, Job posting, etc. |
+| **Author or poster** | Byline, username, or handle, if attributed |
+| **Publication / last-modified date** | Any date the page itself displays (post date, "last updated", copyright year) |
+| **Date captured** | The `obtained` date in the sidecar — when Watchdog fetched the page, distinct from any date on the page |
+| **Capture method** | The sidecar's `capture` field — `rendered` (full Chromium snapshot) or `plain` (script-stripped fetch); a `plain` capture may be missing JavaScript-loaded content |
+| **Archived snapshot** | The sidecar's `archived` field, if present — a Wayback Machine URL for this capture |
+| **Named individuals and roles** | Anyone named on the page, with their stated title or role |
+| **Contact details** | Address, phone number, email shown on the page |
+| **Claims made** | What the page asserts about the organization, product, or subject |
+| **Links to other documents** | Filings, reports, or other pages the page links to or cites |
+
+---
+
+## Red flags — what to look for
+
+### Provenance and capture
+
+- **This is a scraped secondary source, not a primary document** — a captured web page reflects what was published at the moment of capture, not necessarily what is true. Record the capture date (`obtained`) and treat the page's claims as attributed to the page, not established fact.
+- **Capture method may mean missing content** — when the sidecar's `capture` field is `plain` rather than `rendered`, dynamic content (a "load more" feed, a script-populated table, an embedded widget) may not appear in the captured text. Note when the visible content looks truncated or a described feature (a gallery, a list) is absent — this may be a capture limitation, not an absence on the live page.
+- **Page has an archived history** — when the sidecar carries an `archived` (Wayback Machine) field, record it; a captured page with a citable permanent snapshot is stronger provenance than one without.
+- **Retrieval path** — record the sidecar's `retrieved_by` (`research-mode` vs `fetch`) and `source_type` tag (official-registry, news, blog, forum, social, etc.) as given; these set the reliability frame the extractor already has, rather than something to redetermine from the page text.
+
+### Self-description and claims
+
+- **Self-published claims about the subject itself** — an "About Us" page, a company bio, or a profile describes its subject in its own words. Record what is claimed ("family owned since 1985", "no history of complaints", "industry-leading compliance") as a stated self-description, not a verified fact.
+- **Contact details matching or conflicting with the entity digest** — an address, phone number, or email on the page that matches a value already recorded on an entity in the digest is a strong link; one that conflicts with a value the digest already states for the same entity is worth recording as a contradiction. Both sides must be explicitly stated to count as a conflict.
+- **Team or leadership bios naming individuals not elsewhere in the vault** — capture each named person and their stated title; a name on a "leadership" or "team" page is often the first mention of someone worth a full profile.
+- **Testimonials, reviews, and endorsements** — record who or what is credited (a named person, "a satisfied customer", an unnamed reviewer) and what is claimed; the extractor cannot verify authenticity, so note anonymous or unverifiable attribution as such.
+
+### Web-specific patterns
+
+- **Look-alike branding or naming** — a site whose name, logo description, or copy closely mirrors a known organization (a government department, a bank, a well-known company) may be designed to look official when it isn't. This is visible in the page's own text and styling description; record the resemblance as stated.
+- **Anonymous or pseudonymous authorship** — forum posts, comments, and some blog posts carry only a username or handle. Record the handle as given; do not assume it identifies a real person unless the page itself states one.
+- **Job postings revealing operational detail** — a job posting can disclose expansion plans, new office locations, technology in use, headcount growth, or compensation bands that the organization doesn't state elsewhere. Record these as stated facts about the posting.
+- **Allegations in comments or forum replies** — a comment section or forum thread sometimes contains claims more direct than the page it's attached to (an accusation, an insider account). Record the claim and its unverified, anonymous or pseudonymous source; this is a lead, not a finding.
+- **Marketplace listing details** — price, seller identity, item condition, and location on a marketplace or e-commerce listing are often the only public trace of a transaction or asset; record them as stated.
+
+---
+
+## Terminology
+
+| Term | Meaning |
+|------|---------|
+| **Wayback Machine** | The Internet Archive's public web archive; stores dated snapshots of pages, useful for tracking how a page changed over time |
+| **Save Page Now (SPN2)** | The Wayback Machine's on-demand archiving API; Watchdog can use it to archive a source at capture time (see the sidecar's `archived` field) |
+| **Cache / cached page** | A search engine's or archiving tool's stored copy of a page, sometimes retrievable after the live page is edited or removed |
+| **Canonical URL** | The URL a page declares as its authoritative address, which may differ from the address it was actually fetched at |
+| **Open Graph tags / meta tags** | Structured metadata embedded in a page's HTML (title, description, image) used by social platforms and search engines, sometimes containing details not shown in the rendered page |
+| **Rendered capture** | A full browser (Chromium) snapshot of a page after scripts run, preserving JavaScript-loaded content; Watchdog's preferred capture mode |
+| **Plain capture** | A sanitized fetch of a page's raw HTML with scripts stripped but not executed; may miss content that only appears after a script runs |
+| **DOM** | Document Object Model — the structured representation of a page's content that a browser builds; what a rendered capture preserves |
+| **Permalink** | A stable, dedicated URL for one piece of content (a post, a comment) intended not to change |
+| **UGC (user-generated content)** | Content posted by a platform's users rather than its operator — forum posts, reviews, comments |
+| **Sock puppet** | A fake or secondary online identity used to post reviews, comments, or votes to create a false impression of independent support |
+| **Astroturfing** | Coordinated, often anonymous or pseudonymous online activity made to look like spontaneous grassroots opinion |
+
+---
+
+## Relationships to extract
+
+1. **Person → Organization**: Role or title stated on a team, staff, or "About" page
+2. **Organization → Place**: Address shown on a contact or "About" page
+3. **Person → Person**: Named together on the same page (co-authors, co-founders, quoted alongside one another)
+4. **Website/Domain → Organization**: Stated operator or publisher of the site (cross-reference the `dns-whois` skill for the registrant of the underlying domain)
+5. **Person → Document**: A document, filing, or report the page links to or cites
+
+Use `→` notation. Include the relationship type after the colon.
+
+---
+
+## What investigators typically miss
+
+1. **The Wayback Machine's full crawl history, not just one snapshot** — a single captured page is one moment; the Wayback Machine's calendar view of a URL can show when text, staff bios, or claims were added, changed, or quietly removed.
+2. **Search-engine or archive.today cache of a page since taken down** — a page that returns a 404 today may still be retrievable through a cache or a second archiving service, especially useful when a subject deletes a page shortly after being contacted.
+3. **Page metadata beneath the visible text** — meta tags, Open Graph data, and structured data (JSON-LD) can carry an author name, a publish date, or an internal document ID not shown in the rendered page; worth checking "view source" directly.
+4. **A site's sitemap or robots.txt** — these can reveal pages that exist but aren't linked from the visible navigation, including pages the operator would rather not surface.
+5. **Reverse image search on staff photos or logos** — a "team" page whose headshots are stock photography, or a logo copied from another organization, is a strong signal of a fabricated or shell front; this requires an image search the extractor cannot perform, so log it as a lead.
+6. **Template or copy reused across differently named sites** — near-identical design, boilerplate text, or even typos repeated across sites presented as unrelated organizations can indicate a network of fronts run by the same operator.
+7. **The domain's registration and hosting history** — a website's content is one layer; who registered and hosts the domain is a separate, often more revealing record, covered by the `dns-whois` skill.
+8. **Language and locale versions** — a multinational or foreign-linked organization's site often has versions in other languages that carry different, sometimes more candid, content than the English version.
+
+---
+
+## Sources and further reading
+
+### Practitioner and public interest
+
+- [Internet Archive Wayback Machine](https://web.archive.org) — Free, searchable web archive; the primary tool for viewing a page's history and recovering removed content
+- [archive.today](https://archive.ph) — Independent on-demand archiving service, useful as a second archive when the Wayback Machine lacks a snapshot or a site blocks its crawler
+
+### Journalism resources
+
+- [Bellingcat's Online Investigation Toolkit](https://bellingcat.gitbook.io/toolkit) — Community-maintained catalogue of OSINT tools, including web-archiving, reverse image search, and social media verification resources
+- [First Draft — Verifying Online Information](https://firstdraftnews.org/long-form-article/verifying-online-information/) — Practical guide to verifying web content, including provenance, authorship, and date checks
+
+**Notes on unsourced claims:** The observation that reused design templates or boilerplate text across differently branded sites can indicate a network of fronts (under *What investigators typically miss*) reflects practitioner experience from investigative reporting rather than a single citable source.

--- a/src/watchdog/skills/records/websites-html.md
+++ b/src/watchdog/skills/records/websites-html.md
@@ -1,24 +1,20 @@
 ---
-description: a captured web page — a corporate or organizational website, personal or professional profile, government agency page, online directory, forum post, social media post, blog, marketplace or job listing, or an archived/Wayback Machine snapshot of any of these
+description: an HTML file or a downloaded/captured website page, of any kind
 ---
 # Domain knowledge — Websites and HTML pages
 
-This skill is loaded by Watchdog when the document is a general web page captured via `watchdog research` or `watchdog fetch` — a corporate or organizational website, a personal or professional profile, a government agency page, an online directory, a forum post, a social media post, a blog, or a marketplace or job listing. It does not cover news articles, wire stories, or press releases (see `news-clippings`), WHOIS/DNS/infrastructure records (see `dns-whois`), or audio/video transcripts (see `audio-video`) — those document types are owned by their own skills even when captured through the same web-research pipeline.
+This skill is loaded by Watchdog for any HTML document or captured website page — not only pages deposited into `_INCOMING/` by `watchdog research` or `watchdog fetch`, but any website page that enters the vault by any means. It does not cover news articles, wire stories, or press releases (see `news-clippings`), WHOIS/DNS/infrastructure records (see `dns-whois`), or audio/video transcripts (see `audio-video`) — those document types are owned by their own skills even when the underlying file is HTML.
+
+An HTML document carries two layers a reporter can read: the **presentation content** (the text, images, and structure a visitor sees) and the **markup and code beneath it** (tags, scripts, comments, embedded identifiers, links). The second layer is at least as revealing as the first and is easy to skip past — this skill weights both.
 
 ---
 
 ## Document types covered
 
-- Corporate and organizational websites (About, Team, Contact, Products/Services pages)
-- Personal or professional profile and bio pages
-- Government or public-body web pages that are not themselves a filing, report, or transcript
-- Online directories and registries rendered as web pages (chamber-of-commerce listings, professional directories, business registries with a web front end)
-- Forum posts, message boards, and comment sections
-- Social media posts and profile pages
-- Blogs (personal, corporate, or advocacy — non-journalistic)
-- Marketplace and e-commerce listings
-- Job postings
-- Archived or cached snapshots of any of the above (Wayback Machine, archive.today, search-engine cache)
+- Any HTML file or web page, of any subject or purpose
+- Rendered (full browser/Chromium) or plain sanitized-fetch captures of a website
+- Archived or cached snapshots of a web page (Wayback Machine, archive.today, search-engine cache)
+- Website pages added to the vault by any means, not only through `watchdog research`/`watchdog fetch`
 
 ---
 
@@ -26,45 +22,48 @@ This skill is loaded by Watchdog when the document is a general web page capture
 
 | Field | What to look for |
 |-------|-----------------|
-| **Page title / headline** | The page's own title, as rendered or in its `<title>`/heading |
-| **Site or organization name** | The website's or account's stated owner or operator |
-| **URL** | The source URL — carried in the sidecar's `source` field |
-| **Page type** | About, Team, Contact, Product/Service, Forum post, Profile, Listing, Job posting, etc. |
-| **Author or poster** | Byline, username, or handle, if attributed |
-| **Publication / last-modified date** | Any date the page itself displays (post date, "last updated", copyright year) |
-| **Date captured** | The `obtained` date in the sidecar — when Watchdog fetched the page, distinct from any date on the page |
+| **Page title** | The page's own title, as rendered or in its `<title>` element |
+| **Site or organization name** | The website's stated owner, operator, or account name |
+| **URL** | The source URL — carried in the sidecar's `source` field, or a `canonical` link element in the markup |
+| **Author or poster** | Byline, username, handle, or `author` meta tag, if present |
+| **Publication / last-modified date** | Any date the page displays, or a date in its metadata (`article:published_time`, `article:modified_time`, copyright year) |
+| **Date captured** | The `obtained` date in the sidecar — when Watchdog fetched the page, distinct from any date on or in the page |
 | **Capture method** | The sidecar's `capture` field — `rendered` (full Chromium snapshot) or `plain` (script-stripped fetch); a `plain` capture may be missing JavaScript-loaded content |
 | **Archived snapshot** | The sidecar's `archived` field, if present — a Wayback Machine URL for this capture |
-| **Named individuals and roles** | Anyone named on the page, with their stated title or role |
-| **Contact details** | Address, phone number, email shown on the page |
-| **Claims made** | What the page asserts about the organization, product, or subject |
-| **Links to other documents** | Filings, reports, or other pages the page links to or cites |
+| **Platform / generator** | A CMS or site-builder fingerprint visible in the markup — a `generator` meta tag, a platform-specific asset path (`/wp-content/`, `/cdn.shopify.com/`), or template markers |
+| **Tracking and analytics identifiers** | Any analytics, tag-manager, or pixel ID embedded in the page (see red flags below) |
+| **Outbound links** | Every hyperlink target, grouped by destination domain |
+| **Hidden or non-rendered elements** | Any element the markup itself marks as not meant to be seen (see red flags below) |
+| **Embedded structured data** | `JSON-LD`, Open Graph, or other structured metadata blocks in the `<head>` |
+| **Claims made** | What the page's text asserts about its subject |
 
 ---
 
 ## Red flags — what to look for
 
+### Markup and code
+
+- **Analytics and tracking identifiers** — a Google Analytics measurement ID (`G-XXXXXXX`/`UA-XXXXXXXX`), a Google Tag Manager container ID (`GTM-XXXXXXX`), a Meta/Facebook Pixel ID, or any other tracking snippet's account ID is a stable identifier the page's markup carries whether or not the visible content mentions it. Record every such ID exactly as it appears. **The same ID appearing on two pages presented as unrelated sites or organizations is one of the strongest links available** — capture it and compare against the entity digest and against IDs seen on other captured pages.
+- **Platform or CMS fingerprint** — a `<meta name="generator">` tag, a template-specific path (`/wp-content/`, `/wp-json/`, a Substack or Squarespace asset URL, a Shopify CDN path), or boilerplate class names reveal what software built the site. Record the platform as stated; a claimed enterprise operation running on a template starter site, or two "independent" sites sharing an identical, uncommon template fingerprint, is worth flagging.
+- **Hidden or non-rendered content** — an element whose inline style or class sets it to not display (`display:none`, `visibility:hidden`, zero height/width, off-screen positioning), a hidden `<input>` field carrying a value, or text present in the markup that a visitor would never see. Record the hidden content verbatim and where it sits in the page; content authored for a reader but hidden from one (or authored for a search engine or bot but hidden from a human, i.e. cloaking) is itself a fact worth capturing, not something to explain away.
+- **Outbound links across domains** — collect every hyperlink's destination domain. A page's outbound-link pattern (which domains it sends visitors to) can reveal an affiliate network, a syndication relationship, an advertising partner, or a shared operator behind pages that otherwise look unrelated. Record the set of external domains linked; a link target that recurs across pages already in the digest is a match worth flagging.
+- **HTML comments and leftover markup** — text inside `<!-- -->` comments is invisible to a visitor but present in the source: developer notes, TODOs, an earlier draft of a claim, or content commented out rather than deleted. Record any comment with substantive content.
+- **Meta tags that contradict the visible page** — a `robots` meta tag or header set to `noindex`/`nofollow` means the page's operator asked search engines not to surface it; combined with content that reads as intended for public visibility, this is worth recording as a stated fact about how the page was configured. Likewise record a `canonical` link element that points to a different URL than the one captured — it names what the page's own markup claims is the authoritative version.
+- **Embedded third-party scripts and widgets** — a chat widget (Intercom, Zendesk, Drift), a payment processor (Stripe, PayPal), or an ad network's script tag names a vendor relationship the visible page may not mention. Record the vendor and any account/site ID the embed carries.
+- **Inline data blobs** — some pages embed a JSON blob directly in a `<script>` tag (e.g. a `window.__INITIAL_STATE__` or similar bootstrap object) carrying structured data — internal IDs, API endpoints, or content not otherwise rendered. Record anything substantive found there.
+
 ### Provenance and capture
 
 - **This is a scraped secondary source, not a primary document** — a captured web page reflects what was published at the moment of capture, not necessarily what is true. Record the capture date (`obtained`) and treat the page's claims as attributed to the page, not established fact.
-- **Capture method may mean missing content** — when the sidecar's `capture` field is `plain` rather than `rendered`, dynamic content (a "load more" feed, a script-populated table, an embedded widget) may not appear in the captured text. Note when the visible content looks truncated or a described feature (a gallery, a list) is absent — this may be a capture limitation, not an absence on the live page.
-- **Page has an archived history** — when the sidecar carries an `archived` (Wayback Machine) field, record it; a captured page with a citable permanent snapshot is stronger provenance than one without.
-- **Retrieval path** — record the sidecar's `retrieved_by` (`research-mode` vs `fetch`) and `source_type` tag (official-registry, news, blog, forum, social, etc.) as given; these set the reliability frame the extractor already has, rather than something to redetermine from the page text.
+- **Capture method may mean missing content** — when the sidecar's `capture` field is `plain` rather than `rendered`, dynamic content (a script-populated table, a "load more" feed, an embedded widget) may not appear in the captured markup. Note when visible content looks truncated, or a described feature is absent — this may be a capture limitation, not an absence on the live page.
+- **Retrieval path** — record the sidecar's `retrieved_by` (`research-mode` vs `fetch`) and `source_type` tag, where present, as given; these set the reliability frame the extractor already has, rather than something to redetermine from the page text.
 
-### Self-description and claims
+### Presentation content
 
-- **Self-published claims about the subject itself** — an "About Us" page, a company bio, or a profile describes its subject in its own words. Record what is claimed ("family owned since 1985", "no history of complaints", "industry-leading compliance") as a stated self-description, not a verified fact.
+- **Self-published claims about the subject itself** — a page describes its subject in its own words. Record what is claimed as a stated self-description, not a verified fact.
 - **Contact details matching or conflicting with the entity digest** — an address, phone number, or email on the page that matches a value already recorded on an entity in the digest is a strong link; one that conflicts with a value the digest already states for the same entity is worth recording as a contradiction. Both sides must be explicitly stated to count as a conflict.
-- **Team or leadership bios naming individuals not elsewhere in the vault** — capture each named person and their stated title; a name on a "leadership" or "team" page is often the first mention of someone worth a full profile.
-- **Testimonials, reviews, and endorsements** — record who or what is credited (a named person, "a satisfied customer", an unnamed reviewer) and what is claimed; the extractor cannot verify authenticity, so note anonymous or unverifiable attribution as such.
-
-### Web-specific patterns
-
-- **Look-alike branding or naming** — a site whose name, logo description, or copy closely mirrors a known organization (a government department, a bank, a well-known company) may be designed to look official when it isn't. This is visible in the page's own text and styling description; record the resemblance as stated.
-- **Anonymous or pseudonymous authorship** — forum posts, comments, and some blog posts carry only a username or handle. Record the handle as given; do not assume it identifies a real person unless the page itself states one.
-- **Job postings revealing operational detail** — a job posting can disclose expansion plans, new office locations, technology in use, headcount growth, or compensation bands that the organization doesn't state elsewhere. Record these as stated facts about the posting.
-- **Allegations in comments or forum replies** — a comment section or forum thread sometimes contains claims more direct than the page it's attached to (an accusation, an insider account). Record the claim and its unverified, anonymous or pseudonymous source; this is a lead, not a finding.
-- **Marketplace listing details** — price, seller identity, item condition, and location on a marketplace or e-commerce listing are often the only public trace of a transaction or asset; record them as stated.
+- **Named individuals** — capture each person named on the page and their stated title or role; a name on a page is often the first mention of someone worth a full profile.
+- **Anonymous or pseudonymous authorship** — a post, comment, or listing that carries only a username or handle. Record the handle as given; do not assume it identifies a real person unless the page itself states one.
 
 ---
 
@@ -72,28 +71,30 @@ This skill is loaded by Watchdog when the document is a general web page capture
 
 | Term | Meaning |
 |------|---------|
-| **Wayback Machine** | The Internet Archive's public web archive; stores dated snapshots of pages, useful for tracking how a page changed over time |
-| **Save Page Now (SPN2)** | The Wayback Machine's on-demand archiving API; Watchdog can use it to archive a source at capture time (see the sidecar's `archived` field) |
-| **Cache / cached page** | A search engine's or archiving tool's stored copy of a page, sometimes retrievable after the live page is edited or removed |
-| **Canonical URL** | The URL a page declares as its authoritative address, which may differ from the address it was actually fetched at |
-| **Open Graph tags / meta tags** | Structured metadata embedded in a page's HTML (title, description, image) used by social platforms and search engines, sometimes containing details not shown in the rendered page |
+| **DOM** | Document Object Model — the structured tree of elements a browser builds from a page's markup; what a rendered capture preserves |
 | **Rendered capture** | A full browser (Chromium) snapshot of a page after scripts run, preserving JavaScript-loaded content; Watchdog's preferred capture mode |
 | **Plain capture** | A sanitized fetch of a page's raw HTML with scripts stripped but not executed; may miss content that only appears after a script runs |
-| **DOM** | Document Object Model — the structured representation of a page's content that a browser builds; what a rendered capture preserves |
-| **Permalink** | A stable, dedicated URL for one piece of content (a post, a comment) intended not to change |
+| **Generator meta tag** | A `<meta name="generator">` element some CMS/site builders add automatically, naming the software that produced the page |
+| **Google Analytics ID / GA4 measurement ID** | An identifier (`UA-XXXXXXXX` or `G-XXXXXXX`) tying a page's traffic data to a specific Google Analytics account; the same ID across sites indicates the same account holder |
+| **Google Tag Manager (GTM) container ID** | An identifier (`GTM-XXXXXXX`) for a tag-management container; like an analytics ID, shared use across sites is a strong operator link |
+| **Meta/Facebook Pixel** | Meta's tracking snippet, identified by a numeric Pixel ID, used for ad targeting and conversion tracking |
+| **Canonical link** | A `<link rel="canonical">` element declaring the URL a page considers its authoritative address, which may differ from the address actually fetched |
+| **Robots meta tag / noindex / nofollow** | Markup instructing search engines whether to index a page or follow its links; `noindex` signals the operator did not want the page found through search |
+| **Cloaking** | Serving different content to search engines/bots than to human visitors, or hiding content from visitors while leaving it in the markup — a technique associated with SEO manipulation |
+| **Open Graph tags** | Meta tags (`og:title`, `og:image`, etc.) that control how a page appears when shared on social platforms, sometimes containing details not shown in the rendered page |
+| **JSON-LD** | Structured data embedded in a `<script type="application/ld+json">` block, machine-readable metadata about the page's content |
+| **Wayback Machine** | The Internet Archive's public web archive; stores dated snapshots of pages, useful for tracking how a page changed over time |
 | **UGC (user-generated content)** | Content posted by a platform's users rather than its operator — forum posts, reviews, comments |
-| **Sock puppet** | A fake or secondary online identity used to post reviews, comments, or votes to create a false impression of independent support |
-| **Astroturfing** | Coordinated, often anonymous or pseudonymous online activity made to look like spontaneous grassroots opinion |
 
 ---
 
 ## Relationships to extract
 
-1. **Person → Organization**: Role or title stated on a team, staff, or "About" page
-2. **Organization → Place**: Address shown on a contact or "About" page
-3. **Person → Person**: Named together on the same page (co-authors, co-founders, quoted alongside one another)
-4. **Website/Domain → Organization**: Stated operator or publisher of the site (cross-reference the `dns-whois` skill for the registrant of the underlying domain)
-5. **Person → Document**: A document, filing, or report the page links to or cites
+1. **Website → Website**: Shared analytics/tracking identifier, embedded-script vendor, or generator/template fingerprint (a markup-level match between two otherwise unrelated pages)
+2. **Person → Organization**: Role or title stated on the page
+3. **Organization → Place**: Address shown on the page
+4. **Website/Domain → Organization**: Stated or implied operator of the site (cross-reference the `dns-whois` skill for the registrant of the underlying domain)
+5. **Website → Website**: Outbound link to another domain (partner, affiliate, syndication, or advertising relationship)
 
 Use `→` notation. Include the relationship type after the colon.
 
@@ -101,14 +102,14 @@ Use `→` notation. Include the relationship type after the colon.
 
 ## What investigators typically miss
 
-1. **The Wayback Machine's full crawl history, not just one snapshot** — a single captured page is one moment; the Wayback Machine's calendar view of a URL can show when text, staff bios, or claims were added, changed, or quietly removed.
-2. **Search-engine or archive.today cache of a page since taken down** — a page that returns a 404 today may still be retrievable through a cache or a second archiving service, especially useful when a subject deletes a page shortly after being contacted.
-3. **Page metadata beneath the visible text** — meta tags, Open Graph data, and structured data (JSON-LD) can carry an author name, a publish date, or an internal document ID not shown in the rendered page; worth checking "view source" directly.
-4. **A site's sitemap or robots.txt** — these can reveal pages that exist but aren't linked from the visible navigation, including pages the operator would rather not surface.
-5. **Reverse image search on staff photos or logos** — a "team" page whose headshots are stock photography, or a logo copied from another organization, is a strong signal of a fabricated or shell front; this requires an image search the extractor cannot perform, so log it as a lead.
-6. **Template or copy reused across differently named sites** — near-identical design, boilerplate text, or even typos repeated across sites presented as unrelated organizations can indicate a network of fronts run by the same operator.
-7. **The domain's registration and hosting history** — a website's content is one layer; who registered and hosts the domain is a separate, often more revealing record, covered by the `dns-whois` skill.
-8. **Language and locale versions** — a multinational or foreign-linked organization's site often has versions in other languages that carry different, sometimes more candid, content than the English version.
+1. **Reading the raw markup, not just the rendered page** — view-source (or the equivalent in a captured file) surfaces analytics IDs, hidden elements, comments, and platform fingerprints that never appear in the rendered text a casual reading captures.
+2. **A shared analytics or tag-manager ID across "unrelated" sites** — this is one of the most reliable ways to tie a network of seemingly independent websites to a single operator, and it requires nothing more than comparing an ID string across pages.
+3. **The Wayback Machine's full crawl history, not just one snapshot** — a single captured page is one moment; a URL's calendar view can show when text, markup, or tracking tags were added, changed, or quietly removed.
+4. **Search-engine or archive.today cache of a page since taken down** — a page that 404s today may still be retrievable through a cache or a second archiving service, especially useful when a subject deletes a page shortly after being contacted.
+5. **A site's sitemap or robots.txt** — these can reveal pages that exist but aren't linked from the visible navigation, including pages the operator marked `noindex` or would rather not surface.
+6. **Reverse image search on photos or logos** — a page whose images are stock photography, or a logo copied from another organization, is a strong signal the extractor cannot verify itself; this requires an image search, so log it as a lead.
+7. **Template or markup reused across differently named sites** — near-identical generator fingerprints, class names, or even code comments repeated across sites presented as unrelated organizations can indicate a network of fronts run by the same operator.
+8. **The domain's registration and hosting history** — a page's markup is one layer; who registered and hosts the domain is a separate, often more revealing record, covered by the `dns-whois` skill.
 
 ---
 
@@ -118,10 +119,11 @@ Use `→` notation. Include the relationship type after the colon.
 
 - [Internet Archive Wayback Machine](https://web.archive.org) — Free, searchable web archive; the primary tool for viewing a page's history and recovering removed content
 - [archive.today](https://archive.ph) — Independent on-demand archiving service, useful as a second archive when the Wayback Machine lacks a snapshot or a site blocks its crawler
+- [BuiltWith](https://builtwith.com) — Technology-profiling tool that identifies a site's CMS, analytics, and tracking tags from its markup; useful for confirming a platform fingerprint or comparing tracking IDs across domains
 
 ### Journalism resources
 
 - [Bellingcat's Online Investigation Toolkit](https://bellingcat.gitbook.io/toolkit) — Community-maintained catalogue of OSINT tools, including web-archiving, reverse image search, and social media verification resources
 - [First Draft — Verifying Online Information](https://firstdraftnews.org/long-form-article/verifying-online-information/) — Practical guide to verifying web content, including provenance, authorship, and date checks
 
-**Notes on unsourced claims:** The observation that reused design templates or boilerplate text across differently branded sites can indicate a network of fronts (under *What investigators typically miss*) reflects practitioner experience from investigative reporting rather than a single citable source.
+**Notes on unsourced claims:** The observation that a shared analytics/tag-manager ID or reused template markup across differently branded sites can indicate a single operator or a network of fronts (under *Markup and code* and *What investigators typically miss*) reflects a technique documented in open-source investigation practice (e.g. Bellingcat's toolkit) rather than a single canonical citation.


### PR DESCRIPTION
Adds a new record skill for general web pages captured via `watchdog research` or `watchdog fetch`, covering corporate websites, profiles, forums, social media, blogs, marketplace listings, and job postings.

## Changes

- **New skill**: `src/watchdog/skills/records/websites-html.md` — comprehensive domain knowledge for web page extraction, including:
  - Document types covered (corporate sites, profiles, forums, social media, blogs, marketplace listings, job postings, archived snapshots)
  - Fields to extract (page title, site name, URL, page type, author, dates, capture method, named individuals, contact details, claims, linked documents)
  - Red flags specific to web provenance (capture method limitations, self-published claims, look-alike branding, anonymous authorship, allegations in comments)
  - Terminology (Wayback Machine, rendered vs. plain captures, Open Graph tags, sock puppets, astroturfing)
  - Relationships to extract (person→organization, organization→place, website→organization)
  - Common investigator oversights (Wayback history, cached pages, page metadata, sitemaps, reverse image search, template reuse, domain registration history, language versions)
  - Sources and further reading

- **Updated documentation**: `docs/skills.md` — incremented skill count from 32 to 33 and added the new skill to the catalogue table

The skill distinguishes web pages from news articles (covered by `news-clippings`), infrastructure records (covered by `dns-whois`), and transcripts (covered by `audio-video`), and emphasizes the distinction between captured content (a secondary source reflecting one moment in time) and live truth.

https://claude.ai/code/session_01P7Vm1iWLG9xhEhGB2WV7Vi