### PR TITLE
watchdog usage/list/status/dig: cost-per-page, awaiting-dig/bark split, dialog clarity

### DIFF
--- a/src/watchdog/cmd/base.py
+++ b/src/watchdog/cmd/base.py
@@ -533,6 +533,31 @@ def _count_queued(vault: Path) -> int:
     return sum(1 for f in queue.iterdir() if f.suffix == ".json")
 
 
+def _count_awaiting_dig(vault: Path) -> int:
+    """Queued documents with no staged extraction yet — chewed but not yet dug (#461). A queue
+    file persists until `bark` commits it (`orchestrate._commit_extracted`), so post-dig/bark
+    split `_count_queued` alone conflates "not yet dug" with "dug, awaiting bark" — this and
+    `_count_awaiting_bark` split it by whether a matching `.watchdog/extracted/<sha>.json`
+    (staged by `dig`) exists for that queue entry."""
+    queue = vault / ".watchdog" / "queue"
+    if not queue.exists():
+        return 0
+    extracted = vault / ".watchdog" / "extracted"
+    return sum(1 for f in queue.iterdir()
+              if f.suffix == ".json" and not (extracted / f.name).exists())
+
+
+def _count_awaiting_bark(vault: Path) -> int:
+    """Queued documents already dug (staged extraction present) but not yet committed via
+    `bark` — see `_count_awaiting_dig`."""
+    queue = vault / ".watchdog" / "queue"
+    if not queue.exists():
+        return 0
+    extracted = vault / ".watchdog" / "extracted"
+    return sum(1 for f in queue.iterdir()
+              if f.suffix == ".json" and (extracted / f.name).exists())
+
+
 def _warn_pending_research(vault: Path) -> None:
     """Warn when web-research URLs are queued but not downloaded (#196). A crashed research session
     leaves them in the durable worklist; bare `watchdog`, `chew`, and `status` surface them so they

--- a/src/watchdog/cmd/ingest.py
+++ b/src/watchdog/cmd/ingest.py
@@ -775,8 +775,10 @@ def cmd_ingest(args, *, confirm: bool = True, skip_preview: bool = False) -> Non
         print(f"  {_DIM}A new ingest resets it — what would you like to do?{_RESET}")
         choice = interactive.pick(
             [f"Merge it into this ingest {_DIM}— extract the new docs, then finalize everything together{_RESET}",
-             f"Finalize it now, then stop {_DIM}— ingest the new docs afterward{_RESET}",
-             "Discard it and ingest only the new docs"],
+             f"Finalize it now, then stop {_DIM}— real model spend now (reconciliation, synthesis, "
+             f"the briefing); ingest the new docs after{_RESET}",
+             f"Discard it and ingest only the new docs {_DIM}— safe: never touches what's already "
+             f"extracted, just clears state kept for a future bark{_RESET}"],
             0, title="Pending batch")
         if choice is interactive.CANCELLED:
             return

--- a/src/watchdog/cmd/usage.py
+++ b/src/watchdog/cmd/usage.py
@@ -12,6 +12,7 @@ Formerly the standalone `scripts/analyze-session` dev tool; folded into the CLI 
 usable without a repo checkout."""
 
 import json
+import re
 import sys
 from pathlib import Path
 
@@ -52,6 +53,35 @@ def _wall_span(calls: list[dict]) -> float | None:
     return max(ends) - min(starts)
 
 
