### PR TITLE
Update benchmarking docs/tooling for the dig/bark split

### DIFF
--- a/tests/documents/BENCHMARK-RESULTS.md
+++ b/tests/documents/BENCHMARK-RESULTS.md
@@ -1,0 +1,63 @@
+# Extraction benchmark results (#361 / #215) — running log
+
+Living document. Updated as each arm in `BENCHMARKING.md`'s Step 4/5 tables completes. Numbers
+below are from `score_arms.py` (deterministic, numeric-anchor-only — ranks arms against each
+other, not an absolute recall measure; see `keys/README.md`) plus each vault's own usage
+telemetry and coverage-gap field. No judge-model pass has run yet — everything here is the free,
+offline slice.
+
+## Extractor sweep (Step 4)
+
+| Arm | Facts | must_not_miss | Cost (6 docs) | Latency (summed) | Retries / sectioning | Coverage gap |
+|---|---|---|---|---|---|---|
+| `bench-ex2-ds-flash` | 82% (32/39) | 71% (17/24) | $0.032 | 152s | 0 | none |
+| `bench-ex2-ds-flash-think` | 79% (31/39) | 71% (17/24) | $0.014† | 239s | 1 (on the 5-page doc) | First Report, pp.15–34 (20/34 skipped) |
+| `bench-ex2-ds-pro` | 92% (36/39) | 83% (20/24) | $0.119 | 438s | 1 (on the 70-page doc — expected) | none |
+| `bench-ex2-ds-pro-think` | 90% (35/39) | 83% (20/24) | $0.143 | 1,143s | the 36-page doc needed 5 calls (1 retry + 3 overlapping re-sections + a digest) | First Report, pp.17–34 (18/34 skipped) |
+| `bench-ex2-sonnet-high` | — pending — | | | | | |
+| `bench-ex2-sonnet-med` | — pending — | | | | | |
+| `bench-ex2-haiku` | — pending — | | | | | |
+| `bench-ex-opus-high` (optional) | — not run — | | | | | |
+
+† Looks low relative to `ds-flash`, which is suspicious — DeepSeek's reasoning-token billing may
+not be captured the same way in `cost_usd`. Sanity-check against DeepSeek's own dashboard before
+citing this figure.
+
+## Finalizer sweep (Step 5)
+
+Not started — needs a `dig` at `deepseek:deepseek-v4-flash` into `bench-fn-base`, then a copy per
+finalizer arm (see `BENCHMARKING.md` Step 5).
+
+## Findings so far
+
+**DeepSeek's "thinking" toggle doesn't pay for itself on this corpus.** Confirmed on both model
+sizes, not a one-run fluke — `bench-ex2-ds-pro-think` reproduced the same anomaly
+`bench-ex2-ds-flash-think` showed while it was still mid-run:
+
+- **Coverage:** both thinking variants skip roughly the back half of *Laurentian First Report of
+  the Monitor* (pp. 15–34 / 17–34 of 34). Both non-thinking variants have zero coverage gaps
+  anywhere, including the dense 70-page annual report — the document #339 expected cheap
+  conditions to degrade on first. Thinking mode is degrading coverage on an *easier* document
+  instead.
+- **Reliability:** flash-think needed a retry on the corpus's easiest document (5 pages). Pro-think
+  needed the pipeline to fall back to sectioning a 36-page document — well under the size
+  threshold that normally triggers that — into 5 separate calls.
+- **Cost/latency:** pro-think costs +20% over pro and runs at 2.6× pro's summed latency, for
+  materially the same fact recall (90% vs 92%) and identical must_not_miss (83%).
+- **Recall itself is roughly a wash** — thinking neither clearly helps nor hurts on the numeric
+  slice. The case against it is entirely about coverage, reliability, and cost.
+
+Implication for #361's DeepSeek decision: unlikely to be worth documenting both a thinking and
+non-thinking DeepSeek recommendation. Pending the judge pass on the ~⅔ of key items with no
+numeric anchor before that's final.
+
+## Corrections logged along the way
+
+- The original `bench-ex-sonnet-high`/`bench-ex-sonnet-med` vaults (run 2026-07-15, before #403's
+  `dig`/`bark` split shipped) have no `.watchdog/extracted/*.json` and do not score through the
+  current `score_arms.py`. Re-run under `bench-ex2-*` names instead — see `BENCHMARKING.md`.
+
+## Next
+
+`watchdog dig --estimate` for `bench-ex2-sonnet-high`, `bench-ex2-sonnet-med`, `bench-ex2-haiku` —
+pending Tom's go-ahead before the live runs (session token spend).

