### PR TITLE
Print a running… line before each arm starts

### DIFF
--- a/benchmarks/run_benchmark.py
+++ b/benchmarks/run_benchmark.py
@@ -509,15 +509,29 @@ def confirm_run(previews: list[tuple[str, dict, dict]], *, estimate_only: bool) 
     return interactive.confirm(f"\nRun {len(previews)} arm(s)?", default=False)
 
 
+def _arm_idx(i: int, total: int) -> str:
+    return f"[{i:>{len(str(total))}}/{total}]"
+
+
+def _arm_starting_line(i: int, total: int, label: str) -> str:
+    """Printed the moment an arm begins, before its own line in the run loop. A real extraction
+    arm can run for several minutes (a 209-page document at high effort), and `_quiet` suppresses
+    the underlying pipeline's own progress output entirely — without this there is nothing on
+    screen to say the run is alive rather than hung. A second, separate line rather than
+    overwriting this one in place (`\\r`): the runner's own scrolling design is meant to survive
+    being piped to a log file, which in-place terminal updates don't."""
+    return f"  {_arm_idx(i, total)} {label:<28} running…"
+
+
 def _arm_line(i: int, total: int, label: str, result: ArmResult, elapsed: float) -> str:
-    """One terse line per finished arm. Developer-only tool — the underlying pipeline's own
-    verbose per-document output (progress rows, warnings, an elapsed ticker) is suppressed
-    (`_quiet`) during a real run in favour of this; full failure detail goes to errors.log,
-    not the terminal, so a bad arm doesn't have to be read off a scrolling wall of text."""
-    width = len(str(total))
+    """One terse line per finished arm, printed after `_arm_starting_line`'s. Developer-only
+    tool — the underlying pipeline's own verbose per-document output (progress rows, warnings, an
+    elapsed ticker) is suppressed (`_quiet`) during a real run in favour of this; full failure
+    detail goes to errors.log, not the terminal, so a bad arm doesn't have to be read off a
+    scrolling wall of text."""
     secs = int(elapsed)
     dur = f"{secs // 60}m{secs % 60:02d}s"
-    idx = f"[{i:>{width}}/{total}]"
+    idx = _arm_idx(i, total)
     if result.cancelled:
         return f"  {idx} {label:<28} interrupted"
     if not result.ok or result.doc_errors:
@@ -690,6 +704,8 @@ def main(argv: list[str] | None = None) -> int:
     print(f"\nRunning {total} arm(s)…\n")
     with _caffeinate():
         for i, (kind, ctx) in enumerate(plan, 1):
+            label = f"{kind}:{ctx['arm']['id']}"
+            print(_arm_starting_line(i, total, label), flush=True)
             start = time.monotonic()
             if kind == "extractor":
                 result = run_extractor_arm(ctx["arm"], ctx["vault"])
@@ -707,8 +723,7 @@ def main(argv: list[str] | None = None) -> int:
                 result = run_extractor_arm(ctx["arm"], ctx["vault"])
                 result.stage = "sdk-check"
             results.append(result)
-            print(_arm_line(i, total, f"{kind}:{ctx['arm']['id']}", result,
-                            time.monotonic() - start))
+            print(_arm_line(i, total, label, result, time.monotonic() - start))
             if result.cancelled:
                 print(f"\nRun stopped — {i} of {total} arm(s) completed.")
                 break

--- a/tests/test_benchmark_runner.py
+++ b/tests/test_benchmark_runner.py
@@ -371,6 +371,16 @@ def test_arm_line_cancelled():
     assert "✓" not in text and "✗" not in text
 
 
+def test_arm_starting_line_shares_index_and_label_with_the_completion_line():
+    """Printed before a (possibly minutes-long) arm begins, so there is something on screen
+    while it's running — without it, a real extraction call leaves the terminal silent for as
+    long as the call takes, indistinguishable from a hang."""
+    text = rb._arm_starting_line(5, 16, "extractor:sonnet-high")
+    assert "5/16" in text
+    assert "extractor:sonnet-high" in text
+    assert "running" in text
+
+
 # ── resilience: try/except SystemExit per arm ──────────────────────────────────
 
 def test_run_extractor_arm_records_failure_without_raising(monkeypatch, tmp_path):
@@ -901,6 +911,9 @@ def test_cancelled_arm_stops_the_run_before_the_next_arm(tmp_path, monkeypatch, 
     assert calls == ["sonnet-med-sdk"]   # sonnet-med-api and haiku never ran
     out = capsys.readouterr().out
     assert "Run stopped — 1 of 3 arm(s) completed." in out
+    # Printed before the fake arm ran — proof the "running…" line isn't just a formatter that
+    # exists but is never actually called from the loop.
+    assert "extractor:sonnet-med-sdk" in out and "running" in out
 
 
 # ── sdk-check stage (#482 follow-up) ───────────────────────────────────────────


### PR DESCRIPTION
## Summary

Follow-up to #485. The terse per-arm output only printed once an arm completed — during a real extraction call (several minutes on a large document at high effort), `_quiet` suppresses the underlying pipeline's own progress output entirely, so the terminal sat completely silent the whole time. From the outside that's indistinguishable from a hang (confirmed live: had to check process/file state directly to verify a run was actually progressing, not stuck).

Now prints `[i/N] stage:arm  running…` the moment an arm starts. Deliberately a second line rather than an in-place `\r` overwrite of the same line — the runner's whole scrolling-output design (from #485) is meant to survive being piped to a log file, which terminal control codes don't.

## Test plan
- [x] Full suite green, lint clean
- [x] Mutation-tested: removed the print call from the loop, confirmed the integration test (which checks the running-line for the specific arm that gets cancelled) goes red, restored