### PR TITLE
Make the benchmark runner terse; fix the ctrl+c-per-arm problem

### DIFF
--- a/benchmarks/BENCHMARKING.md
+++ b/benchmarks/BENCHMARKING.md
@@ -13,6 +13,23 @@ paying for the whole ~$15 sweep. An unknown id is a hard error, not a silent ful
 run_benchmark.py --stages extractor --arms sonnet-med-sdk,sonnet-med-api
 ```
 
+**A real run is terse — one line per arm, not the underlying pipeline's own verbose output.**
+This is developer-only tooling, so `watchdog dig`/`watchdog bark`'s usual per-document progress,
+warnings, and elapsed ticker are suppressed; you get `[i/N] stage:arm  ✓/✗  duration` and nothing
+else per arm. Full failure detail — including a per-document failure that `cmd_extract` catches
+and tallies internally rather than raising, which an `ok`-only summary would miss entirely — goes
+to `errors.log` in the run's report folder, not the terminal; a failed or partially-failed arm's
+terse line just says `(see errors.log)`. Report folders are named to the minute
+(`benchmarks/2026-07-29-1432/`), not just the date, so more than one session in a day gets its
+own folder without a manual `-2`/`-3` disambiguation.
+
+**Ctrl+C stops the whole run, not just the current arm.** `cmd_extract`/`cmd_finalize` trap a
+SIGINT internally and return normally (finishing in-flight writes first) rather than raising —
+without something checking for that, a single interrupt only ever stopped the *current* arm, and
+the runner just started the next one's real API calls. The runner now reads that signal off the
+return value and stops the whole matrix after the interrupted arm finishes, instead of requiring
+one Ctrl+C per remaining arm.
+
 **Pin the Claude backend when it is what you are measuring (#475).** A bare `sonnet` arm carries
 no backend of its own — `_effective_extract_backend` picks one from the *current auth mode*
 (subscription → `claude-agent-sdk`, api-key → `claude-api`). Those two bill materially different

--- a/benchmarks/bench_report.py
+++ b/benchmarks/bench_report.py
@@ -15,9 +15,10 @@ import yaml
 
 
 def run_id(now: datetime | None = None, *, existing: set[str] | None = None) -> str:
-    """"YYYY-MM-DD", or "YYYY-MM-DD-2"/"-3"/... if that name is already taken (`existing`, or —
-    when not given — an empty set, i.e. always the bare date)."""
-    base = (now or datetime.now()).date().isoformat()
+    """"YYYY-MM-DD-HHMM", or "-2"/"-3"/... if that exact minute is already taken (`existing`, or —
+    when not given — an empty set). Minute precision (not just the date) so more than one run in
+    a day gets its own folder without colliding — a working session often means several."""
+    base = (now or datetime.now()).strftime("%Y-%m-%d-%H%M")
     taken = existing if existing is not None else set()
     if base not in taken:
         return base
@@ -226,6 +227,22 @@ def docs_summary_md(results: list, scores: dict) -> str:
     return "\n".join(lines)
 
 
+def _errors_log_text(results: list) -> str:
+    """Full failure detail for every arm that had any — a hard failure (`error`, arm-level) or
+    per-document failures caught and tallied internally by cmd_extract/cmd_finalize (`doc_errors`
+    — these never raise, so `ok` alone misses them). Kept out of the terminal (run_benchmark.py's
+    terse per-arm line just says "see errors.log") and out of REPORT.md's tables, which are
+    read as much for their shape as their content."""
+    blocks = []
+    for r in results:
+        if r.error:
+            blocks.append(f"{r.stage}:{r.arm_id}\n  {r.error}")
+        elif r.doc_errors:
+            body = "\n".join(f"  {e}" for e in r.doc_errors)
+            blocks.append(f"{r.stage}:{r.arm_id}\n{body}")
+    return "\n\n".join(blocks)
+
+
 def write_run(out_root: Path, results: list, scores: dict, config: dict) -> Path:
     out_root = Path(out_root)
     existing = {p.name for p in out_root.iterdir()} if out_root.is_dir() else set()
@@ -246,14 +263,20 @@ def write_run(out_root: Path, results: list, scores: dict, config: dict) -> Path
         "## Classifier smoke test", "", classifier_table_md(results), "",
         "## Classifier model sweep", "", classifier_sweep_table_md(results), "",
     ]
-    failed = [r for r in results if not r.ok]
+    failed = [r for r in results if not r.ok or r.doc_errors]
     if failed:
-        report += ["## Failed arms", ""]
-        report += [f"- `{r.stage}:{r.arm_id}` — {r.error}" for r in failed]
+        report += ["## Failed arms", "", "Full detail in `errors.log`.", ""]
+        report += [f"- `{r.stage}:{r.arm_id}` — "
+                  + (r.error if r.error else f"{len(r.doc_errors)} document(s) failed")
+                  for r in failed]
         report.append("")
     (run_dir / "REPORT.md").write_text("\n".join(report), encoding="utf-8")
     (run_dir / "docs-summary.md").write_text(docs_summary_md(results, scores), encoding="utf-8")
     (run_dir / "config.yaml").write_text(yaml.safe_dump(config, sort_keys=False), encoding="utf-8")
+
+    errors_text = _errors_log_text(results)
+    if errors_text:
+        (run_dir / "errors.log").write_text(errors_text + "\n", encoding="utf-8")
 
     artifacts = run_dir / "artifacts"
     for r in results:

--- a/benchmarks/run_benchmark.py
+++ b/benchmarks/run_benchmark.py
@@ -29,6 +29,7 @@ import io
 import os
 import shutil
 import sys
+import time
 from dataclasses import dataclass, field
 from pathlib import Path
 from types import SimpleNamespace
@@ -283,7 +284,13 @@ class ArmResult:
     vault: Path | None
     ok: bool
     skipped: bool = False          # true only for classifier-sweep with an empty corpus
+    cancelled: bool = False        # ctrl+c during this arm — the whole run stops after it
     error: str | None = None
+    # Per-document failures inside an otherwise-successful call (cmd_extract/cmd_finalize catch
+    # these internally and return normally — `ok` alone would miss them entirely, silently, once
+    # the terse runner stops printing the underlying pipeline's own per-document error lines).
+    # Written to errors.log by bench_report.write_run, not the terminal.
+    doc_errors: list[str] = field(default_factory=list)
     estimate: dict | None = None
     usage: dict | None = None
     extra: dict = field(default_factory=dict)
@@ -353,6 +360,16 @@ def _in_vault(vault: Path):
         os.chdir(prev)
 
 
+def _doc_errors(summary: dict | None) -> list[str]:
+    """Per-document failures from a cmd_extract summary — caught and tallied internally
+    (`_guarded`'s except Exception), never raised, so `ok=True` at the ArmResult level says
+    nothing about whether every document actually succeeded."""
+    if not summary:
+        return []
+    return [f"{r.get('filename') or r.get('sha256', '?')}: {r.get('reason', '')}"
+           for r in summary.get("results", []) if r.get("status") not in ("ok", "skipped", "cancelled")]
+
+
 def run_extractor_arm(arm: dict, vault: Path) -> ArmResult:
     from watchdog.cmd import ingest as ing
     ns = SimpleNamespace(command="dig", extractor_model=arm["extractor_model"],
@@ -360,11 +377,12 @@ def run_extractor_arm(arm: dict, vault: Path) -> ArmResult:
                         force=False, skip_warning=True, wait=False, no_finalize=True)
     try:
         with _in_vault(vault):
-            ing.cmd_extract(ns)
+            summary = _quiet(ing.cmd_extract, ns)
     except SystemExit as e:
         return ArmResult(arm_id=arm["id"], stage="extractor", vault=vault, ok=False, error=str(e))
     return ArmResult(arm_id=arm["id"], stage="extractor", vault=vault, ok=True,
-                     usage=_latest_usage(vault))
+                     cancelled=bool((summary or {}).get("cancelled")),
+                     doc_errors=_doc_errors(summary), usage=_latest_usage(vault))
 
 
 def run_finalizer_arm(arm: dict, vault: Path) -> ArmResult:
@@ -374,11 +392,14 @@ def run_finalizer_arm(arm: dict, vault: Path) -> ArmResult:
                         skip_briefing=False)
     try:
         with _in_vault(vault):
-            ing.cmd_finalize(ns)
+            out = _quiet(ing.cmd_finalize, ns)
     except SystemExit as e:
         return ArmResult(arm_id=arm["id"], stage="finalizer", vault=vault, ok=False, error=str(e))
+    # A finalize failure (rate limit, reconciliation error) is also caught and returned rather
+    # than raised — same silent-`ok=True` trap as extraction's per-document failures.
+    reason = (out or {}).get("error") or (out or {}).get("briefing_error")
     return ArmResult(arm_id=arm["id"], stage="finalizer", vault=vault, ok=True,
-                     usage=_latest_usage(vault))
+                     doc_errors=[reason] if reason else [], usage=_latest_usage(vault))
 
 
 def _classify_results(vault: Path, expected: dict[str, str]) -> dict:
@@ -405,13 +426,17 @@ def run_classifier_smoke(arm: dict, vault: Path, expected: dict[str, str]) -> Ar
                             skip_warning=True, wait=False, no_finalize=True)
     try:
         with _in_vault(vault):
-            ing.cmd_extract(ex_ns)
+            ex_summary = _quiet(ing.cmd_extract, ex_ns)
+            if (ex_summary or {}).get("cancelled"):
+                return ArmResult(arm_id=arm["id"], stage="classifier", vault=vault, ok=True,
+                                 cancelled=True, doc_errors=_doc_errors(ex_summary))
             fn_ns = SimpleNamespace(finalizer_model=arm["finalizer_model"], finalizer_effort=None,
                                     estimate=False, skip_briefing=True)
-            ing.cmd_finalize(fn_ns)
+            _quiet(ing.cmd_finalize, fn_ns)
     except SystemExit as e:
         return ArmResult(arm_id=arm["id"], stage="classifier", vault=vault, ok=False, error=str(e))
     return ArmResult(arm_id=arm["id"], stage="classifier", vault=vault, ok=True,
+                     doc_errors=_doc_errors(ex_summary),
                      extra={"classification": _classify_results(vault, expected)})
 
 
@@ -423,14 +448,18 @@ def run_classifier_sweep_arm(arm: dict, vault: Path, fixed: dict, expected: dict
                             no_finalize=True)
     try:
         with _in_vault(vault):
-            ing.cmd_extract(ex_ns)
+            ex_summary = _quiet(ing.cmd_extract, ex_ns)
+            if (ex_summary or {}).get("cancelled"):
+                return ArmResult(arm_id=arm["id"], stage="classifier-sweep", vault=vault, ok=True,
+                                 cancelled=True, doc_errors=_doc_errors(ex_summary))
             fn_ns = SimpleNamespace(finalizer_model=fixed["finalizer_model"], finalizer_effort=None,
                                     estimate=False, skip_briefing=True)
-            ing.cmd_finalize(fn_ns)
+            _quiet(ing.cmd_finalize, fn_ns)
     except SystemExit as e:
         return ArmResult(arm_id=arm["id"], stage="classifier-sweep", vault=vault, ok=False,
                          error=str(e))
     return ArmResult(arm_id=arm["id"], stage="classifier-sweep", vault=vault, ok=True,
+                     doc_errors=_doc_errors(ex_summary),
                      extra={"classification": _classify_results(vault, expected)})
 
 
@@ -478,6 +507,24 @@ def confirm_run(previews: list[tuple[str, dict, dict]], *, estimate_only: bool) 
     if estimate_only:
         return False
     return interactive.confirm(f"\nRun {len(previews)} arm(s)?", default=False)
+
+
+def _arm_line(i: int, total: int, label: str, result: ArmResult, elapsed: float) -> str:
+    """One terse line per finished arm. Developer-only tool — the underlying pipeline's own
+    verbose per-document output (progress rows, warnings, an elapsed ticker) is suppressed
+    (`_quiet`) during a real run in favour of this; full failure detail goes to errors.log,
+    not the terminal, so a bad arm doesn't have to be read off a scrolling wall of text."""
+    width = len(str(total))
+    secs = int(elapsed)
+    dur = f"{secs // 60}m{secs % 60:02d}s"
+    idx = f"[{i:>{width}}/{total}]"
+    if result.cancelled:
+        return f"  {idx} {label:<28} interrupted"
+    if not result.ok or result.doc_errors:
+        n = len(result.doc_errors)
+        detail = f"{n} failed" if n else "failed"
+        return f"  {idx} {label:<28} ✗ {detail}  {dur}  (see errors.log)"
+    return f"  {idx} {label:<28} ✓  {dur}"
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -639,24 +686,32 @@ def main(argv: list[str] | None = None) -> int:
         return 0
 
     from watchdog.cmd.ingest import _caffeinate
+    total = len(plan)
+    print(f"\nRunning {total} arm(s)…\n")
     with _caffeinate():
-        for kind, ctx in plan:
+        for i, (kind, ctx) in enumerate(plan, 1):
+            start = time.monotonic()
             if kind == "extractor":
-                results.append(run_extractor_arm(ctx["arm"], ctx["vault"]))
+                result = run_extractor_arm(ctx["arm"], ctx["vault"])
             elif kind == "finalizer":
-                results.append(run_finalizer_arm(ctx["arm"], ctx["vault"]))
+                result = run_finalizer_arm(ctx["arm"], ctx["vault"])
             elif kind == "classifier":
-                results.append(run_classifier_smoke(ctx["arm"], ctx["vault"], expected_skills))
+                result = run_classifier_smoke(ctx["arm"], ctx["vault"], expected_skills)
             elif kind == "classifier-sweep":
-                results.append(run_classifier_sweep_arm(ctx["arm"], ctx["vault"], ctx["fixed"],
-                                                        ctx["expected"]))
+                result = run_classifier_sweep_arm(ctx["arm"], ctx["vault"], ctx["fixed"],
+                                                  ctx["expected"])
             elif kind == "sdk-check":
                 # Same extraction path as the main sweep (run_extractor_arm), relabelled so it's
                 # excluded from extractor-sweep recall scoring and the six-document cost summary
                 # below — its two-document corpus doesn't match either one.
                 result = run_extractor_arm(ctx["arm"], ctx["vault"])
                 result.stage = "sdk-check"
-                results.append(result)
+            results.append(result)
+            print(_arm_line(i, total, f"{kind}:{ctx['arm']['id']}", result,
+                            time.monotonic() - start))
+            if result.cancelled:
+                print(f"\nRun stopped — {i} of {total} arm(s) completed.")
+                break
 
     import bench_report
     vaults_to_score = [str(r.vault) for r in results
@@ -665,7 +720,9 @@ def main(argv: list[str] | None = None) -> int:
     scores = score_vaults(vaults_to_score) if vaults_to_score else {
         "vaults": [], "detail": [], "totals": {"facts": {}, "must_not_miss": {}}, "unscorable": []}
     out_dir = bench_report.write_run(args.out, results, scores, config)
-    print(f"\nReport written to {out_dir}")
+    n_failed = sum(1 for r in results if not r.ok or r.doc_errors)
+    tail = f" — {n_failed} arm(s) had failures, see errors.log" if n_failed else ""
+    print(f"\nReport written to {out_dir}{tail}")
     return 0
 
 

--- a/src/watchdog/cmd/ingest.py
+++ b/src/watchdog/cmd/ingest.py
@@ -685,7 +685,7 @@ def _requeue_failed(vault: Path) -> int:
     return len(files)
 
 
-def cmd_ingest(args, *, confirm: bool = True, skip_preview: bool = False) -> None:
+def cmd_ingest(args, *, confirm: bool = True, skip_preview: bool = False) -> dict | None:
     vault = Path(".").resolve()
     if not (vault / ".watchdog").is_dir():
         sys.exit("Error: must be run from inside a Watchdog vault directory")
@@ -1026,6 +1026,7 @@ def cmd_ingest(args, *, confirm: bool = True, skip_preview: bool = False) -> Non
         _handle_force_gate(vault, summary, post_model, post_effort, post_backend,
                            skip_briefing=skip_briefing, finalizer_overrides=finalizer_overrides)
     _print_ingest_summary(summary, pipeline_hint)
+    return summary
 
 
 def _print_ingest_summary(summary: dict, pipeline_hint: str = "watchdog") -> None:
@@ -1097,17 +1098,17 @@ def _print_ingest_summary(summary: dict, pipeline_hint: str = "watchdog") -> Non
         print(f"\n  {_DIM}Open a fresh Claude Code session to ask investigation questions.{_RESET}\n")
 
 
-def cmd_extract(args) -> None:
+def cmd_extract(args) -> dict | None:
     """`watchdog dig` (#425, renamed from `extract` in #441/D138) — classify + extract queued
     documents, staging the artifacts, and stop before finalize. A thin wrapper around
     `cmd_ingest` with finalization forced off: inherits the estimate path, cost preview, skill
     pinning, `--wait`, the lock/summary machinery, and the "run watchdog bark next" closing
     message for free."""
     args.no_finalize = True
-    cmd_ingest(args)
+    return cmd_ingest(args)
 
 
-def cmd_finalize(args) -> None:
+def cmd_finalize(args) -> dict | None:
     """`watchdog bark` (renamed from `finalize` in #441/D138) — complete post-ingest (entity
     reconciliation + synthesis + timeline + briefing) for an already-extracted batch.
 
@@ -1163,7 +1164,7 @@ def cmd_finalize(args) -> None:
                      f"  Run {_CYAN}watchdog setup{_RESET}{_DIM} to choose how to authenticate.{_RESET}\n")
 
 
-    _run_finalize(vault, post_model, post_effort, post_backend,
+    return _run_finalize(vault, post_model, post_effort, post_backend,
                  skip_briefing=getattr(args, "skip_briefing", False),
                  finalizer_overrides=finalizer_overrides)
 

--- a/tests/test_benchmark_runner.py
+++ b/tests/test_benchmark_runner.py
@@ -340,6 +340,37 @@ def test_confirm_run_asks_once_when_not_estimate_only(monkeypatch):
     assert len(calls) == 1
 
 
+# ── _arm_line: the terse per-arm terminal output ───────────────────────────────
+
+def test_arm_line_ok():
+    text = rb._arm_line(1, 16, "extractor:haiku", _arm_result(), 74.0)
+    assert "1/16" in text
+    assert "extractor:haiku" in text
+    assert "✓" in text
+    assert "1m14s" in text
+
+
+def test_arm_line_hard_failure_points_to_errors_log():
+    text = rb._arm_line(2, 16, "extractor:sonnet-low", _arm_result(ok=False, error="boom"), 3.0)
+    assert "✗" in text
+    assert "errors.log" in text
+
+
+def test_arm_line_per_document_failures_not_masked_by_ok_true():
+    """The exact real-world case: cmd_extract returns ok=True with everything failed inside."""
+    text = rb._arm_line(3, 16, "extractor:sonnet-med",
+                        _arm_result(ok=True, doc_errors=["a: x", "b: y"]), 3.0)
+    assert "✗" in text
+    assert "2 failed" in text
+    assert "errors.log" in text
+
+
+def test_arm_line_cancelled():
+    text = rb._arm_line(4, 16, "extractor:haiku", _arm_result(cancelled=True), 12.0)
+    assert "interrupted" in text
+    assert "✓" not in text and "✗" not in text
+
+
 # ── resilience: try/except SystemExit per arm ──────────────────────────────────
 
 def test_run_extractor_arm_records_failure_without_raising(monkeypatch, tmp_path):
@@ -390,6 +421,39 @@ def test_run_extractor_arm_restores_cwd_even_on_failure(monkeypatch, tmp_path):
     assert Path.cwd() == outside
 
 
+def test_run_extractor_arm_suppresses_cmd_extract_stdout(monkeypatch, tmp_path, capsys):
+    """The runner is terse by design (#benchmark-ux) — the underlying pipeline's own verbose
+    per-document output must not leak to the terminal during a real run."""
+    def _noisy(ns):
+        print("Sending 6 documents to a cloud AI model.")
+        return {"cancelled": False, "results": []}
+    monkeypatch.setattr(wd_ingest, "cmd_extract", _noisy)
+    rb.run_extractor_arm({"id": "haiku", "extractor_model": "haiku"}, tmp_path)
+    assert "Sending 6 documents" not in capsys.readouterr().out
+
+
+def test_run_extractor_arm_picks_up_cancelled_from_summary(monkeypatch, tmp_path):
+    """cmd_extract traps ctrl+c internally and returns normally with `cancelled: True` — no
+    exception to catch, so this has to come from the return value now that cmd_ingest exposes it."""
+    monkeypatch.setattr(wd_ingest, "cmd_extract", lambda ns: {"cancelled": True, "results": []})
+    result = rb.run_extractor_arm({"id": "haiku", "extractor_model": "haiku"}, tmp_path)
+    assert result.ok is True
+    assert result.cancelled is True
+
+
+def test_run_extractor_arm_captures_per_document_failures(monkeypatch, tmp_path):
+    """A per-document failure (e.g. the file_metadata schema bug) is caught inside cmd_extract
+    and tallied in `results`, never raised — `ok` alone would miss it entirely."""
+    summary = {"cancelled": False, "results": [
+        {"sha256": "a1", "filename": "doc1.pdf", "status": "failed", "reason": "400: bad schema"},
+        {"sha256": "a2", "filename": "doc2.pdf", "status": "ok"},
+    ]}
+    monkeypatch.setattr(wd_ingest, "cmd_extract", lambda ns: summary)
+    result = rb.run_extractor_arm({"id": "haiku", "extractor_model": "haiku"}, tmp_path)
+    assert result.ok is True
+    assert result.doc_errors == ["doc1.pdf: 400: bad schema"]
+
+
 # ── run_finalizer_arm delegates correctly ──────────────────────────────────────
 
 def test_run_finalizer_arm_passes_arm_knobs_through(monkeypatch, tmp_path):
@@ -413,6 +477,26 @@ def test_run_finalizer_arm_records_failure(monkeypatch, tmp_path):
     result = rb.run_finalizer_arm({"id": "haiku", "finalizer_model": "haiku"}, tmp_path)
     assert result.ok is False
     assert result.error == "locked"
+
+
+def test_run_finalizer_arm_captures_non_raised_failure(monkeypatch, tmp_path):
+    """A rate limit or reconciliation error during finalize is returned, not raised (same
+    silent-ok=True trap as extraction's per-document failures) — _run_finalize's own `out.get
+    ("error")` check, mirrored here so the terse runner can flag it too."""
+    monkeypatch.setattr(wd_ingest, "cmd_finalize",
+                        lambda ns: {"error": "rate limit reached"})
+    result = rb.run_finalizer_arm({"id": "haiku", "finalizer_model": "haiku"}, tmp_path)
+    assert result.ok is True
+    assert result.doc_errors == ["rate limit reached"]
+
+
+def test_run_finalizer_arm_suppresses_cmd_finalize_stdout(monkeypatch, tmp_path, capsys):
+    def _noisy(ns):
+        print("Finalizing — entity reconciliation + synthesis + timeline + briefing.")
+        return {}
+    monkeypatch.setattr(wd_ingest, "cmd_finalize", _noisy)
+    rb.run_finalizer_arm({"id": "haiku", "finalizer_model": "haiku"}, tmp_path)
+    assert "Finalizing" not in capsys.readouterr().out
 
 
 # ── classifier-sweep skip path ─────────────────────────────────────────────────
@@ -518,6 +602,60 @@ def test_write_run_layout(tmp_path):
 
     run_dir_2 = br.write_run(out_root, results, scores, config)
     assert run_dir_2 != run_dir
+
+
+# ── run_id: minute precision so multiple sessions in a day don't collide ───────
+
+def test_run_id_includes_time_not_just_date():
+    from datetime import datetime
+    rid = br.run_id(datetime(2026, 7, 29, 14, 32))
+    assert rid == "2026-07-29-1432"
+
+
+def test_run_id_still_dedupes_within_the_same_minute():
+    from datetime import datetime
+    now = datetime(2026, 7, 29, 14, 32)
+    first = br.run_id(now)
+    second = br.run_id(now, existing={first})
+    assert second == f"{first}-2"
+
+
+# ── write_run: errors.log ───────────────────────────────────────────────────────
+
+def test_write_run_writes_errors_log_for_a_hard_failure(tmp_path):
+    results = [_arm_result(arm_id="sonnet-low", ok=False, error="auth not configured")]
+    scores = {"totals": {"facts": {}, "must_not_miss": {}}, "detail": [], "unscorable": [],
+             "vaults": []}
+    config = {"corpus": {"sha256": "c"}, "keys": {"sha256": "k"}}
+    run_dir = br.write_run(tmp_path / "benchmarks", results, scores, config)
+    log = (run_dir / "errors.log").read_text()
+    assert "extractor:sonnet-low" in log
+    assert "auth not configured" in log
+    assert "errors.log" in (run_dir / "REPORT.md").read_text()
+
+
+def test_write_run_writes_errors_log_for_per_document_failures(tmp_path):
+    """The exact real-world case: ok=True at the arm level, but every document inside failed —
+    REPORT.md's tables alone would show this arm looking indistinguishable from a clean run."""
+    results = [_arm_result(arm_id="sonnet-med", ok=True,
+                          doc_errors=["doc1.pdf: 400 bad schema", "doc2.pdf: 400 bad schema"])]
+    scores = {"totals": {"facts": {}, "must_not_miss": {}}, "detail": [], "unscorable": [],
+             "vaults": []}
+    config = {"corpus": {"sha256": "c"}, "keys": {"sha256": "k"}}
+    run_dir = br.write_run(tmp_path / "benchmarks", results, scores, config)
+    log = (run_dir / "errors.log").read_text()
+    assert "doc1.pdf: 400 bad schema" in log
+    assert "doc2.pdf: 400 bad schema" in log
+    assert "2 document(s) failed" in (run_dir / "REPORT.md").read_text()
+
+
+def test_write_run_omits_errors_log_when_nothing_failed(tmp_path):
+    results = [_arm_result(arm_id="haiku", ok=True)]
+    scores = {"totals": {"facts": {}, "must_not_miss": {}}, "detail": [], "unscorable": [],
+             "vaults": []}
+    config = {"corpus": {"sha256": "c"}, "keys": {"sha256": "k"}}
+    run_dir = br.write_run(tmp_path / "benchmarks", results, scores, config)
+    assert not (run_dir / "errors.log").exists()
 
 
 # ── score_arms.py refactor regression ──────────────────────────────────────────
@@ -728,6 +866,41 @@ def test_arms_filter_rejects_an_unknown_arm_id(tmp_path, monkeypatch):
     monkeypatch.setattr(rb, "corpus_documents", lambda d: [Path("a.pdf")])
     with pytest.raises(SystemExit, match="unknown arm id"):
         rb.main(["--config", str(cfg), "--stages", "extractor", "--arms", "sonnet-med-sdkk"])
+
+
+# ── ctrl+c stops the whole run, not just the current arm ───────────────────────
+
+def test_cancelled_arm_stops_the_run_before_the_next_arm(tmp_path, monkeypatch, capsys):
+    """cmd_extract traps ctrl+c internally and returns normally (`cancelled: True` in its
+    summary) rather than raising — before this fix the outer loop had no way to see that and
+    just started the next arm's real API calls, which is why a single ctrl+c wasn't enough."""
+    cfg = _matrix_config(tmp_path)   # sonnet-med-sdk, sonnet-med-api, haiku — three arms
+    monkeypatch.setattr(rb, "verify_freeze", lambda *a, **k: None)
+    monkeypatch.setattr(rb, "corpus_documents", lambda d: [Path("a.pdf")])
+    monkeypatch.setattr(rb, "ensure_master_vault", lambda *a, **k: tmp_path / "master")
+    monkeypatch.setattr(rb, "seed_arm_vault", lambda *a, **k: None)
+    monkeypatch.setattr(rb, "arm_vault", lambda prefix, aid, root: tmp_path / f"{prefix}-{aid}")
+    monkeypatch.setattr(rb, "preview_extractor_arm", lambda v, m: {"cost_low": 1.0, "cost_high": 2.0})
+    monkeypatch.setattr(rb, "arm_backend", lambda m, default: "claude-api")
+    monkeypatch.setattr(rb, "_auth_mode", lambda: "api-key")
+    monkeypatch.setattr(wd_interactive, "confirm", lambda *a, **k: True)
+
+    calls = []
+
+    def _fake_run_extractor_arm(arm, vault):
+        calls.append(arm["id"])
+        cancelled = arm["id"] == "sonnet-med-sdk"   # the first arm run
+        return rb.ArmResult(arm_id=arm["id"], stage="extractor", vault=vault, ok=True,
+                            cancelled=cancelled)
+
+    monkeypatch.setattr(rb, "run_extractor_arm", _fake_run_extractor_arm)
+    monkeypatch.setattr(br, "write_run", lambda *a, **k: tmp_path)
+
+    rb.main(["--config", str(cfg), "--stages", "extractor"])
+
+    assert calls == ["sonnet-med-sdk"]   # sonnet-med-api and haiku never ran
+    out = capsys.readouterr().out
+    assert "Run stopped — 1 of 3 arm(s) completed." in out
 
 
 # ── sdk-check stage (#482 follow-up) ───────────────────────────────────────────


### PR DESCRIPTION
## Summary

Two related fixes to `run_benchmark.py` (dev-only tool, never shipped), both from watching a real run:

**Terse output.** `watchdog dig`/`watchdog bark`'s usual verbose per-document output (progress rows, warnings, elapsed ticker) is suppressed during a real run in favour of one line per arm: `[i/N] stage:arm  ✓/✗  duration`. Full failure detail — including a per-document failure that `cmd_extract` catches and tallies internally rather than raising, which `ArmResult.ok` alone would silently miss — goes to `errors.log` in the run's report folder instead of the terminal; a failed arm's terse line just points there. Report folders are now named to the minute (`benchmarks/2026-07-29-1432/`) rather than just the date, so multiple sessions in a day each get their own folder.

**Ctrl+C now stops the whole run, not just the current arm.** `cmd_extract`/`cmd_finalize` trap SIGINT internally and return normally (finishing in-flight writes first) rather than raising — `cmd_ingest` already computed whether a run was cancelled, it just never returned it, so the outer loop had no way to know and just started the next arm's real API calls. That's the actual mechanism behind needing to hit Ctrl+C once per remaining arm. `cmd_ingest`/`cmd_extract`/`cmd_finalize` now return their summary dict instead of `None` (backward compatible — every other caller already discards the return value), and the runner checks it to stop the whole matrix after the interrupted arm finishes.

Also answers a design question along the way: cross-arm parallelism isn't implemented here (deliberately out of scope) — `cmd_extract`/`cmd_finalize` resolve their vault from the process's current working directory (`os.chdir`, global state), so running arms concurrently in threads would race. Real parallelism needs either per-arm subprocesses or a deeper fix making the vault path explicit instead of cwd-based.

## Test plan
- [x] `PYTHONPATH=src pytest` — full suite green (1798 passed)
- [x] `ruff check src tests benchmarks` — clean
- [x] Mutation-tested the cancel-and-break logic (disabled it, confirmed the integration test catches the runner marching on to arms 2 and 3, restored)
- [x] New tests cover: output suppression, cancellation propagation from cmd_extract's return value, per-document failure capture (the exact "ok=True but everything failed" case), `_arm_line` formatting, timestamped run ids, and `errors.log` presence/absence