### PR TITLE
dig: drop finalize option/row, fix double blank line, fix token estimate under caching

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -70,6 +70,8 @@ It's shown every time, not just once per vault — the risk is per-document, not
 
 Each model flag takes a Claude tier (`haiku`, `sonnet`, `opus`) or a `backend:model` value that routes the stage to another provider — see [Model backends](configuration.md#model-backends). The effort flag is ignored when the stage runs on Haiku, which has no effort control.
 
+The "which model runs each stage" line printed before extraction starts shows only classifier and extractor for `dig` — no finalizer row, since `dig` never finalizes in the run it's invoked from; that row appears for `watchdog bark` and the bare guided walk instead, both of which do finalize inline.
+
 **Scope and behaviour flags.**
 
 - `--concurrency N` — documents extracted in parallel (default: 5); lower it if you hit rate limits.
@@ -82,7 +84,7 @@ Each model flag takes a Claude tier (`haiku`, `sonnet`, `opus`) or a `backend:mo
 
 **Resumability.** Pressing Ctrl+C, or hitting a rate limit without `--wait`, stops the batch cleanly: finished documents are saved and unfinished ones stay queued, so re-running `watchdog dig` picks up where it left off. A document that genuinely fails extraction is set aside in `queue/_failed/`; the run reports how many, and `watchdog requeue` moves them back to retry — this is surfaced everywhere the queue's state matters: the normal run summary, `--estimate`, and a bare `watchdog dig` with nothing new to read, which offers to requeue and retry right there instead of just reporting an empty queue. On macOS or Linux, dig also keeps the machine from sleeping for the run's duration — see [Troubleshooting](troubleshooting.md#ingest-prevents-the-machine-from-sleeping-during-a-run).
 
-If a previous batch is still pending finalization when you start `watchdog dig` (or the bare guided walk), it asks what to do: **merge** the pending batch into this run and finalize everything together with a following `watchdog bark`, **finalize** it first and stop, or **discard** it.
+If a previous batch is still pending finalization when you start `watchdog dig`, it asks what to do: **merge** the pending batch into this run (a following `watchdog bark` finalizes both together), or **discard** it. `dig` never finalizes in the run it's invoked from, so it doesn't offer to finalize inline — the bare guided walk (which does finalize inline) offers that as a third option, **finalize** it first and stop.
 
 ### watchdog bark
 

--- a/src/watchdog/cmd/ingest.py
+++ b/src/watchdog/cmd/ingest.py
@@ -152,7 +152,7 @@ def _effective_extract_backend(extract_backend: str | None, auth_mode: str) -> s
 
 def _format_models_line(classify_backend, classify_model, extract_backend, extract_model,
                         post_backend, post_model, extract_effort=None, post_effort=None,
-                        finalizer_overrides=None, concurrency=None) -> str:
+                        finalizer_overrides=None, concurrency=None, is_dig=False) -> str:
     """Which model runs each ingest stage — printed alongside the cost estimate before an
     ingest starts, so a run under a non-default provider (#325) is obvious up front instead of
     the older generic 'Using the configured provider(s).' notice. Stage names are padded to a
@@ -165,17 +165,22 @@ def _format_models_line(classify_backend, classify_model, extract_backend, extra
 
     `concurrency` (#456), when given, is the raw `--concurrency` value the user explicitly
     passed — omitted (None) when a run falls back to the config/default value, so this row
-    only appears when it actually reflects a deliberate choice rather than a fixed default."""
+    only appears when it actually reflects a deliberate choice rather than a fixed default.
+
+    `is_dig` (#456) drops the finalizer row(s) entirely: `watchdog dig` always stops before
+    finalization in the same run (unlike the bare guided walk or the deprecated `ingest`, both of
+    which finalize inline), so which model would run it is irrelevant noise on this run's summary."""
     def label(backend, model):
         return f"{backend}:{model}" if backend else model
     stages = [("classifier", classify_backend, classify_model, None),
-              ("extractor", extract_backend, extract_model, extract_effort),
-              ("finalizer", post_backend, post_model, post_effort)]
-    for stage in _FINALIZER_STAGES:
-        b = (finalizer_overrides or {}).get(f"{stage}_backend", post_backend)
-        m = (finalizer_overrides or {}).get(f"{stage}_model", post_model)
-        if (b, m) != (post_backend, post_model):
-            stages.append((f"finalizer:{stage}", b, m, post_effort))
+              ("extractor", extract_backend, extract_model, extract_effort)]
+    if not is_dig:
+        stages.append(("finalizer", post_backend, post_model, post_effort))
+        for stage in _FINALIZER_STAGES:
+            b = (finalizer_overrides or {}).get(f"{stage}_backend", post_backend)
+            m = (finalizer_overrides or {}).get(f"{stage}_model", post_model)
+            if (b, m) != (post_backend, post_model):
+                stages.append((f"finalizer:{stage}", b, m, post_effort))
     width = max(len(name) for name, *_ in stages)
     if concurrency is not None:
         width = max(width, len("concurrency"))
@@ -220,7 +225,8 @@ def _preview_ingest(vault: Path, args) -> tuple[str, str] | None:
     models_line = _format_models_line(classify_backend, classify_model,
                                       extract_backend, extract_model, post_backend, post_model,
                                       extract_effort, post_effort, finalizer_overrides,
-                                      concurrency=getattr(args, "concurrency", None))
+                                      concurrency=getattr(args, "concurrency", None),
+                                      is_dig=getattr(args, "command", None) == "dig")
     return _format_cost_estimate(est), models_line
 
 
@@ -325,7 +331,11 @@ def cmd_chew(args) -> None:
 def _public_records_warning(n_docs: int) -> str:
     """The README's `## Public records only` warning (README.md:13-17), reworded for the
     terminal gate at the point of no return (#426). Wording tracks the README section so the
-    two never drift."""
+    two never drift.
+
+    No trailing `\\n` on the returned string (#456 follow-up): the caller's `print()` already
+    appends one, and `interactive.pick()`'s own leading blank line supplies the separator before
+    the menu — an embedded trailing newline on top of both stacked into a double blank line."""
     return (
         f"\n  {_YELLOW}⚠{_RESET}  {_BOLD}Public records only{_RESET}\n\n"
         "  The extracted text of every queued document will be sent to a\n"
@@ -333,7 +343,7 @@ def _public_records_warning(n_docs: int) -> str:
         "  documents that are public, or presumptively public — never for\n"
         "  confidential source material, leaks, or anything that could\n"
         "  identify a source.\n\n"
-        f"  {_BOLD}{n_docs}{_RESET} document{'s' if n_docs != 1 else ''} will be sent to the model.\n"
+        f"  {_BOLD}{n_docs}{_RESET} document{'s' if n_docs != 1 else ''} will be sent to the model."
     )
 
 
@@ -665,6 +675,7 @@ def cmd_ingest(args, *, confirm: bool = True, skip_preview: bool = False) -> Non
     # walk (bare, via _offer_ingest). "Run it again" hints below point at whichever of those
     # got the caller here, rather than the retired `watchdog ingest` (#441, D138).
     pipeline_hint = "watchdog dig" if getattr(args, "command", None) == "dig" else "watchdog"
+    is_dig = pipeline_hint == "watchdog dig"
 
     raw_force = getattr(args, "force", False)
     if isinstance(raw_force, list):
@@ -784,28 +795,34 @@ def cmd_ingest(args, *, confirm: bool = True, skip_preview: bool = False) -> Non
         print(f"  {_DIM}A new ingest resets it — what would you like to do?{_RESET}")
         # `dig` never finalizes in the same run it's invoked from — "then finalize everything
         # together" would be wrong there, since merging just carries the old batch's state
-        # forward for a later `watchdog bark` (#456).
+        # forward for a later `watchdog bark` (#456). For the same reason, `dig` drops the
+        # "finalize it now" choice entirely: dig-by-definition stops before finalization, so
+        # offering to finalize inline here would contradict the command it was invoked as (#456).
         merge_label = (
             f"Merge it into this ingest {_DIM}— extract the new docs; a later "
             f"{_RESET}{_CYAN}watchdog bark{_RESET}{_DIM} finalizes both batches together{_RESET}"
-            if pipeline_hint == "watchdog dig" else
+            if is_dig else
             f"Merge it into this ingest {_DIM}— extract the new docs, then finalize everything together{_RESET}")
-        choice = interactive.pick(
-            [merge_label,
-             f"Finalize it now, then stop {_DIM}— real model spend now (reconciliation, synthesis, "
-             f"the briefing); ingest the new docs after{_RESET}",
-             f"Discard it and ingest only the new docs {_DIM}— safe: never touches what's already "
-             f"extracted, just clears state kept for a future bark{_RESET}"],
-            0, title="Pending batch")
+        discard_label = (
+            f"Discard it and ingest only the new docs {_DIM}— safe: never touches what's already "
+            f"extracted, just clears state kept for a future bark{_RESET}")
+        options = [merge_label]
+        if not is_dig:
+            options.append(
+                f"Finalize it now, then stop {_DIM}— real model spend now (reconciliation, synthesis, "
+                f"the briefing); ingest the new docs after{_RESET}")
+        options.append(discard_label)
+        choice = interactive.pick(options, 0, title="Pending batch")
         if choice is interactive.CANCELLED:
             return
-        if choice == 1:                        # finalize now, then stop
+        discard_choice = len(options) - 1
+        if not is_dig and choice == 1:         # finalize now, then stop
             out = _run_finalize(vault, post_model, post_effort, post_backend,
                                 skip_briefing=skip_briefing, finalizer_overrides=finalizer_overrides)
             if not (out.get("error") or out.get("briefing_error")):
                 print(f"  {_DIM}Now run {_RESET}{_CYAN}{pipeline_hint}{_RESET}{_DIM} for the queued documents.{_RESET}\n")
             return
-        if choice == 2:                        # discard
+        if choice == discard_choice:           # discard
             wipe_pending = True
             print(f"  {_DIM}Discarding the pending batch — ingesting only the new documents.{_RESET}")
         else:                                  # default: merge (non-destructive)
@@ -852,7 +869,8 @@ def cmd_ingest(args, *, confirm: bool = True, skip_preview: bool = False) -> Non
         print(f"\n{_format_cost_estimate(est)}")
         print(_format_models_line(classify_backend, classify_model, extract_backend, extract_model,
                                   post_backend, post_model, extract_effort, post_effort,
-                                  finalizer_overrides, concurrency=getattr(args, "concurrency", None)))
+                                  finalizer_overrides, concurrency=getattr(args, "concurrency", None),
+                                  is_dig=is_dig))
     elif batch_pending:
         print(f"\n  {_DIM}Checking on a pending batch extraction…{_RESET}")
 

