### PR TITLE
Fix claude-api 400: schema exceeds Claude's optional-parameter limit

### DIFF
--- a/src/watchdog/pipeline/schemas.py
+++ b/src/watchdog/pipeline/schemas.py
@@ -93,28 +93,27 @@ _ENTITY = _obj(
     ["id", "name", "type"],
 )
 
+# sha256/filename/original_path/page_count, source/obtained, file_metadata, and (on EXTRACTION,
+# below) morgue_document_type used to sit in these schemas too, as optional properties — the
+# model never fills any of them (orchestrate._stamp_document sets every one unconditionally,
+# after the model call returns, straight from pf/sha/document_type — never reading a pre-existing
+# value first), so they were pure dead weight from the model's perspective. They were kept
+# "so the stamped dict validates" against this same schema, but nothing actually re-validates
+# the stamped dict afterward — jsonschema validation only ever runs on the model's raw response,
+# before stamping (model_client.acomplete_json / batch_extract.collect). Claude's strict
+# structured-output mode counts every optional property toward a hard complexity limit
+# ("Schemas contains too many optional parameters (28)... limit: 24") and nullable-typed ones
+# disproportionately so — corpus-v1's dense 70-page document hit exactly this, 400ing every
+# claude-api extraction outright. Dropping these seven dead properties is a genuine schema
+# correction, not just a workaround: they were never part of the model's actual contract.
 _DOCUMENT = _obj(
     {
-        "sha256": {"type": "string"},
-        "filename": {"type": "string"},
-        "original_path": _NULLABLE_STR,
         "title": {"type": "string"},
         "document_type": {"type": "string"},
         "date_of_document": _NULLABLE_STR,
-        "page_count": {"type": ["integer", "null"]},
-        "source": _NULLABLE_STR,
-        "obtained": _NULLABLE_STR,
         "summary": {"type": "string"},
         "key_facts": {"type": "array", "items": _KEY_FACT},
-        "file_metadata": _obj({}, []),
     },
-    # sha256/filename/original_path/page_count, source/obtained, and file_metadata are stamped
-    # by Python (orchestrate._stamp_document) — deterministic values the pipeline already holds,
-    # not echoed by the model. They stay in `properties` (optional) so the stamped dict validates.
-    # file_metadata is `_obj({}, [])` rather than a bare `{"type": "object"}` because Claude's
-    # strict structured-output mode (output_config.format.schema) rejects any object-type node
-    # that doesn't explicitly declare `additionalProperties` — closed-and-empty is correct here
-    # anyway, since the model never fills this field.
     ["title", "document_type", "summary", "key_facts"],
 )
 
