### PR TITLE
Fix claude-api 400: file_metadata schema missing additionalProperties

### DIFF
--- a/src/watchdog/pipeline/schemas.py
+++ b/src/watchdog/pipeline/schemas.py
@@ -106,11 +106,15 @@ _DOCUMENT = _obj(
         "obtained": _NULLABLE_STR,
         "summary": {"type": "string"},
         "key_facts": {"type": "array", "items": _KEY_FACT},
-        "file_metadata": {"type": "object"},
+        "file_metadata": _obj({}, []),
     },
     # sha256/filename/original_path/page_count, source/obtained, and file_metadata are stamped
     # by Python (orchestrate._stamp_document) — deterministic values the pipeline already holds,
     # not echoed by the model. They stay in `properties` (optional) so the stamped dict validates.
+    # file_metadata is `_obj({}, [])` rather than a bare `{"type": "object"}` because Claude's
+    # strict structured-output mode (output_config.format.schema) rejects any object-type node
+    # that doesn't explicitly declare `additionalProperties` — closed-and-empty is correct here
+    # anyway, since the model never fills this field.
     ["title", "document_type", "summary", "key_facts"],
 )
 

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -1,0 +1,47 @@
+"""Structural checks on the model-reasoning schemas (`pipeline/schemas.py`).
+
+Claude's strict structured-output mode (`output_config.format.schema`) rejects any object-type
+schema node that doesn't explicitly declare `additionalProperties` — every `{"type": "object"}`
+in this module is meant to go through the `_obj()` helper, which always sets it, but a bare
+literal dict (like the `file_metadata` bug this guards against) bypasses that and slips through
+silently until a live call 400s.
+"""
+from watchdog.pipeline import schemas
+
+
+def _object_nodes_missing_additional_properties(node, path="$") -> list[str]:
+    """Recursively walk a schema, returning the path of every object-type node that omits
+    `additionalProperties` — regardless of how deeply it's nested in `properties`/`items`."""
+    missing = []
+    if not isinstance(node, dict):
+        return missing
+    if node.get("type") == "object" and "additionalProperties" not in node:
+        missing.append(path)
+    for key, sub in (node.get("properties") or {}).items():
+        missing += _object_nodes_missing_additional_properties(sub, f"{path}.{key}")
+    items = node.get("items")
+    if items:
+        missing += _object_nodes_missing_additional_properties(items, f"{path}[]")
+    return missing
+
+
+_ALL_SCHEMAS = {
+    name: getattr(schemas, name)
+    for name in ("EXTRACTION", "SECTION", "CLASSIFY", "DIGEST", "SYNTHESIS", "RECONCILE",
+                 "BRIEFING", "TIMELINE_DEDUP", "TIMELINE_PRECISION_MATCH")
+}
+
+
+def test_every_object_node_declares_additional_properties():
+    for name, schema in _ALL_SCHEMAS.items():
+        missing = _object_nodes_missing_additional_properties(schema)
+        assert not missing, f"{name} has object node(s) missing 'additionalProperties': {missing}"
+
+
+def test_file_metadata_is_closed_and_empty():
+    """The model never fills this field (Python stamps real values in after the call, D-none —
+    see schemas.py's comment on _DOCUMENT) — closed-and-empty is the correct schema for it, not
+    just the one that satisfies Claude's strict mode."""
+    file_metadata = schemas.EXTRACTION["properties"]["document"]["properties"]["file_metadata"]
+    assert file_metadata["additionalProperties"] is False
+    assert file_metadata["properties"] == {}


### PR DESCRIPTION
## Summary

Every extraction call on the `claude-api` backend was failing with a 400:
```
output_config.format.schema: For 'object' type, 'additionalProperties' must be explicitly set to false
```

Claude's strict structured-output mode rejects any object-type schema node that doesn't declare `additionalProperties` explicitly. `schemas.py`'s `document.file_metadata` was a bare `{"type": "object"}` — the one field in the whole schema that bypassed the `_obj()` helper, which always sets it. Everything else in the file already goes through `_obj()`.

Fixed with `_obj({}, [])` — closed and empty. This is also the semantically correct schema independent of the API requirement: `file_metadata` is never filled by the model — Python stamps real values into it afterward, via `orchestrate._stamp_document` — so the model's own output should never have had a permissive shape to fill it with in the first place. Confirmed safe against the one other place `file_metadata` is touched: `_stamp_document` runs after the schema-validated model response is already returned, mutating the plain dict directly — no re-validation against this schema follows it, so a real (non-empty) `file_metadata` stamped in later is never checked against the now-closed field.

`tests/test_schemas.py` (new) recursively walks every schema in the module checking for an object-type node missing `additionalProperties`, so a future bare `{"type": "object"}` slipping in outside `_obj()` fails a test instead of a live call.

## Test plan
- [x] `PYTHONPATH=src pytest` — full suite green (1785 passed)
- [x] `ruff check src tests` — clean
- [x] Mutation-tested: reverted the fix, confirmed both new tests go red with the exact real error's shape, restored