--- a/tests/documents/BENCHMARKING.md
+++ b/tests/documents/BENCHMARKING.md
@@ -48,10 +48,11 @@ sidecar. Entity resolution and cross-document contradiction detection moved to t
 
 Each stage is measured by varying it while holding the other two fixed at a known baseline.
 
-- **Extractor sweep** — vary `--extractor-model` × `--extractor-effort`; hold the finalizer fixed
-  at a strong baseline (`sonnet` / `high`); the corpus's per-document sidecar pins (D120) keep the
-  classifier out of the loop, no `--skill` flag needed. These are full ingests: this is where the
-  money goes.
+- **Extractor sweep** — vary `--extractor-model` × `--extractor-effort`; the finalizer never runs
+  at all (`watchdog dig` only — see Step 4), since the metrics this sweep scores live entirely in
+  the staged extraction artifacts; the corpus's per-document sidecar pins (D120) keep the
+  classifier out of the loop, no `--skill` flag needed. This is still where the money goes — it's
+  just no longer paying for a finalizer it doesn't need too.
 - **Finalizer sweep** — vary `--finalizer-model` × `--finalizer-effort`; hold the extractor fixed
   at **`deepseek:deepseek-v4-flash`**. Two reasons for the cheap fixed extractor: (a) it keeps the wasted
   re-extraction cheap — you cannot re-finalize a finished vault (#384), so each finalizer arm is its
@@ -97,10 +98,9 @@ judge cross-check in scoring — not for the runs.)
 
 ## Step 3 — the per-condition recipe
 
-Every condition follows the same shape. Worked below for the baseline (`extractor sonnet/high`,
-`finalizer sonnet/high`) — this run **is** `bench-ex-sonnet-high` from Step 4's table, not a
-separate example; repeat the same shape for every other row in Steps 4–6, swapping only the model
-flags and the vault name:
+Every condition starts the same way — fresh vault, all six documents, chew. Worked below for
+`bench-ex-sonnet-high`; swap the vault name for every other row in Steps 4–6 (Step 5's
+`bench-fn-base` included).
 
 ```
 # 1. Fresh vault
@@ -117,35 +117,43 @@ cp "<corpus>/Pension Order Morawetz CJ- March 17 2021(as stamped by Court).PDF"*
 cp "<corpus>/Annual-Financial-Report-19-20.pdf"* _INCOMING/
 cp "<corpus>/Annual-Financial-Report-20-21.pdf"* _INCOMING/
 watchdog chew
-
-# FREE cost preview — always run this first
-watchdog ingest \
-  --extractor-model sonnet --extractor-effort high \
-  --finalizer-model sonnet --finalizer-effort high --estimate
-
-# The real run (same flags, no --estimate)
-watchdog ingest \
-  --extractor-model sonnet --extractor-effort high \
-  --finalizer-model sonnet --finalizer-effort high
 ```
 
 Confirm the sidecars landed before trusting the run: `ls _INCOMING/*.yml` should list six files.
 Classification is skipped for every document (each is pinned by its own sidecar), so this is one
