### PR TITLE
Don't truncate the check-the-source preview in quote/figure verification

### DIFF
--- a/src/watchdog/pipeline/figure_verify.py
+++ b/src/watchdog/pipeline/figure_verify.py
@@ -155,14 +155,14 @@ def verify_figures(extraction: dict, page_texts: dict[int, str]) -> list[str]:
             warnings.append(
                 f"document.key_facts[{i}] figure(s) {', '.join(still_missing)} not found on "
                 f"page {page} (or adjacent pages) — may be derived or garbled; check the "
-                f"source: {text[:80]!r}"
+                f"source: {text!r}"
             )
         if elsewhere:
             detail = ", ".join(f"{t} (page {'/'.join(str(p) for p in pages)})" for t, pages in elsewhere)
             warnings.append(
                 f"document.key_facts[{i}] figure(s) {detail} not found on page {page} (or "
                 f"adjacent pages) but appear(s) elsewhere in the document — the figure is "
-                f"real, the page citation may be wrong; check the source: {text[:80]!r}"
+                f"real, the page citation may be wrong; check the source: {text!r}"
             )
 
     return warnings

--- a/src/watchdog/pipeline/quote_verify.py
+++ b/src/watchdog/pipeline/quote_verify.py
@@ -90,7 +90,7 @@ def verify_quotes(extraction: dict, page_texts: dict[int, str]) -> list[str]:
             quote = (fact.get("quote") or "").strip()
             warnings.append(
                 f"document.key_facts[{i}].quote not found on page {fact.get('page')} "
-                f"(or adjacent pages) — flagged as unverified: {quote[:80]!r}"
+                f"(or adjacent pages) — flagged as unverified: {quote!r}"
             )
 
     for entity in extraction.get("entities", []):

--- a/tests/test_figure_verify.py
+++ b/tests/test_figure_verify.py
@@ -184,3 +184,21 @@ def test_figure_missing_everywhere_still_gets_the_garbled_warning_alongside_cita
     citation = next(w for w in warnings if "page citation may be wrong" in w)
     assert "999999" in garbled
     assert "197600" in citation
+
+
+def test_citation_warning_does_not_truncate_the_fact_before_the_flagged_figure():
+    """Real #456/#460 case: the fact text is long enough that the old hard 80-char truncation
+    (no ellipsis) cut it off right after the first figure, so the citation warning about the
+    *second* figure showed a preview that never contained the number it was flagging."""
+    fact_text = ("Total claims asserted by creditors as per the claims process were $360.3 "
+                "million, compared to $186.8 million recognized as subject to compromise.")
+    assert len(fact_text) > 80
+    assert fact_text.index("186.8") > 80   # falls past the old truncation point
+    extraction = _fact(fact_text, page=49)
+    pages = {
+        19: "Recognized as subject to compromise: $186.8 million.",
+        49: "Nothing about claims figures on this page.",
+    }
+    warnings = verify_figures(extraction, pages)
+    citation = next(w for w in warnings if "page citation may be wrong" in w)
+    assert fact_text in citation

--- a/tests/test_quote_verify.py
+++ b/tests/test_quote_verify.py
@@ -99,3 +99,18 @@ def test_verify_quotes_skips_verification_when_no_page_text_available():
     warnings = verify_quotes(extraction, {})
     assert "quote_verified" not in extraction["document"]["key_facts"][0]
     assert warnings == []
+
+
+def test_verify_quotes_does_not_truncate_the_quote_shown_in_the_warning():
+    """The warning used to hard-truncate the quote to 80 chars with no ellipsis (#456/#460) —
+    on a quote over that length, the truncated preview can cut off before the part that
+    actually failed to verify, making the warning look inexplicable rather than accurate."""
+    long_quote = ("Total claims asserted by creditors as per the claims process were $360.3 "
+                  "million, compared to $186.8 million recognized as subject to compromise.")
+    assert len(long_quote) > 80
+    extraction = {"document": {"key_facts": [
+        {"fact": "x", "page": 3, "quote": long_quote},
+    ]}, "entities": []}
+    warnings = verify_quotes(extraction, {3: "Totally unrelated page content."})
+    assert len(warnings) == 1
+    assert long_quote in warnings[0]


### PR DESCRIPTION
## Summary

Fixes #460 (split from #456's "key_facts alerts that seem off").

Root cause, verified against real extraction data from the corpus-v1 benchmark runs: `quote_verify.py` and `figure_verify.py` both hard-truncated their "check the source" preview to 80 characters with no ellipsis. Checking actual `key_facts` fact/quote strings from real runs, **82% exceed 80 characters** — this wasn't an edge case.

Worse, the truncation could hide the exact figure a warning was about. The real example from #456:

```
⚠  document.key_facts[31] figure(s) 360.3 not found on page 49 ... check the source: 'Total claims asserted by creditors as per the claims process were $360.3 million'
⚠  document.key_facts[31] figure(s) 186.8 (page 19) not found on page 49 ... but appear(s) elsewhere in the document ... check the source: 'Total claims asserted by creditors as per the claims process were $360.3 million'
```

The full fact is *"Total claims asserted by creditors as per the claims process were $360.3 million, compared to $186.8 million recognized as subject to compromise."* — the 80-char cutoff lands right after "$360.3 million," so the second warning (about 186.8) shows a preview that never contains 186.8 at all. Confirmed by pulling the actual staged extraction JSON from the `bench-ex2-ds-flash` vault — this is exactly what "seems off" about these alerts: accurate warnings with evidence previews that don't back them up.

Removed the truncation rather than raising the cutoff — `key_facts` sentences are short and bounded by the extraction schema (max observed across two benchmark runs: 307 chars), so there's no pathological-length case to guard against, and any fixed cutoff just reintroduces the same failure mode for a long enough fact.

## Test plan
- [x] `~/.local/pipx/venvs/watchdog-intel/bin/pytest` — 1680 passed
- [x] `pipx run ruff check src tests` — clean
- [x] New tests reproducing the exact #456 case for both modules (full text preserved past the old 80-char cutoff); mutation-tested (reverted each fix, confirmed red, restored)

🤖 Generated with [Claude Code](https://claude.com/claude-code)