### PR TITLE
Fix dig output copy and GLiNER stderr leaks

### DIFF
--- a/src/watchdog/cmd/ingest.py
+++ b/src/watchdog/cmd/ingest.py
@@ -152,7 +152,7 @@ def _effective_extract_backend(extract_backend: str | None, auth_mode: str) -> s
 
 def _format_models_line(classify_backend, classify_model, extract_backend, extract_model,
                         post_backend, post_model, extract_effort=None, post_effort=None,
-                        finalizer_overrides=None) -> str:
+                        finalizer_overrides=None, concurrency=None) -> str:
     """Which model runs each ingest stage — printed alongside the cost estimate before an
     ingest starts, so a run under a non-default provider (#325) is obvious up front instead of
     the older generic 'Using the configured provider(s).' notice. Stage names are padded to a
@@ -161,7 +161,11 @@ def _format_models_line(classify_backend, classify_model, extract_backend, extra
 
     `finalizer_overrides` (#433) adds one extra row per post-ingest stage whose resolved
     model/backend differs from the aggregate finalizer row — an unoverridden stage (the common
-    case) stays folded into the single "finalizer" line rather than repeating it four times."""
+    case) stays folded into the single "finalizer" line rather than repeating it four times.
+
+    `concurrency` (#456), when given, is the raw `--concurrency` value the user explicitly
+    passed — omitted (None) when a run falls back to the config/default value, so this row
+    only appears when it actually reflects a deliberate choice rather than a fixed default."""
     def label(backend, model):
         return f"{backend}:{model}" if backend else model
     stages = [("classifier", classify_backend, classify_model, None),
@@ -173,10 +177,14 @@ def _format_models_line(classify_backend, classify_model, extract_backend, extra
         if (b, m) != (post_backend, post_model):
             stages.append((f"finalizer:{stage}", b, m, post_effort))
     width = max(len(name) for name, *_ in stages)
+    if concurrency is not None:
+        width = max(width, len("concurrency"))
     lines = []
     for name, b, m, effort in stages:
         suffix = f" {_DIM}(effort: {effort}){_RESET}" if effort else ""
         lines.append(f"  {_DIM}{name:<{width}}{_RESET} {_CYAN}{label(b, m)}{_RESET}{suffix}")
+    if concurrency is not None:
+        lines.append(f"  {_DIM}{'concurrency':<{width}}{_RESET} {_CYAN}{concurrency}{_RESET}")
     return "\n".join(lines)
 
 
@@ -211,7 +219,8 @@ def _preview_ingest(vault: Path, args) -> tuple[str, str] | None:
     est = cost_estimate(vault, queue_files, _effective_extract_backend(extract_backend, auth_mode))
     models_line = _format_models_line(classify_backend, classify_model,
                                       extract_backend, extract_model, post_backend, post_model,
-                                      extract_effort, post_effort, finalizer_overrides)
+                                      extract_effort, post_effort, finalizer_overrides,
+                                      concurrency=getattr(args, "concurrency", None))
     return _format_cost_estimate(est), models_line
 
 
@@ -773,8 +782,16 @@ def cmd_ingest(args, *, confirm: bool = True, skip_preview: bool = False) -> Non
         detail = f" {_DIM}({', '.join(bits)}){_RESET}" if bits else ""
         print(f"\n  {_YELLOW}A previous batch is pending finalization{_RESET}{detail}{_DIM}.{_RESET}")
         print(f"  {_DIM}A new ingest resets it — what would you like to do?{_RESET}")
+        # `dig` never finalizes in the same run it's invoked from — "then finalize everything
+        # together" would be wrong there, since merging just carries the old batch's state
+        # forward for a later `watchdog bark` (#456).
+        merge_label = (
+            f"Merge it into this ingest {_DIM}— extract the new docs; a later "
+            f"{_RESET}{_CYAN}watchdog bark{_RESET}{_DIM} finalizes both batches together{_RESET}"
+            if pipeline_hint == "watchdog dig" else
+            f"Merge it into this ingest {_DIM}— extract the new docs, then finalize everything together{_RESET}")
         choice = interactive.pick(
-            [f"Merge it into this ingest {_DIM}— extract the new docs, then finalize everything together{_RESET}",
+            [merge_label,
              f"Finalize it now, then stop {_DIM}— ingest the new docs afterward{_RESET}",
              "Discard it and ingest only the new docs"],
             0, title="Pending batch")
@@ -833,7 +850,7 @@ def cmd_ingest(args, *, confirm: bool = True, skip_preview: bool = False) -> Non
         print(f"\n{_format_cost_estimate(est)}")
         print(_format_models_line(classify_backend, classify_model, extract_backend, extract_model,
                                   post_backend, post_model, extract_effort, post_effort,
-                                  finalizer_overrides))
+                                  finalizer_overrides, concurrency=getattr(args, "concurrency", None)))
     elif batch_pending:
         print(f"\n  {_DIM}Checking on a pending batch extraction…{_RESET}")
 
@@ -903,8 +920,11 @@ def cmd_ingest(args, *, confirm: bool = True, skip_preview: bool = False) -> Non
         _say_since_pick(f"  {_YELLOW}--force{_RESET}{_DIM}: re-extracting even where a cached "
                         f"extraction or a committed vault note already exists.{_RESET}")
     if no_finalize:
-        _say_since_pick(f"  {_DIM}--no-finalize: stopping after extraction — run {_RESET}"
-                        f"{_CYAN}watchdog bark{_RESET}{_DIM} later to complete the batch.{_RESET}")
+        # `no_finalize` is only ever set by `cmd_extract` (dig) — there is no user-facing
+        # `--no-finalize` flag to reference here (#456).
+        _say_since_pick(f"  {_DIM}Running {_RESET}{_CYAN}watchdog dig{_RESET}{_DIM} and stopping "
+                        f"after extraction — run {_RESET}{_CYAN}watchdog bark{_RESET}{_DIM} later "
+                        f"to complete the batch.{_RESET}")
     if extract_backend == "claude-batch":
         _say_since_pick(f"  {_DIM}claude-batch: sectioned documents (if any) extract via claude-api now; "
                         f"the rest submit as one batch and finish later.{_RESET}")
@@ -1026,7 +1046,7 @@ def _print_ingest_summary(summary: dict, pipeline_hint: str = "watchdog") -> Non
               f"{_DIM}({_RESET}{_BOLD}{ext}{_RESET}{_DIM} document{'s' if ext != 1 else ''} on disk).{_RESET}")
         print(f"  {_DIM}Finalize when ready — run it once for the vault as-is, or copy the vault "
               f"folder to try more than one finalizer:{_RESET}")
-        print(f"  {_CYAN}watchdog bark{_RESET}{_DIM} [--finalizer-model MODEL]{_RESET}\n")
+        print(f"  {_CYAN}watchdog bark{_RESET}\n")
     else:
         print(f"\n  {_DIM}Open a fresh Claude Code session to ask investigation questions.{_RESET}\n")
 

--- a/src/watchdog/pipeline/harvest.py
+++ b/src/watchdog/pipeline/harvest.py
@@ -16,6 +16,7 @@ any model failure degrades to an empty list rather than breaking ingest.
 
 import contextlib
 import io
+import os
 import re
 import warnings
 
@@ -226,26 +227,46 @@ _GLINER_WINDOW_OVERLAP = 50
 _gliner_model = None   # module-level singleton — loaded once per process
 
 
+@contextlib.contextmanager
+def _quiet_stderr():
+    """Suppress stderr at the OS file-descriptor level for the duration of the block, on top of
+    whatever Python-level suppression (`redirect_stderr`, `warnings` filters) the caller also has
+    active. `contextlib.redirect_stderr` only swaps Python's `sys.stderr` object; huggingface_hub's
+    own logging handler doesn't consult it — it holds a direct reference to the real stream,
+    captured at import time — so its "unauthenticated requests" notice writes straight past
+    redirect_stderr regardless of the warnings/logging filters in effect (#456). An fd-level
+    dup2 catches that write no matter which mechanism produced it."""
+    saved_fd = os.dup(2)
+    devnull_fd = os.open(os.devnull, os.O_WRONLY)
+    try:
+        os.dup2(devnull_fd, 2)
+        yield
+    finally:
+        os.dup2(saved_fd, 2)
+        os.close(devnull_fd)
+        os.close(saved_fd)
+
+
 def _load_gliner():
     global _gliner_model
     if _gliner_model is None:
         # Verify the model download via the OS trust store rather than certifi's bundled list —
         # same corporate-proxy fix as D122. `inject_into_ssl` patches the global `ssl` module,
         # so it's scoped to just this one-time load via `finally` (harmless no-op when cached).
-        import os
         import truststore
-        # The load prints hub progress bars to stderr even on a cache hit; ingest's terminal
-        # output is user-facing, so keep them out of it. `from_pretrained` also emits a
-        # load-time UserWarning (resume_download deprecation) and an unauthenticated-requests
-        # notice via huggingface_hub's own logging — neither is a predict-time warning, so
-        # they slip past harvest_entities' own catch_warnings (#419). redirect_stderr catches
-        # both regardless of which mechanism raises them, same pattern as setup_cmd's model
-        # downloads.
         os.environ.setdefault("HF_HUB_DISABLE_PROGRESS_BARS", "1")
+        # Ignored permanently, not just for this load call: harvest_entities runs concurrently
+        # across documents via asyncio.to_thread, and a scoped `warnings.catch_warnings()` context
+        # per predict() call (the previous approach) is documented as not thread-safe — concurrent
+        # enter/exit pairs race on the shared global filter list, letting a truncation warning from
+        # one thread leak out when another thread's context has already restored it (#456). A
+        # permanent filter, set once here before any concurrent predict() call can start, needs no
+        # restore and so can't race.
+        warnings.filterwarnings("ignore", category=UserWarning, module=r"gliner(\..*)?")
         truststore.inject_into_ssl()
         try:
             from gliner import GLiNER
-            with warnings.catch_warnings(), contextlib.redirect_stderr(io.StringIO()):
+            with warnings.catch_warnings(), contextlib.redirect_stderr(io.StringIO()), _quiet_stderr():
                 warnings.simplefilter("ignore", UserWarning)
                 _gliner_model = GLiNER.from_pretrained("urchade/gliner_multi-v2.1")
         finally:
@@ -272,16 +293,15 @@ def harvest_entities(text_by_page: dict[int, str]) -> list[dict]:
 
     try:
         candidates = []
-        # gliner warns on stderr when a window still exceeds its token limit; ingest's terminal
-        # output is user-facing, so keep those out of it — truncation is already mitigated by
-        # the conservative window size above.
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", UserWarning)
-            for page, text in text_by_page.items():
-                for chunk in _chunk_words(text):
-                    for ent in model.predict_entities(chunk, _GLINER_LABELS,
-                                                       threshold=_GLINER_THRESHOLD):
-                        candidates.append({"page": page, "kind": ent["label"], "value": ent["text"]})
+        # gliner warns on stderr when a window still exceeds its token limit — truncation is
+        # already mitigated by the conservative window size above; the permanent filter set in
+        # _load_gliner keeps it out of ingest's terminal output without a per-call context
+        # manager (concurrent documents call this via asyncio.to_thread, see _load_gliner).
+        for page, text in text_by_page.items():
+            for chunk in _chunk_words(text):
+                for ent in model.predict_entities(chunk, _GLINER_LABELS,
+                                                   threshold=_GLINER_THRESHOLD):
+                    candidates.append({"page": page, "kind": ent["label"], "value": ent["text"]})
         return _dedupe_and_cap(candidates)
     except Exception:
         return []

--- a/src/watchdog/pipeline/orchestrate.py
+++ b/src/watchdog/pipeline/orchestrate.py
@@ -1970,18 +1970,23 @@ async def run(vault: Path, *, concurrency: int = DEFAULT_CONCURRENCY,
         tasks[:] = [asyncio.ensure_future(_guarded(s)) for s in shas]
 
         async def _tick_elapsed() -> None:
-            """Keep a pinned "elapsed MM:SS" row at the bottom of the live region while
+            """Keep a pinned "Elapsed MM:SS" row at the bottom of the live region while
             extraction runs (#411) — a long pause on a dense document (minutes, not seconds,
             #398) otherwise reads as a stall rather than normal progress."""
             start = time.monotonic()
             while True:
                 await asyncio.sleep(1)
                 elapsed = int(time.monotonic() - start)
-                _board.update("__elapsed__", f"  {_DIM}elapsed {elapsed // 60:02d}:{elapsed % 60:02d}{_RESET}",
+                _board.update("__elapsed__", f"  {_DIM}Elapsed {elapsed // 60:02d}:{elapsed % 60:02d}{_RESET}",
                               pin=True)
 
         # Only on a real TTY — LiveRegion.update() falls back to plain append-only printing
         # when disabled, which would spam a new line every second into logs/CI output.
+        if _board.enabled:
+            # Blank clearance line above the elapsed row (#456), same pattern as chew's own
+            # pinned progress bar (preprocess_batch._SPACER_KEY) — registered once, before the
+            # timer starts, since pinned rows render in insertion order among pinned keys.
+            _board.update("__elapsed_spacer__", "", pin=True)
         timer_task = asyncio.ensure_future(_tick_elapsed()) if _board.enabled else None
 
         def _on_interrupt() -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2737,6 +2737,63 @@ def test_cmd_ingest_and_cmd_finalize_agree_on_finalizer_default(wdg_home, tmp_pa
     assert finalizer_defaults["ingest"] == finalizer_defaults["finalize"] == "haiku"
 
 
+def test_pending_batch_merge_label_reflects_dig_vs_ingest(wdg_home, tmp_path, monkeypatch):
+    """`dig` never finalizes in the same run it's invoked from — its pending-finalization
+    dialog must not claim merging "finalizes everything together"; only `watchdog bark` does
+    that later. The old combined pipeline (bare `watchdog`/`ingest`) does finalize inline, so
+    keeps the original wording (#456)."""
+    from watchdog.cmd import auth as auth_module
+    from watchdog.cmd import ingest as ing
+    from watchdog.pipeline import orchestrate as orch_module
+
+    vault = _vault_with_queued_doc(tmp_path)
+    monkeypatch.chdir(vault)
+    monkeypatch.setattr(auth_module, "resolve_auth", lambda: {"mode": "api-key", "key": "sk-x"})
+    monkeypatch.setattr(orch_module, "has_pending_finalization", lambda v: True)
+    monkeypatch.setattr(orch_module, "pending_finalization", lambda v: {"docs": 1, "entities": 0})
+
+    class _Stop(Exception):
+        pass
+
+    monkeypatch.setattr("watchdog.pipeline.ingest_setup.run",
+                        lambda *a, **k: (_ for _ in ()).throw(_Stop()))
+
+    captured = {}
+
+    def _fake_pick(choices, *a, **k):
+        captured["choices"] = choices
+        return 0   # Merge
+
+    monkeypatch.setattr(ing.interactive, "pick", _fake_pick)
+
+    with pytest.raises(_Stop):
+        ing.cmd_ingest(args(command="dig"), confirm=False)
+    dig_merge_label = captured["choices"][0]
+    assert "watchdog bark" in dig_merge_label
+    assert "then finalize everything together" not in dig_merge_label
+
+    captured.clear()
+    with pytest.raises(_Stop):
+        ing.cmd_ingest(args(), confirm=False)
+    bare_merge_label = captured["choices"][0]
+    assert "then finalize everything together" in bare_merge_label
+
+
+def test_format_models_line_shows_concurrency_only_when_explicitly_set(monkeypatch):
+    """`--concurrency` was silently dropped from the pre-run summary (#456) — it should only
+    appear when the user actually passed it, not for a run left at the default/config value."""
+    from watchdog.cmd import ingest as ing
+
+    without = ing._format_models_line("haiku", "haiku", None, "sonnet", None, "haiku",
+                                      "medium", None, None, concurrency=None)
+    assert "concurrency" not in without
+
+    with_value = ing._format_models_line("haiku", "haiku", None, "sonnet", None, "haiku",
+                                         "medium", None, None, concurrency=2)
+    assert "concurrency" in with_value
+    assert "2" in with_value.splitlines()[-1]
+
+
 # ── ingest --estimate (#269) ────────────────────────────────────────────────────
 
 def test_cmd_ingest_estimate_prints_and_exits_without_lock(wdg_home, tmp_path, monkeypatch, capsys):

--- a/tests/test_harvest.py
+++ b/tests/test_harvest.py
@@ -214,6 +214,31 @@ def test_load_gliner_suppresses_load_time_warnings_and_stderr(monkeypatch, capsy
     assert capsys.readouterr().err == ""
 
 
+def test_load_gliner_installs_permanent_predict_time_filter(monkeypatch):
+    """Predict-time truncation warnings used to be suppressed via a `warnings.catch_warnings()`
+    context scoped to each `harvest_entities` call — the stdlib documents that context manager as
+    not thread-safe, and `harvest_entities` runs concurrently across documents via
+    `asyncio.to_thread`, so one thread's `__exit__` could restore the filters while another
+    thread's predict() call still expected them suppressed, leaking a warning (#456). `_load_gliner`
+    now installs a permanent, module-scoped filter instead, which needs no restore and can't race.
+    Simulated with `warn_explicit` (rather than a real gliner call) so this doesn't depend on the
+    installed gliner version's exact warning text or call site."""
+    class _FakeGLiNER:
+        @staticmethod
+        def from_pretrained(name):
+            return "fake-model"
+
+    monkeypatch.setitem(sys.modules, "gliner", types.SimpleNamespace(GLiNER=_FakeGLiNER))
+    monkeypatch.setattr(harvest, "_gliner_model", None)
+
+    harvest._load_gliner()
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.warn_explicit("Sentence of length 999 has been truncated to 384", UserWarning,
+                               "processor.py", 417, module="gliner.data_processing.processor")
+    assert caught == []
+
+
 # ── real-corpus regression fixtures (#361 benchmark misses) ────────────────────────────────
 
 def test_regression_university_administrative_fee():


### PR DESCRIPTION
## Summary

Partial fix for #456 — the copy/logic issues that were self-contained and well-understood. Does **not** close #456: the `key_facts` alert investigation and the `watchdog list`/`status` revision for dig-only vaults are still open and need separate work (see comment on #456).

- `dig`'s pending-finalization dialog no longer claims a merge "finalizes everything together" — `dig` never finalizes in the same run it's invoked from, so that was simply wrong; the old combined pipeline (bare `watchdog`/`ingest`) keeps the original wording since it does finalize inline.
- Dropped the stale `--no-finalize:` message, which referenced a flag that no longer exists as a CLI option (only ever set internally by `dig`'s wrapper) — now describes what actually happened.
- Dropped the `[--finalizer-model MODEL]` hint from the closing `watchdog bark` message.
- `--concurrency` now shows up in the pre-run models summary when explicitly passed.
- Added a blank clearance line above the live "Elapsed MM:SS" row and capitalized it, matching chew's own pinned-progress-bar spacing.
- `harvest.py` (GLiNER): two separate, verified bugs behind the noisy `dig` output —
  - The "unauthenticated requests" notice bypassed `contextlib.redirect_stderr` entirely — confirmed via a direct repro (redirect_stderr's captured buffer had the tqdm output but not this line). huggingface_hub's logging handler holds a direct reference to the real stderr stream, not a dynamic `sys.stderr` lookup, so no Python-level redirection reaches it. Fixed with an OS-level fd redirect (`os.dup2`) around the load call.
  - The `processor.py` truncation warnings leaked intermittently under concurrency — `harvest_entities` runs per document via `asyncio.to_thread`, and its old per-call `warnings.catch_warnings()` context is documented by the stdlib as **not thread-safe**: concurrent enter/exit pairs race on the shared global filter list. Replaced with a permanent, module-scoped filter installed once in `_load_gliner`, which needs no restore and can't race. Verified clean under a 5-way concurrent repro before and after.
  - Also answers "are we re-downloading GLiNER each time?" — no: the "Fetching N files" progress line completes in under a second on a cache hit, confirming it's a fast local cache check, not a real download.

## Test plan
- [x] `~/.local/pipx/venvs/watchdog-intel/bin/pytest` — 1681 passed
- [x] `pipx run ruff check src tests` — clean
- [x] New tests added for both the dig-vs-ingest dialog wording and the `--concurrency` summary row; mutation-tested (reverted each fix, confirmed red, restored)
- [x] New test for the permanent GLiNER warning filter; mutation-tested the same way
- [x] Manually reproduced both GLiNER stderr leaks against the real installed package (not mocks) before and after, in fresh subprocesses and under real concurrency

🤖 Generated with [Claude Code](https://claude.com/claude-code)