-`chew`/`ingest` pass instead of the two the corpus used to need — see `keys/README.md` for why.
+`chew`/`dig` pass instead of the two the corpus used to need — see `keys/README.md` for why.
+
+From here the two sweeps diverge (see Step 4 and Step 5): the extractor sweep only ever needs
+`watchdog dig`, since `score_arms.py` reads the staged `.watchdog/extracted/*.json` artifacts
+directly and those are written before any finalizer call. The finalizer sweep needs `watchdog
+bark` too, but only once per vault — extract once, copy the vault, finalize each copy
+differently.
 
 **Capture, per vault, before touching the next one** (the terminal output is not recoverable — page
 -coverage warnings and per-document digest-size lines print only there):
 
 ```
 watchdog usage --all > usage.txt      # token/cost/latency per stage
-cp -r briefings/ ../captures/<vault>-briefings/
-cp -r .watchdog/registry ../captures/<vault>-registry/
-# and save the scrollback of each ingest run
+cp -r .watchdog/extracted ../captures/<vault>-extracted/   # what score_arms.py reads
+# if bark ran: cp -r briefings/ ../captures/<vault>-briefings/
+#              cp -r .watchdog/registry ../captures/<vault>-registry/
+# and save the scrollback of each run
 ```
 
 ## Step 4 — extractor sweep (the spend)
 
-Finalizer fixed at `sonnet` / `high`. One vault each. Run `--estimate` before each.
+`watchdog dig` only — **no `bark`**. Everything this step scores (material-fact recall,
+`must_not_miss`, coverage warnings) is in the staged extraction artifacts before any finalizer
+call runs, so finalizing here would just spend money and time on a stage this step doesn't
+measure. One vault each. Run `--estimate` before each.
+
+```
+# FREE cost preview — always run this first
+watchdog dig --extractor-model sonnet --extractor-effort high --estimate
+
+# The real run (same flags, no --estimate)
+watchdog dig --extractor-model sonnet --extractor-effort high
+```
 
 | Vault | `--extractor-model` | `--extractor-effort` | Serves |
 |---|---|---|---|
@@ -158,15 +166,46 @@ Finalizer fixed at `sonnet` / `high`. One vault each. Run `--estimate` before ea
 | `bench-ex-ds-pro` | `deepseek:deepseek-v4-pro` | — | DeepSeek pro, thinking off |
 | `bench-ex-ds-pro-think` | `deepseek:deepseek-v4-pro-thinking` | — | DeepSeek pro, thinking on |
 