@@ -124,9 +123,6 @@ EXTRACTION = _obj(
         "document": _DOCUMENT,
         "entities": {"type": "array", "items": _ENTITY},
         "morgue_entity_id": {"type": "string"},
-        # morgue_document_type is derived in Python as slugify(document.document_type)
-        # (orchestrate._stamp_document) — kept optional here so the stamped dict validates.
-        "morgue_document_type": {"type": "string"},
         "scratchpad": {"type": "string"},   # curated briefing notes (Step 9 of the old skill)
         # Concrete documents this document refers to that a reporter could go and get (#365) —
         # moved out of scratchpad, not duplicated. Optional: omit entirely when none apply.

--- a/tests/test_batch_extract.py
+++ b/tests/test_batch_extract.py
@@ -90,7 +90,7 @@ def _not_succeeded(custom_id, rtype):
 VALID_EXTRACTION = {
     "document": {"title": "Acme AR", "document_type": "Annual Report",
                 "date_of_document": None, "summary": "s", "key_facts": []},
-    "entities": [], "morgue_entity_id": "acme-corp", "morgue_document_type": "annual-report",
+    "entities": [], "morgue_entity_id": "acme-corp",
     "scratchpad": "",
 }
 

--- a/tests/test_model_client.py
+++ b/tests/test_model_client.py
@@ -759,8 +759,8 @@ def test_prune_unknown_removes_nested_array_item_key():
 
 
 def test_prune_unknown_leaves_free_form_object_untouched():
-    # file_metadata is a real example (schemas.py's _DOCUMENT): a plain {"type": "object"}
-    # with no additionalProperties:False, so its contents must never be touched.
+    # A hypothetical free-form object property: a plain {"type": "object"} with no
+    # additionalProperties:False, so its contents must never be touched.
     free_form_schema = {
         "type": "object",
         "properties": {"file_metadata": {"type": "object"}},

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -1,10 +1,14 @@
 """Structural checks on the model-reasoning schemas (`pipeline/schemas.py`).
 
-Claude's strict structured-output mode (`output_config.format.schema`) rejects any object-type
-schema node that doesn't explicitly declare `additionalProperties` — every `{"type": "object"}`
-in this module is meant to go through the `_obj()` helper, which always sets it, but a bare
-literal dict (like the `file_metadata` bug this guards against) bypasses that and slips through
-silently until a live call 400s.
+Two real constraints Claude's strict structured-output mode (`output_config.format.schema`)
+enforces, both of which fail a live call outright (400) rather than degrading gracefully:
+
+1. Every object-type schema node must explicitly declare `additionalProperties` — every
+   `{"type": "object"}` in this module is meant to go through the `_obj()` helper, which always
+   sets it, but a bare literal dict bypasses that and slips through silently until a live call
+   hits it.
+2. A hard cap on total optional (non-required) properties across the whole schema tree
+   ("Schemas contains too many optional parameters... limit: 24").
 """
 from watchdog.pipeline import schemas
 
@@ -38,10 +42,57 @@ def test_every_object_node_declares_additional_properties():
         assert not missing, f"{name} has object node(s) missing 'additionalProperties': {missing}"
 
 
-def test_file_metadata_is_closed_and_empty():
-    """The model never fills this field (Python stamps real values in after the call, D-none —
-    see schemas.py's comment on _DOCUMENT) — closed-and-empty is the correct schema for it, not
-    just the one that satisfies Claude's strict mode."""
-    file_metadata = schemas.EXTRACTION["properties"]["document"]["properties"]["file_metadata"]
-    assert file_metadata["additionalProperties"] is False
-    assert file_metadata["properties"] == {}
+def _count_optional(node, total=0) -> int:
+    """Total optional (non-required) properties across every nested object/array in a schema
+    tree — the same shape of count Claude's strict structured-output mode enforces a hard limit
+    against ("Schemas contains too many optional parameters... limit: 24")."""
+    if not isinstance(node, dict):
+        return total
+    if node.get("type") == "object":
+        props = node.get("properties") or {}
+        required = set(node.get("required") or [])
+        total += sum(1 for k in props if k not in required)
+        for sub in props.values():
+            total = _count_optional(sub, total)
+    items = node.get("items")
+    if items:
+        total = _count_optional(items, total)
+    return total
+
+
+# Anthropic doesn't document the exact counting rule (confirmed unclear even in their own repo's
+# issue tracker as of this writing) — nullable-typed optional fields appear to cost more than
+# plain ones. Margin sized against that: EXTRACTION/SECTION have at most one nullable optional
+# field each (document.date_of_document) after this fix, so even a 2x worst case adds only ~1 —
+# comfortably inside a margin of 2, without demanding headroom the schema has no more room to give
+# (SECTION's own top-level optionality is genuine per-section business logic — see
+# schemas.py's SECTION comment — not padding left to trim).
+_CLAUDE_OPTIONAL_PARAM_LIMIT = 24
+_SAFETY_MARGIN = 2
+
+
+def test_extraction_and_section_stay_under_claudes_optional_parameter_limit():
+    for name in ("EXTRACTION", "SECTION"):
+        n = _count_optional(getattr(schemas, name))
+        assert n <= _CLAUDE_OPTIONAL_PARAM_LIMIT - _SAFETY_MARGIN, (
+            f"{name} has {n} optional properties, too close to Claude's strict-mode limit of "
+            f"{_CLAUDE_OPTIONAL_PARAM_LIMIT} (every claude-api extraction 400s outright when "
+            f"this is exceeded) — this is a real API constraint, not a style preference")
+
+
+def test_document_has_no_python_stamped_fields():
+    """sha256/filename/original_path/page_count/source/obtained/file_metadata are set
+    unconditionally by orchestrate._stamp_document after the model call returns — the model
+    never fills any of them (confirmed: _stamp_document never reads a pre-existing value first).
+    They don't belong in the model-facing schema; keeping them was the direct cause of hitting
+    Claude's optional-parameter limit on corpus-v1's dense document."""
+    doc_props = set(schemas.EXTRACTION["properties"]["document"]["properties"])
+    stamped_only = {"sha256", "filename", "original_path", "page_count", "source",
+                    "obtained", "file_metadata"}
+    assert doc_props.isdisjoint(stamped_only)
+
+
+def test_extraction_has_no_morgue_document_type():
+    """Same dead-weight pattern as document's stamped fields — orchestrate._stamp_document
+    unconditionally derives this as slugify(document_type), never reading the model's value."""
+    assert "morgue_document_type" not in schemas.EXTRACTION["properties"]


### PR DESCRIPTION
## Summary

Every `claude-api` extraction call failed outright: *"Schemas contains too many optional parameters (28), which would make grammar compilation inefficient. Reduce the number of optional parameters in your tool schemas (limit: 24)."* Confirmed live against both corpus-v1's 70-page dense document and, after several minutes of apparent internal retries, a plain 5-page smoke test too — the limit is on the schema itself, not document size (background: [anthropics/anthropic-sdk-python#1185](https://github.com/anthropics/anthropic-sdk-python/issues/1185) confirms Anthropic doesn't document the exact counting rule, and that nullable-typed optional fields cost disproportionately more).

**Root cause:** `sha256`/`filename`/`original_path`/`page_count`/`source`/`obtained`/`file_metadata` (on `_DOCUMENT`) and `morgue_document_type` (on `EXTRACTION`) were declared as optional properties purely "so the stamped dict validates" — but `orchestrate._stamp_document` sets every one of them unconditionally after the model call returns, never reading a pre-existing value first, and nothing re-validates the stamped dict against this schema afterward (jsonschema validation only ever runs on the model's *raw* response, in `model_client.acomplete_json` / `batch_extract.collect`, before stamping). These eight fields were never actually part of the model's contract — dead weight that happened to push the schema over Claude's limit.

Removing them: `EXTRACTION` drops from 21 optional properties to 13, `SECTION` from 28 to 21 (via the shared `_DOCUMENT` properties dict) — both comfortably under the limit. This is a genuine schema correction, not a workaround grafted on to dodge an API quirk.

## Test plan
- [x] `PYTHONPATH=src pytest` — full suite green (1803 passed)
- [x] `ruff check src tests` — clean
- [x] Mutation-tested: reintroduced two of the eight dead fields, confirmed the new tests go red, restored
- [x] New tests: absence checks for the dead fields, plus a recursive optional-parameter counter with a regression guard against Claude's documented limit, so a future addition can't silently reintroduce this