### PR TITLE
Pin extractor_effort on the OpenAI/Gemini reasoning benchmark arms

### DIFF
--- a/benchmarks/benchmark.yaml
+++ b/benchmarks/benchmark.yaml
@@ -26,7 +26,14 @@ extractor_sweep:
     - {id: ds-pro,            extractor_model: "deepseek:deepseek-v4-pro"}
     - {id: ds-pro-think,      extractor_model: "deepseek:deepseek-v4-pro-thinking"}
     - {id: gemini-flash-lite, extractor_model: "gemini:gemini-3.1-flash-lite"}   # cheap tier
-    - {id: gemini-flash,      extractor_model: "gemini:gemini-3.5-flash"}       # middle tier
+    # No effort pinned above means no `reasoning_effort` is sent at all — Gemini accepts the knob
+    # unconditionally (unlike OpenAI, no reasoning-capability gate), so this ran on whatever
+    # implicit thinking budget Google defaults to. Measured at 15m21s for this corpus, the same
+    # ~51-call section split every enforces-max-tokens backend gets (see the gpt-* comment below)
+    # even though its output tokens stayed well under the per-call ceiling — the time cost here is
+    # pure section-count overhead, not runaway reasoning tokens. Pinned low for the same reason as
+    # the OpenAI arms: measure the model's real minimum-effort cost, not an unstated default.
+    - {id: gemini-flash,      extractor_model: "gemini:gemini-3.5-flash", extractor_effort: low}   # middle tier
     # Opus dropped (not worth testing this round).
     #
     # Backend A/B (#475). The arms above name a bare Claude tier, which resolves to
@@ -59,9 +66,23 @@ extractor_sweep:
     # that). So an OpenAI arm measures the model plus our weaker prompt-only enforcement, not the
     # model alone — a poor result here is genuinely ambiguous in a way a Gemini arm's isn't, by
     # our own schema-design choice rather than a model or provider defect. See D98.
-    - {id: gpt-nano,          extractor_model: "openai:gpt-5.4-nano"}   # cheap tier
-    - {id: gpt-mini,          extractor_model: "openai:gpt-5.4-mini"}   # middle tier
-    - {id: gpt-luna,          extractor_model: "openai:gpt-5.6-luna"}   # middle tier, 1.05M window
+    #
+    # All three are reasoning models (model_catalog.yaml's `reasoning: true`) and, unlike every
+    # Claude arm above, none pinned `extractor_effort` — so `reasoning_effort` was omitted from
+    # the request entirely and OpenAI applied its own default. Measured on this corpus, that
+    # default burned a median 12K-24K *output* tokens per section call (`gpt-mini` peaked at 46K,
+    # against a 48K hard ceiling) — reasoning tokens dwarfing the actual JSON, on section inputs
+    # capped at ~7K estimated tokens by the same conservative sectioning ceiling. That drove
+    # gpt-nano to 26min/$0.89 and gpt-mini to 43min/$5.71 for a 6-document corpus — see the
+    # investigation notes for the full numbers. Pinned to `low` so these arms measure each model's
+    # real minimum controllable cost instead of an unbounded implicit default. The section-count
+    # side of this (51 calls, ~22 of them for the 70-page report alone) is a separate, deeper
+    # issue in `output_ceiling_for_sectioning` shared with production `watchdog dig` — tracked
+    # separately rather than fixed here, since it needs real data on how much `low` effort alone
+    # changes the picture before touching sectioning math every ingest relies on.
+    - {id: gpt-nano,          extractor_model: "openai:gpt-5.4-nano", extractor_effort: low}   # cheap tier
+    - {id: gpt-mini,          extractor_model: "openai:gpt-5.4-mini", extractor_effort: low}   # middle tier
+    - {id: gpt-luna,          extractor_model: "openai:gpt-5.6-luna", extractor_effort: low}   # middle tier, 1.05M window
 
 finalizer_sweep:
   vault_prefix: bench-fn


### PR DESCRIPTION
## Summary
- `gpt-nano`/`gpt-mini`/`gpt-luna`/`gemini-flash` never set `extractor_effort`, so `reasoning_effort` was omitted entirely and each provider applied its own implicit default.
- Measured live on this corpus: `gpt-mini` burned a median 24K output tokens per section call (peak 46K against a 48K ceiling) on ~7K-token section inputs — reasoning tokens dwarfing the actual JSON — driving it to 43min/$5.71 for 6 documents. `gpt-nano` and `gemini-flash` showed the same shape at smaller scale (26min/$0.89 and 15min/$2.05 respectively).
- Pins all four to `extractor_effort: low`, matching every Claude arm's practice of pinning (or documenting a no-op default) instead of leaving effort unstated.

## Not included
The section-count side of this (51 calls per arm, ~22 for the 70-page report alone) is a separate, deeper issue in `output_ceiling_for_sectioning` — shared production code every real `watchdog dig` run on these backends relies on, not benchmark-only. Deliberately left untouched pending a follow-up rerun with `low` effort in hand, to see how much of the 51-call count was itself downstream of the unbounded default before touching shared sectioning math.

## Test plan
- [x] `pytest tests/test_benchmark_runner.py` (73 passed)
- [x] Full suite (1803 passed)
- [x] `ruff check src tests benchmarks` clean
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` confirms the four arms parse with `extractor_effort: low`