+**Correction:** the original `bench-ex-sonnet-high` and `bench-ex-sonnet-med` vaults were run
+(2026-07-15) before the `dig`/`bark` split shipped (#403, merged 2026-07-20/21) — they have no
+`.watchdog/extracted/*.json` at all, just the old committed vault notes. They do **not** score
+through the current `score_arms.py`, and still need a fresh `dig` run under new vault names
+(e.g. `bench-ex2-sonnet-high`, `bench-ex2-sonnet-med`) alongside `bench-ex2-haiku`.
+
 Optional expansion if the core set leaves a question open: `sonnet`/`low`, `opus`/`medium`.
 
-Score against the frozen keys: **material-fact recall** and **`must_not_miss`** (the extractor
-metrics). Also read the coverage warnings on the 70-page report — that is where cheap conditions
-degrade first.
+Score against the frozen keys with `score_arms.py` (Step 7): **material-fact recall** and
+**`must_not_miss`** (the extractor metrics). Also read the coverage warnings on the 70-page
+report, printed during `dig` itself — that is where cheap conditions degrade first.
+
+If you want a briefing to eyeball for a particular arm, run `watchdog bark` on that vault
+afterward — it's optional and doesn't change how the arm scores.
 
 ## Step 5 — finalizer sweep (cheap)
 
-Extractor fixed at `deepseek:deepseek-v4-flash`. One vault each.
+Extractor fixed at `deepseek:deepseek-v4-flash`. Unlike Step 4, **extract once and reuse it** —
+the finalizer metrics (entity-duplicate count, contradictions) depend only on `bark`, so paying
+for six fresh extractions of the same fixed input would be wasted spend:
+
+```
+# Following Step 3 with vault name "bench-fn-base":
+watchdog dig --extractor-model deepseek:deepseek-v4-flash --extractor-effort high
+
+cd ..
+cp -r bench-fn-base bench-fn-haiku
+cp -r bench-fn-base bench-fn-sonnet-high
+cp -r bench-fn-base bench-fn-sonnet-med
+cp -r bench-fn-base bench-fn-opus-high
+cp -r bench-fn-base bench-fn-ds-flash
+cp -r bench-fn-base bench-fn-ds-pro-think
+```
+
+Then, in each copy, `--estimate` first, then finalize:
+
+```
+cd bench-fn-haiku && watchdog bark --finalizer-model haiku --estimate
+watchdog bark --finalizer-model haiku
+```
 
 | Vault | `--finalizer-model` | `--finalizer-effort` |
 |---|---|---|
@@ -180,6 +219,7 @@ Extractor fixed at `deepseek:deepseek-v4-flash`. One vault each.
 Score: **entity-duplicate count** and **contradictions C1/C2** (the finalizer metrics). Read the
 contradictions from the `[!contradiction]` callouts written into the entity notes — each carries a
 label, both values, both document slugs, and both page numbers — not the briefing's "flagged" count.
+This also answers #432 (should reconciliation use Haiku?) — no separate protocol needed.
 
 ## Step 6 — classifier smoke test
 
@@ -213,8 +253,8 @@ Full scoring protocol and the decision rules are in **#361** and **`keys/README.
 - **Read the first scorecard by hand** before automating anything (#362).
 
 For a free first pass before any judge model runs, `score_arms.py` (this directory) scores the
-keys' numeric-anchored items — roughly a third of them — against one or more ingested vaults,
-offline, no model calls:
+keys' numeric-anchored items — roughly a third of them — against one or more benchmark vaults
+(dig-only or finalized, both work), offline, no model calls:
 
 ```
 ~/.local/pipx/venvs/watchdog-intel/bin/python tests/documents/score_arms.py \
@@ -231,6 +271,8 @@ First used for the Tier 0 checklist A/B (#412).
 Order-of-magnitude, from the per-token pricing (extraction is output-dominated). The full corpus on
 Sonnet is around $5; scale by the model's output rate relative to Sonnet ($15/Mtok): Haiku ~⅓,
 Opus ~1.7×, DeepSeek flash ~2% of Sonnet, DeepSeek pro ~6%; thinking variants add roughly 2–4× for
-the chain-of-thought. The extractor sweep lands near **$20**, dominated by the Opus and Sonnet arms;
-the finalizer sweep and classifier test are **~$2** combined. **`watchdog ingest --estimate` is the
-real number — trust it over this paragraph**, and run it before every condition.
+the chain-of-thought. Dropping `bark` from the extractor sweep (Step 4) removes a Sonnet/high
+finalize from every arm, so the sweep now lands near **$15** instead of $20, still dominated by
+the Opus and Sonnet extractor arms; the finalizer sweep (one extraction, six finalize calls) and
+classifier test are **~$2** combined. **`watchdog dig --estimate` / `watchdog bark --estimate` are
+the real numbers — trust them over this paragraph**, and run one before every condition.

--- a/tests/documents/score_arms.py
+++ b/tests/documents/score_arms.py
@@ -1,15 +1,19 @@
 """Deterministic anchor-based scorer: frozen corpus-v1 keys vs benchmark-arm vaults (#412).
 
 Not a pytest module — a standalone benchmark tool (no ``test_`` prefix, so pytest never
-collects it). Run it against one or more ingested benchmark vaults:
+collects it). Run it against one or more benchmark vaults, dig-only or fully finalized:
 
     ~/.local/pipx/venvs/watchdog-intel/bin/python tests/documents/score_arms.py \
         ~/Investigations/bench-ex-sonnet-med ~/Investigations/bench-t0-sonnet-med ...
 
 For each key item (facts F*, must_not_miss M*), it pulls numeric anchors from the key text,
 generates formatting variants (comma-grouped, thousands-as-millions decimal, rounded $M),
-and checks them against the vault's extraction-derived markdown (documents/, entities/,
-timeline.md — never morgue/ or _INCOMING/, which would credit the raw source).
+and checks them against `.watchdog/extracted/*.json` — the raw per-document extraction
+artifacts `watchdog dig` stages before any finalizer call. Scoring against these instead of
+the committed vault notes means `watchdog bark` never needs to run for an extractor-only
+arm, and the finalizer's reconciliation/synthesis pass can't dilute the measurement — the
+artifacts persist after `bark` too, so this reads the same regardless of whether a vault has
+been finalized.
 
 Caveats (same spirit as the #215 verbatim tier, see keys/README.md): this RANKS arms against
 the same fixed reference — it is not absolute recall. Scoring is blob-level (no citation
@@ -18,6 +22,7 @@ provenance), so sibling documents can cross-credit; only ~a third of key items c
 First used for the Tier 0 checklist A/B recorded in #412.
 """
 import glob
+import json
 import os
 import re
 import sys
@@ -59,14 +64,23 @@ def norm(text):
     return re.sub(r"(\d),(\d)", r"\1\2", text.lower())   # strip thousands commas
 
 
+def _strings(obj):
+    if isinstance(obj, str):
+        return obj
+    if isinstance(obj, dict):
+        return " ".join(_strings(v) for v in obj.values())
+    if isinstance(obj, list):
+        return " ".join(_strings(v) for v in obj)
+    return ""
+
+
 def vault_text(vault):
     parts = []
-    for pat in ("documents/*.md", "entities/**/*.md", "timeline.md"):
-        for f in glob.glob(os.path.join(vault, pat), recursive=True):
-            try:
-                parts.append(open(f, encoding="utf-8").read())
-            except OSError:
-                pass
+    for f in glob.glob(os.path.join(vault, ".watchdog", "extracted", "*.json")):
+        try:
+            parts.append(_strings(json.loads(open(f, encoding="utf-8").read())))
+        except (OSError, json.JSONDecodeError):
+            pass
     return norm("\n".join(parts))
 
 

--- a/tests/documents/seed_bench.sh
+++ b/tests/documents/seed_bench.sh
@@ -1,0 +1,20 @@
+root=/Users/tcardoso/Investigations
+master="$root/master-vault"
+
+dests=(
+  "$root/bench-ex2-sonnet-med"
+  "$root/bench-ex2-haiku"
+  "$root/bench-ex2-ds-flash"
+  "$root/bench-ex2-ds-flash-think"
+  "$root/bench-ex2-ds-pro"
+  "$root/bench-ex2-ds-pro-think"
+)
+
+for dest in "${dests[@]}"; do
+  mkdir -p "$dest/.watchdog/staging" "$dest/.watchdog/queue"
+  cp -r "$master/.watchdog/staging/." "$dest/.watchdog/staging/"
+  cp "$master/.watchdog/queue/"*.json "$dest/.watchdog/queue/"
+  sed -i '' "s#${master}#${dest}#g" "$dest"/.watchdog/queue/*.json
+  n=$(ls "$dest/.watchdog/queue/"*.json 2>/dev/null | wc -l | tr -d ' ')
+  echo "seeded $dest ($n queued)"
+done


### PR DESCRIPTION
## Summary

- `BENCHMARKING.md` and `score_arms.py` updated to reflect #403's `dig`/`bark` split: the extractor sweep (Step 4) now runs `watchdog dig` only — no `bark` — since everything it scores lives in the staged `.watchdog/extracted/*.json` artifacts before any finalizer call runs, so `score_arms.py` reads those directly instead of the committed vault notes.
- The finalizer sweep (Step 5) now extracts once into a base vault and copies it per finalizer arm, instead of re-extracting for each one.
- Adds `seed_bench.sh`, which seeds a master vault's staged queue into each `bench-ex2-*` arm directory for the extractor sweep.
- Adds `BENCHMARK-RESULTS.md`, the running log of extractor-sweep scores as each arm completes (currently: DeepSeek flash/pro, thinking and non-thinking; Sonnet/Haiku arms pending).

## Test plan
- Documentation and benchmark-tooling changes only; no pipeline code touched. `score_arms.py` is a standalone offline scorer (not pytest-collected) — no test suite changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)