+def _peak_concurrency(calls: list[dict]) -> int:
+    """Highest number of `calls` with overlapping [start, end) intervals at any instant (#457) —
+    what the "N calls ran concurrently" line used to report was just `len(calls)`, the stage's
+    total call count, which overstates it for any run capped below that by `--concurrency`: 4
+    calls that ran two at a time (`--concurrency 2`) both extend the wall-clock span past the
+    fastest call's latency (so the "ran concurrently" line fires) and total 4, even though only
+    2 were ever in flight together. A standard sweep over start/end events tracks the real peak
+    instead. Calls with no `end_ts` (usage files written before #317's follow-up) are excluded,
+    same as `_wall_span`; returns 1 if none carry one (nothing to sweep, no overlap knowable)."""
+    events = []
+    for c in calls:
+        end = c.get("end_ts")
+        if not end:
+            continue
+        start = end - (c.get("latency_s") or 0.0)
+        events.append((start, 1))
+        events.append((end, -1))
+    if not events:
+        return 1
+    # End events (-1) sort before start events (1) at the same instant, so a call ending exactly
+    # when another begins isn't counted as briefly overlapping.
+    events.sort(key=lambda e: (e[0], e[1]))
+    running = peak = 0
+    for _, delta in events:
+        running += delta
+        peak = max(peak, running)
+    return peak
+
+
 def _stage_models(calls: list[dict]) -> str:
     """Distinct full model names used across `calls`, in first-seen order — printed once next
     to the stage header rather than truncated into a per-row column (a per-row abbreviation like
@@ -76,15 +106,55 @@ def _short_auth(mode: str | None) -> str:
     return "—"
 
 
+_PAGE_RANGE_RE = re.compile(r"^pages (\d+)–(\d+)")
+
+
+def _pages_in_detail(detail: str | None) -> int | None:
+    """Page count a call's own `detail` string covers (#457) — `"pages 1–36"` -> 36, `"pages
+    15–34"` -> 20 (a section call's own range, not the whole document's). None for anything
+    that isn't a page range: `"digest"`, `"part N of M"` (a section with no page markers to
+    label by), or a finalizer detail (a date, a month, an entity/pair count)."""
+    if not detail:
+        return None
+    m = _PAGE_RANGE_RE.match(detail)
+    if not m:
+        return None
+    start, end = int(m.group(1)), int(m.group(2))
+    return end - start + 1
+
+
 def _corpus_pages(vault: Path) -> tuple[int, int] | None:
-    """(total_pages, document_count) from the vault's document registry, or None if unavailable —
-    the right denominator for cost/page, since it covers every ingested document, not just this run."""
+    """(total_pages, document_count) covering every ingested document, not just the run being
+    displayed — the right denominator for cost/page.
+
+    Reads `.watchdog/extracted/*.json` (#457), the artifacts `watchdog dig` stages before any
+    `bark` call — present for a dig-only vault too, unlike the committed document registry this
+    used to require exclusively, which stays empty until `bark` runs (never, for a vault that's
+    dig-only by design, e.g. an extractor-only benchmark arm). `_commit_extracted` never deletes
+    an extracted artifact once staged, so this also covers every already-barked document. Falls
+    back to the registry only for a vault ingested before the dig/bark split (#403) shipped,
+    which has committed documents but no `extracted/` directory at all."""
+    extracted = vault / ".watchdog" / "extracted"
+    pages, n = 0, 0
+    if extracted.exists():
+        for f in extracted.glob("*.json"):
+            try:
+                doc = json.loads(f.read_text(encoding="utf-8")).get("document", {})
+            except (json.JSONDecodeError, OSError):
+                continue
+            pages += doc.get("page_count") or 0
+            n += 1
+    if n:
+        return (pages, n)
+
     reg = vault / ".watchdog" / "registry" / "documents.json"
     if not reg.exists():
         return None
     try:
         docs = json.loads(reg.read_text(encoding="utf-8"))
     except (json.JSONDecodeError, OSError):
+        return None
+    if not docs:
         return None
     pages = sum((v.get("page_count") or 0) for v in docs.values() if isinstance(v, dict))
     return (pages, len(docs))
@@ -110,7 +180,7 @@ def _print_cost_per_page(vault: Path, total_cost: float) -> None:
         print(f"  {'Corpus':<14} {_fmt(pages)} pages across {n_docs} document{'s' if n_docs != 1 else ''}")
         print(f"  {'Cost / page':<14} ${total_cost / pages:.4f}  (${total_cost:.4f} / {_fmt(pages)} pages)")
     else:
-        print(f"  {'Cost / page':<14} unavailable — no document registry at {vault}")
+        print(f"  {'Cost / page':<14} unavailable — no extracted documents on disk for {vault}")
     print()
 
 
@@ -129,7 +199,8 @@ def _print_stage(calls: list[dict]) -> dict:
 
     hdr = (f"  {'Filename':<{name_w}}  {'Detail':<{detail_w}}  {'Effort':<{effort_w}}  "
            f"{'Auth':<{auth_w}}  "
-           f"{'Input':>8}  {'C.read':>8}  {'C.write':>8}  {'Output':>7}  {'Latency':>8}  {'Cost':>8}")
+           f"{'Input':>8}  {'C.read':>8}  {'C.write':>8}  {'Output':>7}  {'Latency':>8}  "
+           f"{'Cost':>8}  {'$/pg':>7}")
     print(hdr)
     print(f"  {'─' * (len(hdr) - 2)}")
 
@@ -147,6 +218,11 @@ def _print_stage(calls: list[dict]) -> dict:
         retry_note = f"  ×{attempts}" if attempts > 1 else ""
         if c.get("failed"):
             retry_note += f"  {_YELLOW}✗ failed{_RESET}"
+        # Per-call cost/page (#457), parsed from this call's own `detail` — None (shown as "—")
+        # for anything that isn't a page range: a digest call, a section with no page markers,
+        # or a finalizer detail (a date, a month, an entity/pair count).
+        pages = _pages_in_detail(c.get("detail"))
+        per_page = f"${cost / pages:.4f}" if pages else "—"
         # The claude-agent-sdk harness's own timing (#402): time actually spent in API requests,
         # vs. this row's wall-clock Latency figure — a large gap is the harness backing off
         # internally (throttled), not the model being slow. Only present for that backend, so
@@ -160,7 +236,7 @@ def _print_stage(calls: list[dict]) -> dict:
             f"  {trunc_name:<{name_w}}  {trunc_detail:<{detail_w}}  "
             f"{effort:<{effort_w}}  {auth:<{auth_w}}  "
             f"{_fmt(c['input_tokens']):>8}  {_fmt(c['cache_read_tokens']):>8}  {_fmt(c['cache_write_tokens']):>8}  "
-            f"{_fmt(c['output_tokens']):>7}  {_fmt_secs(latency):>8}  ${cost:>6.4f}{retry_note}{api_note}"
+            f"{_fmt(c['output_tokens']):>7}  {_fmt_secs(latency):>8}  ${cost:>6.4f}  {per_page:>7}{retry_note}{api_note}"
         )
         totals["input_tokens"] += c["input_tokens"]
         totals["output_tokens"] += c["output_tokens"]
@@ -181,7 +257,9 @@ def _print_stage(calls: list[dict]) -> dict:
     # file predates end_ts.
     span = _wall_span(calls)
     if span is not None and len(calls) > 1 and totals["latency_s"] - span > 0.1:
-        print(f"  ↳ {_fmt_secs(span)} elapsed (wall-clock; {len(calls)} calls ran concurrently)")
+        peak = _peak_concurrency(calls)
+        print(f"  ↳ {_fmt_secs(span)} elapsed (wall-clock; {len(calls)} calls, "
+              f"up to {peak} concurrent)")
     return totals
 
 

--- a/src/watchdog/cmd/vault.py
+++ b/src/watchdog/cmd/vault.py
@@ -16,6 +16,8 @@ from watchdog.cmd.base import (
     _BOLD, _CYAN, _DIM, _GREEN, _RESET, _YELLOW,
     _check_project_health,
     _check_vault_locks,
+    _count_awaiting_bark,
+    _count_awaiting_dig,
     _count_incoming,
     _count_queued,
     _warn_pending_research,
@@ -942,40 +944,51 @@ def cmd_list(args) -> None:
         docs     = str(reg["document_count"]) if reg else "—"
         entities = str(reg["entity_count"])   if reg else "—"
         updated  = _fmt_date(reg["last_updated"]) if reg else "—"
-        incoming = str(_count_incoming(vault)) if vault.exists() else "—"
-        queued   = str(_count_queued(vault))   if vault.exists() else "—"
+        incoming = str(_count_incoming(vault))    if vault.exists() else "—"
+        # Split rather than a single "queued" count (#461): a queue file persists until `bark`
+        # commits it, so post-dig/bark split, "queued" alone conflates "not yet dug" with "dug,
+        # awaiting bark" — two very different states for a vault that may stay dig-only forever
+        # (e.g. an extractor-only benchmark arm).
+        awaiting_dig  = str(_count_awaiting_dig(vault))  if vault.exists() else "—"
+        awaiting_bark = str(_count_awaiting_bark(vault)) if vault.exists() else "—"
         created  = _fmt_date(info.get("created_at", ""))
         size     = _fmt_size(_vault_size(vault)) if vault.exists() else "—"
         is_arch  = bool(info.get("archived"))
         description = info.get("description", "")
-        rows.append((info["name"], slug, docs, entities, updated, incoming, queued, is_arch, description, health, created, size))
+        rows.append((info["name"], slug, docs, entities, updated, incoming, awaiting_dig,
+                    awaiting_bark, is_arch, description, health, created, size))
 
     name_w = max(len(r[0]) for r in rows) + 2
     slug_w = max(len(r[1]) for r in rows) + 2
-    sep_w = name_w + slug_w + 6 + 8 + 7 + 9 + 10 + 8 + 10 + 9 * 2 - 2
     header = (
         f"  {_BOLD}{'Project':<{name_w}}{_RESET}"
         f"  {_DIM}{'Slug':<{slug_w}}"
         f"  {'Docs':>6}"
         f"  {'Entities':>8}"
-        f"  {'To chew':>7}"
-        f"  {'To ingest':>9}"
+        f"  {'Awaiting chew':>13}"
+        f"  {'Awaiting dig':>12}"
+        f"  {'Awaiting bark':>13}"
         f"  {'Created':>10}"
         f"  {'Size':>8}"
         f"  Updated{_RESET}"
     )
+    sep_w = len(re.sub(r"\033\[[0-9;]*m", "", header)) - 2
     print(f"\n{header}")
     print(f"  {_DIM}{'─' * sep_w}{_RESET}")
-    for name, slug, docs, entities, updated, incoming, queued, is_arch, description, health, created, size in rows:
+    for (name, slug, docs, entities, updated, incoming, awaiting_dig, awaiting_bark,
+         is_arch, description, health, created, size) in rows:
         inc = "—" if incoming == "0" else incoming
-        que = "—" if queued   == "0" else queued
+        dig = "—" if awaiting_dig  == "0" else awaiting_dig
+        bark = "—" if awaiting_bark == "0" else awaiting_bark
         if is_arch:
-            inc_str = f"{_DIM}{inc:>7}{_RESET}"
-            que_str = f"{_DIM}{que:>9}{_RESET}"
+            inc_str = f"{_DIM}{inc:>13}{_RESET}"
+            dig_str = f"{_DIM}{dig:>12}{_RESET}"
+            bark_str = f"{_DIM}{bark:>13}{_RESET}"
             name_str = f"  {_DIM}{name:<{name_w}}{_RESET}"
         else:
-            inc_str = f"{_YELLOW}{inc:>7}{_RESET}" if inc != "—" else f"{_DIM}{inc:>7}{_RESET}"
-            que_str = f"{_YELLOW}{que:>9}{_RESET}" if que != "—" else f"{_DIM}{que:>9}{_RESET}"
+            inc_str = f"{_YELLOW}{inc:>13}{_RESET}" if inc != "—" else f"{_DIM}{inc:>13}{_RESET}"
+            dig_str = f"{_YELLOW}{dig:>12}{_RESET}" if dig != "—" else f"{_DIM}{dig:>12}{_RESET}"
+            bark_str = f"{_YELLOW}{bark:>13}{_RESET}" if bark != "—" else f"{_DIM}{bark:>13}{_RESET}"
             name_str = f"  {_BOLD}{name:<{name_w}}{_RESET}"
         print(
             f"{name_str}"
@@ -983,7 +996,8 @@ def cmd_list(args) -> None:
             f"  {docs:>6}"
             f"  {entities:>8}{_RESET}"
             f"  {inc_str}"
-            f"  {que_str}"
+            f"  {dig_str}"
+            f"  {bark_str}"
             f"  {_DIM}{created:>10}"
             f"  {size:>8}"
             f"  {updated}{_RESET}"
@@ -1040,7 +1054,8 @@ def cmd_status(args) -> None:
     doc_types   = Counter(d["document_type"] for d in docs_data.values() if d.get("document_type"))
     ent_types   = Counter(e["type"]          for e in ents_data.values() if e.get("type"))
     incoming_n = _count_incoming(vault)
-    queued_n   = _count_queued(vault)
+    awaiting_dig_n  = _count_awaiting_dig(vault)
+    awaiting_bark_n = _count_awaiting_bark(vault)
 
     print(f"\n  {_BOLD}{info['name']}{_RESET}  {_DIM}{slugify(info['name'])}{_RESET}")
     print(f"  {_CYAN}{info['path']}{_RESET}")
@@ -1065,8 +1080,10 @@ def cmd_status(args) -> None:
 
     if incoming_n:
         print(f"  {_YELLOW}{incoming_n} file{'s' if incoming_n != 1 else ''}{_RESET} in {_CYAN}_INCOMING/{_RESET} {_DIM}— run{_RESET} {_CYAN}watchdog chew{_RESET}")
-    if queued_n:
-        print(f"  {_YELLOW}{queued_n} file{'s' if queued_n != 1 else ''}{_RESET} chewed and waiting for {_CYAN}watchdog dig{_RESET}")
+    if awaiting_dig_n:
+        print(f"  {_YELLOW}{awaiting_dig_n} file{'s' if awaiting_dig_n != 1 else ''}{_RESET} chewed and awaiting {_CYAN}watchdog dig{_RESET}")
+    if awaiting_bark_n:
+        print(f"  {_YELLOW}{awaiting_bark_n} file{'s' if awaiting_bark_n != 1 else ''}{_RESET} dug and awaiting {_CYAN}watchdog bark{_RESET}")
     _warn_pending_research(vault)
 
     if orchestrate.has_pending_finalization(vault):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -500,6 +500,56 @@ def test_cmd_list_missing_registry_shows_dashes(configured, wdg_home, capsys):
     assert "—" in capsys.readouterr().out
 
 
+def _queue_file(vault: Path, sha: str) -> None:
+    q = vault / ".watchdog" / "queue"
+    q.mkdir(parents=True, exist_ok=True)
+    (q / f"{sha}.json").write_text(json.dumps({"sha256": sha, "filename": f"{sha}.pdf", "page_count": 1}))
+
+
+def _extracted_file(vault: Path, sha: str) -> None:
+    e = vault / ".watchdog" / "extracted"
+    e.mkdir(parents=True, exist_ok=True)
+    (e / f"{sha}.json").write_text(json.dumps({"document": {"filename": f"{sha}.pdf"}}))
+
+
+def test_cmd_list_shows_awaiting_dig_and_bark_columns(configured, wdg_home, capsys):
+    """A dig-only vault (#461): the table gets a column for each pipeline stage rather than one
+    ambiguous 'To ingest' count that conflated 'not yet dug' with 'dug, awaiting bark'. One
+    queue file has no staged extraction (awaiting dig), the other already does (awaiting bark),
+    so the two new columns must each show 1, not fall back to a shared/blended count."""
+    cli.cmd_new(args(name="Shell Co Probe", dir=str(configured)))
+    vault = configured / "shell-co-probe"
+    _queue_file(vault, "sha_not_dug")
+    _queue_file(vault, "sha_dug")
+    _extracted_file(vault, "sha_dug")
+    cli.cmd_list(args())
+    lines = _strip_ansi(capsys.readouterr().out).splitlines()
+    assert "To ingest" not in "\n".join(lines)
+    header = next(line for line in lines if "Awaiting dig" in line)
+    row = next(line for line in lines if "Shell Co Probe" in line)
+    dig_start = header.index("Awaiting dig")
+    bark_start = header.index("Awaiting bark")
+    assert row[dig_start:dig_start + len("Awaiting dig")].strip() == "1"
+    assert row[bark_start:bark_start + len("Awaiting bark")].strip() == "1"
+
+
+def test_cmd_status_splits_awaiting_dig_and_awaiting_bark(configured, capsys):
+    """Same split as `cmd_list` (#461), in `cmd_status`'s prose lines: a queue file persists
+    until `bark` commits it, so a raw queue count alone can't distinguish 'chewed, not yet dug'
+    from 'dug, awaiting bark' — two very different states for a vault that may stay dig-only."""
+    cli.cmd_new(args(name="Test Proj", dir=str(configured)))
+    vault = configured / "test-proj"
+    _queue_file(vault, "sha_not_dug")
+    _queue_file(vault, "sha_dug")
+    _extracted_file(vault, "sha_dug")
+    cli.cmd_status(args(name="Test Proj"))
+    lines = _strip_ansi(capsys.readouterr().out).splitlines()
+    dig_line = next(line for line in lines if "awaiting watchdog dig" in line)
+    bark_line = next(line for line in lines if "awaiting watchdog bark" in line)
+    assert "1 file" in dig_line
+    assert "1 file" in bark_line
+
+
 def test_cmd_list_shows_description(configured, wdg_home, capsys):
     cli.cmd_new(args(name="Shell Co Probe", description="Offshore owners behind city land deals", dir=str(configured)))
     cli.cmd_list(args())

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2787,6 +2787,41 @@ def test_cmd_ingest_and_cmd_finalize_agree_on_finalizer_default(wdg_home, tmp_pa
     assert finalizer_defaults["ingest"] == finalizer_defaults["finalize"] == "haiku"
 
 
+def test_pending_batch_dialog_flags_spend_and_safety(wdg_home, tmp_path, monkeypatch):
+    """The pending-finalization dialog's "Finalize it now" and "Discard" options used to give
+    no hint that one spends real money right now and the other is actually safe/non-destructive
+    (#458) — a reader had to already know the internals to tell them apart."""
+    from watchdog.cmd import auth as auth_module
+    from watchdog.cmd import ingest as ing
+    from watchdog.pipeline import orchestrate as orch_module
+
+    vault = _vault_with_queued_doc(tmp_path)
+    monkeypatch.chdir(vault)
+    monkeypatch.setattr(auth_module, "resolve_auth", lambda: {"mode": "api-key", "key": "sk-x"})
+    monkeypatch.setattr(orch_module, "has_pending_finalization", lambda v: True)
+    monkeypatch.setattr(orch_module, "pending_finalization", lambda v: {"docs": 1, "entities": 0})
+
+    class _Stop(Exception):
+        pass
+
+    monkeypatch.setattr("watchdog.pipeline.ingest_setup.run",
+                        lambda *a, **k: (_ for _ in ()).throw(_Stop()))
+
+    captured = {}
+
+    def _fake_pick(choices, *a, **k):
+        captured["choices"] = choices
+        return 0
+
+    monkeypatch.setattr(ing.interactive, "pick", _fake_pick)
+
+    with pytest.raises(_Stop):
+        ing.cmd_ingest(args(), confirm=False)
+    finalize_label, discard_label = captured["choices"][1], captured["choices"][2]
+    assert "real model spend" in finalize_label
+    assert "safe" in discard_label
+
+
 # ── ingest --estimate (#269) ────────────────────────────────────────────────────
 
 def test_cmd_ingest_estimate_prints_and_exits_without_lock(wdg_home, tmp_path, monkeypatch, capsys):

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -150,8 +150,31 @@ def test_cmd_usage_shows_wall_clock_elapsed_for_concurrent_stage(tmp_path, monke
     out = capsys.readouterr().out
     assert "9.0s" in out                       # summed call time (subtotal)
     assert "5.0s elapsed" in out               # wall-clock span, per stage
-    assert "concurrently" in out
+    assert "up to 3 concurrent" in out         # all three genuinely overlap at t=99 (#457)
     assert "5.0s elapsed" in out.split("TOTAL")[1]   # and on the TOTAL line
+
+
+def test_cmd_usage_peak_concurrency_not_just_call_count(tmp_path, monkeypatch, capsys):
+    """#457: the old message reported `len(calls)` as "N calls ran concurrently", which
+    overstates it whenever a run was concurrency-capped below the stage's total call count —
+    four calls that ran two at a time still extend the wall-clock span past one call's latency
+    (so the line fires) and total 4, even though only 2 were ever in flight together. Four 2s
+    calls in two back-to-back overlapping pairs (a/b end at t=10/11, c/d end at t=13/14) never
+    have more than 2 overlapping at once."""
+    vault = _build_vault(tmp_path, runs={
+        "usage-2026-01-01T00-00-00": [
+            _call(filename="a.pdf", latency_s=2.0, end_ts=10.0),
+            _call(filename="b.pdf", latency_s=2.0, end_ts=11.0),
+            _call(filename="c.pdf", latency_s=2.0, end_ts=13.0),
+            _call(filename="d.pdf", latency_s=2.0, end_ts=14.0),
+        ],
+    })
+    monkeypatch.chdir(vault)
+
+    cmd_usage(_args())
+
+    out = capsys.readouterr().out
+    assert "4 calls, up to 2 concurrent" in out
 
 
 def test_cmd_usage_omits_wall_clock_when_no_end_ts(tmp_path, monkeypatch, capsys):
@@ -323,3 +346,52 @@ def test_cmd_usage_cost_per_page_from_documents_registry(tmp_path, monkeypatch, 
     out = capsys.readouterr().out
     assert "20 pages across 2 documents" in out
     assert "$0.0500" in out   # 1.0 / 20 pages
+
+
+def test_cmd_usage_cost_per_page_from_extracted_artifacts_without_registry(tmp_path, monkeypatch, capsys):
+    """A dig-only vault (#457/#461) has never committed anything — no documents.json — but
+    `watchdog dig` already staged `.watchdog/extracted/<sha>.json` for each document, carrying
+    the same page_count. Cost/page must work from that alone rather than require a commit."""
+    vault = _build_vault(tmp_path, runs={"usage-2026-01-01T00-00-00": [_call(cost_usd=1.0)]})
+    extracted = vault / ".watchdog" / "extracted"
+    extracted.mkdir(parents=True)
+    (extracted / "sha1.json").write_text(json.dumps({"document": {"page_count": 10}}))
+    (extracted / "sha2.json").write_text(json.dumps({"document": {"page_count": 10}}))
+    monkeypatch.chdir(vault)
+
+    cmd_usage(_args())
+
+    out = capsys.readouterr().out
+    assert "20 pages across 2 documents" in out
+    assert "$0.0500" in out   # 1.0 / 20 pages
+
+
+def test_cmd_usage_no_extracted_or_registry_reports_unavailable(tmp_path, monkeypatch, capsys):
+    vault = _build_vault(tmp_path, runs={"usage-2026-01-01T00-00-00": [_call(cost_usd=1.0)]})
+    monkeypatch.chdir(vault)
+
+    cmd_usage(_args())
+
+    out = capsys.readouterr().out
+    assert "unavailable" in out
+
+
+def test_cmd_usage_per_call_cost_per_page(tmp_path, monkeypatch, capsys):
+    """#457: a "$/pg" column per row, parsed from that call's own page range in `detail` — not
+    the whole-corpus figure. A digest call (no page range) shows "—" instead of a bogus value."""
+    vault = _build_vault(tmp_path, runs={
+        "usage-2026-01-01T00-00-00": [
+            _call(filename="a.pdf", detail="pages 1–36", cost_usd=0.36),
+            _call(filename="b.pdf", detail="digest", cost_usd=0.10),
+        ],
+    })
+    monkeypatch.chdir(vault)
+
+    cmd_usage(_args())
+
+    out = capsys.readouterr().out
+    lines = out.splitlines()
+    a_row = next(line for line in lines if "a.pdf" in line)
+    b_row = next(line for line in lines if "b.pdf" in line)
+    assert "$0.0100" in a_row   # 0.36 / 36 pages
+    assert "—" in b_row


### PR DESCRIPTION
## Summary

Closes #457, #458, #461 — three self-contained CLI-feedback issues, done together per your request.

**#457 — `watchdog usage` feedback**
- Cost/page no longer requires the committed document registry (which stays empty for a dig-only vault, e.g. an extractor-only benchmark arm that never runs `bark`) — reads `.watchdog/extracted/*.json` instead, the artifacts `dig` stages before any commit. Falls back to the registry for vaults ingested before the dig/bark split (#403).
- "N calls ran concurrently" used to just report the stage's total call count regardless of the actual `--concurrency` cap — a `--concurrency 2` run with 4 calls (two waves of two) said "4 calls ran concurrently." Replaced with a real peak-overlap sweep over each call's time interval; now reports "4 calls, up to 2 concurrent."
- Added a `$/pg` column per row, parsed from that call's own page range in `detail`.

**#461 — `watchdog list`/`status` for dig-only vaults**
- A queue file persists until `bark` commits it, so the old single queued-count conflated "chewed, not yet dug" with "dug, awaiting bark" — a dig-only vault showed as 0 docs / 0 entities with no sign it had made real progress. Split into two counts (`Awaiting dig` / `Awaiting bark` in `list`'s table, matching prose lines in `status`) based on whether a queued document has a matching staged extraction. Docs/Entities keep meaning exactly what they mean today (committed via bark). Per your note, avoided "ingest" language entirely — dig/bark are the only two verbs now.

**#458 — pending-finalization dialog clarity**
- "Finalize it now, then stop" now says it's real model spend happening right now (reconciliation, synthesis, the briefing) — previously gave no hint of that.
- "Discard it and ingest only the new docs" now says it's safe — it only clears scratch state for a future `bark` (with an automatic backup), never touches the durable staged extraction artifacts, and already-extracted documents are skipped rather than re-billed on the next `dig`.

## Test plan
- [x] `~/.local/pipx/venvs/watchdog-intel/bin/pytest` — 1685 passed
- [x] `pipx run ruff check src tests` — clean
- [x] New tests for each fix (cost/page from extracted artifacts, per-call $/pg, peak-concurrency vs. call-count, awaiting-dig/bark split in both `list` and `status`, dialog wording); mutation-tested each (reverted the fix, confirmed red, restored)

🤖 Generated with [Claude Code](https://claude.com/claude-code)