--- a/src/watchdog/pipeline/ingest_setup.py
+++ b/src/watchdog/pipeline/ingest_setup.py
@@ -54,13 +54,26 @@ def scan_queue(vault: Path) -> list[dict]:
     return queue_files
 
 
+def _real_input_tokens(totals: dict) -> int:
+    """Total tokens the model actually processed as input for a run's calls (issue #470): plain
+    `input_tokens` alone badly undercounts once prompt caching is in play, since a cache hit or
+    write moves the bulk of a call's input volume into `cache_read_tokens`/`cache_write_tokens`
+    instead — a sectioned extraction that carries a growing shared prefix across calls can show
+    `input_tokens` in the single digits while the real content processed is orders of magnitude
+    larger. The naive chars/4 estimate this is calibrated against counts a document's full text
+    once regardless of how many cached/fresh calls served it, so the comparison point needs the
+    same full-volume accounting."""
+    return ((totals.get("input_tokens") or 0) + (totals.get("cache_read_tokens") or 0)
+            + (totals.get("cache_write_tokens") or 0))
+
+
 def _tokens_calibration(vault: Path, max_runs: int = 3) -> float | None:
     """Empirical correction factor for the naive chars/4 'tokens in' estimate (issue #417).
 
     Every usage-<ts>.json written by a run that actually extracted documents now carries both
     what was estimated for those documents at queue time (``totals.est_input_tokens``, the same
     chars/4 heuristic ``scan_queue`` uses, summed by `orchestrate._compact_result`) and what
-    extraction really consumed (``totals.input_tokens``) — their ratio is how far off the
+    extraction really consumed (`_real_input_tokens`, #470) — their ratio is how far off the
     heuristic ran, against this vault's own recent documents rather than a fixed global guess.
     Averaged over the last `max_runs` such files (a blend here, unlike `cost_estimate`'s
     deliberate low/high range for dollars: this feeds a single displayed token count, not a
@@ -81,7 +94,7 @@ def _tokens_calibration(vault: Path, max_runs: int = 3) -> float | None:
             totals = json.loads(uf.read_text(encoding="utf-8")).get("totals", {})
         except (OSError, json.JSONDecodeError):
             continue
-        est, actual = totals.get("est_input_tokens"), totals.get("input_tokens")
+        est, actual = totals.get("est_input_tokens"), _real_input_tokens(totals)
         if est and actual:
             ratios.append(actual / est)
         if len(ratios) >= max_runs:
@@ -123,7 +136,7 @@ def cost_estimate(vault: Path, queue_files: list[dict], backend: str | None,
             totals = json.loads(uf.read_text(encoding="utf-8")).get("totals", {})
         except (OSError, json.JSONDecodeError):
             continue
-        input_tokens, cost_usd = totals.get("input_tokens") or 0, totals.get("cost_usd")
+        input_tokens, cost_usd = _real_input_tokens(totals), totals.get("cost_usd")
         if input_tokens > 0 and cost_usd:
             ratios.append(cost_usd / input_tokens)
 
@@ -184,7 +197,7 @@ def finalize_cost_estimate(vault: Path, backend: str | None, max_runs: int = 3) 
         if not calls or any(c.get("task") not in orchestrate.FINALIZE_TASKS for c in calls):
             continue   # empty, or shares a usage file with extraction/classification
         totals = data.get("totals", {})
-        input_tokens, cost_usd = totals.get("input_tokens") or 0, totals.get("cost_usd")
+        input_tokens, cost_usd = _real_input_tokens(totals), totals.get("cost_usd")
         if input_tokens > 0 and cost_usd:
             ratios.append(cost_usd / input_tokens)
         if len(ratios) >= max_runs:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1938,6 +1938,20 @@ def test_confirm_public_records_cancel(monkeypatch):
     assert ing._confirm_public_records(1) is False
 
 
+def test_confirm_public_records_no_double_blank_line_before_menu(monkeypatch, capsys):
+    """The warning's own trailing newline plus `print()`'s and `pick()`'s own leading blank line
+    used to stack into two blank lines before the menu — the same anti-pattern #395 fixed
+    elsewhere in the picker (#456 follow-up)."""
+    from watchdog.cmd import ingest as ing
+    monkeypatch.setattr("builtins.input", lambda *a: "1")
+    ing._confirm_public_records(1)
+    out = capsys.readouterr().out
+    lines = out.split("\n")
+    idx = next(i for i, line in enumerate(lines) if "will be sent to the model" in line)
+    assert lines[idx + 1].strip() == ""       # exactly one blank line separates content from menu
+    assert lines[idx + 2].strip() != ""       # not a second blank line
+
+
 def test_cmd_ingest_confirm_cancel_never_calls_model(wdg_home, tmp_path, monkeypatch):
     from watchdog.cmd import auth as auth_module
     from watchdog.cmd import ingest as ing
@@ -2864,6 +2878,49 @@ def test_pending_batch_merge_label_reflects_dig_vs_ingest(wdg_home, tmp_path, mo
     assert "then finalize everything together" in bare_merge_label
 
 
+def test_pending_batch_dialog_omits_finalize_for_dig(wdg_home, tmp_path, monkeypatch):
+    """`watchdog dig` is documented to stop before finalization (#456) — its pending-finalization
+    dialog must not offer "Finalize it now", since dig itself can never carry that out. The bare
+    guided walk still offers all three options."""
+    from watchdog.cmd import auth as auth_module
+    from watchdog.cmd import ingest as ing
+    from watchdog.pipeline import orchestrate as orch_module
+
+    vault = _vault_with_queued_doc(tmp_path)
+    monkeypatch.chdir(vault)
+    monkeypatch.setattr(auth_module, "resolve_auth", lambda: {"mode": "api-key", "key": "sk-x"})
+    monkeypatch.setattr(orch_module, "has_pending_finalization", lambda v: True)
+    monkeypatch.setattr(orch_module, "pending_finalization", lambda v: {"docs": 1, "entities": 0})
+
+    class _Stop(Exception):
+        pass
+
+    monkeypatch.setattr("watchdog.pipeline.ingest_setup.run",
+                        lambda *a, **k: (_ for _ in ()).throw(_Stop()))
+
+    captured = {}
+
+    def _fake_pick(choices, *a, **k):
+        captured["choices"] = choices
+        return len(choices) - 1   # discard, whatever index that lands on
+
+    monkeypatch.setattr(ing.interactive, "pick", _fake_pick)
+
+    # dig: only merge + discard, no "finalize it now".
+    with pytest.raises(_Stop):
+        ing.cmd_ingest(args(command="dig"), confirm=False)
+    assert len(captured["choices"]) == 2
+    assert not any("Finalize it now" in c for c in captured["choices"])
+    assert "Discard" in captured["choices"][1]
+
+    # bare guided walk: still all three, finalize included.
+    captured.clear()
+    with pytest.raises(_Stop):
+        ing.cmd_ingest(args(), confirm=False)
+    assert len(captured["choices"]) == 3
+    assert any("Finalize it now" in c for c in captured["choices"])
+
+
 def test_format_models_line_shows_concurrency_only_when_explicitly_set(monkeypatch):
     """`--concurrency` was silently dropped from the pre-run summary (#456) — it should only
     appear when the user actually passed it, not for a run left at the default/config value."""
@@ -2877,6 +2934,21 @@ def test_format_models_line_shows_concurrency_only_when_explicitly_set(monkeypat
                                          "medium", None, None, concurrency=2)
     assert "concurrency" in with_value
     assert "2" in with_value.splitlines()[-1]
+
+
+def test_format_models_line_omits_finalizer_for_dig(monkeypatch):
+    """`watchdog dig` always stops before finalization in the same run (#456) — showing which
+    model would finalize is irrelevant noise there, unlike the bare guided walk or `ingest`,
+    which do finalize inline and still need the row."""
+    from watchdog.cmd import ingest as ing
+
+    for_dig = ing._format_models_line("haiku", "haiku", None, "sonnet", None, "haiku",
+                                      "medium", None, None, is_dig=True)
+    assert "finalizer" not in for_dig
+
+    not_dig = ing._format_models_line("haiku", "haiku", None, "sonnet", None, "haiku",
+                                      "medium", None, None, is_dig=False)
+    assert "finalizer" in not_dig
 
 
 # ── ingest --estimate (#269) ────────────────────────────────────────────────────

--- a/tests/test_ingest_setup.py
+++ b/tests/test_ingest_setup.py
@@ -23,11 +23,13 @@ def _write_queue_file(vault: Path, sha256: str, source_type: str = "docling", fi
 
 
 def _write_usage_file(vault: Path, ts: str, input_tokens: int, cost_usd,
-                      est_input_tokens: int | None = None, calls: list | None = None) -> None:
+                      est_input_tokens: int | None = None, calls: list | None = None,
+                      cache_read_tokens: int = 0, cache_write_tokens: int = 0) -> None:
     reg = vault / ".watchdog" / "registry"
     reg.mkdir(parents=True, exist_ok=True)
     totals = {"input_tokens": input_tokens, "output_tokens": 0,
-              "cache_read_tokens": 0, "cache_write_tokens": 0, "cost_usd": cost_usd}
+              "cache_read_tokens": cache_read_tokens, "cache_write_tokens": cache_write_tokens,
+              "cost_usd": cost_usd}
     if est_input_tokens is not None:
         totals["est_input_tokens"] = est_input_tokens
     (reg / f"usage-{ts}.json").write_text(json.dumps({
@@ -410,6 +412,26 @@ def test_cost_estimate_applies_empirical_calibration(tmp_path):
     assert est["est_tokens"] == 1500   # 1000 (raw) * 1.5 (calibration)
     # The dollar range is derived from the *calibrated* tokens, so it also reflects the correction.
     assert est["cost_low"] == est["cost_high"] == 1.5
+
+
+def test_cost_estimate_calibration_counts_cache_tokens_as_real_input(tmp_path):
+    """Prompt caching (#470) moves most of a call's real input volume into
+    `cache_read_tokens`/`cache_write_tokens`, leaving bare `input_tokens` in the single digits even
+    though the model processed the document's full content — a sectioned extraction with a shared,
+    growing prefix across calls is exactly this shape. Calibrating against `input_tokens` alone
+    used to produce a near-zero ratio and an absurdly undercounted 'tokens in' display; it must
+    fold cache reads/writes into the real-input figure instead."""
+    vault = _make_vault(tmp_path)
+    qf = vault / ".watchdog" / "queue" / "abc123.json"
+    qf.write_text(json.dumps({"filename": "x.pdf", "pages": [{"page": 1, "markdown": "a" * 4000}]}))
+    # est_input_tokens=1000 naive; almost nothing counted as bare input_tokens, but cache
+    # read+write together account for the document's real ~1500-token volume → ratio 1.5.
+    _write_usage_file(vault, "20260101T000000Z", input_tokens=1, cost_usd=1.5, est_input_tokens=1000,
+                      cache_read_tokens=500, cache_write_tokens=999)
+
+    est = cost_estimate(vault, scan_queue(vault), backend="claude-api")
+
+    assert est["est_tokens"] == 1500   # 1000 (raw) * 1.5 (calibration from input+cache tokens)
 
 
 def test_cost_estimate_calibration_ignores_standalone_finalize_runs(tmp_path):


### PR DESCRIPTION
## Summary

Follow-up to #456/#458 — three issues surfaced from a live `dig` session that the prior wording-only fix (#463, merged) didn't fully resolve:

- **Pending-finalization dialog still offered "Finalize it now, then stop" for `dig`.** `dig` never finalizes in the run it's invoked from (it forces `no_finalize`), so offering to finalize inline there was always wrong — the dialog now drops that choice entirely for `dig` (merge/discard only), while the bare guided walk and deprecated `ingest` (which do finalize inline) keep all three options.
- **Pre-run summary still showed a `finalizer   haiku` row for `dig` runs.** Same root cause — `dig` will never invoke that model in this run, so which one is configured is noise. `_format_models_line` now takes an `is_dig` flag that drops the finalizer row (and any per-stage overrides) when true.
- **Double blank line before "Acknowledge and ingest".** `_public_records_warning`'s returned string carried its own trailing `\n`; `print()` added another; `interactive.pick()`'s own leading blank stacked a third — three fixed into one. Same anti-pattern PR #395 fixed elsewhere, just never applied to this later (#426) call site.
- **"est. ~21 tokens in" for a ~209-page queue that should estimate ~160K.** Traced to `_tokens_calibration`/`cost_estimate` comparing the naive chars/4 estimate against bare `input_tokens` only. Under prompt caching, most of a call's real input volume shows up in `cache_read_tokens`/`cache_write_tokens` instead — verified against a real vault's usage file (`input_tokens: 15`, `cache_read_tokens: 72046`, `cache_write_tokens: 209813`), which produced a ~0.0001 calibration ratio and collapsed the estimate by ~5 orders of magnitude. Calibration and the $/token ratio now sum input + cache_read + cache_write as the real input volume.

## Test plan
- [x] `~/.local/pipx/venvs/watchdog-intel/bin/pytest` — 1694 passed
- [x] `pipx run ruff check src tests` — clean
- [x] New/updated tests for each fix, each mutation-tested (reverted the fix in memory or via a probe, confirmed red, restored):
  - `test_pending_batch_dialog_omits_finalize_for_dig`
  - `test_format_models_line_omits_finalizer_for_dig`
  - `test_confirm_public_records_no_double_blank_line_before_menu`
  - `test_cost_estimate_calibration_counts_cache_tokens_as_real_input`
- [x] `docs/commands.md` updated: pending-finalization dialog section and the "which model runs each stage" line, both now describe the `dig`-only behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)