### PR TITLE
Fix batch collection: await batches.results() before iterating it

### DIFF
--- a/src/watchdog/pipeline/batch_extract.py
+++ b/src/watchdog/pipeline/batch_extract.py
@@ -128,7 +128,8 @@ async def collect(batch_id: str, api_key: str, model_id: str) -> dict[str, dict]
     business-rule validation still runs afterward, exactly as it does for a synchronous call."""
     client = _client(api_key)
     out: dict[str, dict] = {}
-    async for item in client.messages.batches.results(batch_id):
+    result_stream = await client.messages.batches.results(batch_id)
+    async for item in result_stream:
         sha = item.custom_id
         rtype = item.result.type
         if rtype != "succeeded":

--- a/tests/test_batch_extract.py
+++ b/tests/test_batch_extract.py
@@ -48,6 +48,23 @@ class _Obj:
         return dict(self.__dict__)
 
 
+class _FakeResultPage:
+    """Stands in for the SDK's `AsyncJSONLDecoder` — an object `results()` resolves to once
+    awaited, itself async-iterable. Distinct from `results()` being an async generator (the
+    shape this fake used to have), since that shape is directly iterable the moment it's called
+    and so hid the missing `await` in `batch_extract.collect` (the real SDK requires it)."""
+    def __init__(self, items):
+        self._items = list(items)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if not self._items:
+            raise StopAsyncIteration
+        return self._items.pop(0)
+
+
 class FakeBatches:
     def __init__(self, batch_id="batch_123", processing_status="ended",
                 request_counts=None, results=None):
@@ -65,8 +82,7 @@ class FakeBatches:
         return _Obj(processing_status=self.processing_status, request_counts=self.request_counts)
 
     async def results(self, batch_id):
-        for r in self._results:
-            yield r
+        return _FakeResultPage(self._results)
 
 
 class FakeClient:


### PR DESCRIPTION
## Summary
- `batch_extract.collect()` used `async for item in client.messages.batches.results(batch_id)` directly — but the Anthropic SDK's `results()` is an `async def` that must be awaited first to get the async-iterable results page. Hit live: `TypeError: 'async for' requires an object with __aiter__ method, got coroutine`, while collecting the `batch-sonnet-med` benchmark arm.
- The test fake hid this: `FakeBatches.results` was an async *generator* (`async def results(...): yield ...`), which is directly iterable the instant it's called — so it never exercised the missing `await` the real SDK requires.

## Fix
- `collect()`: `result_stream = await client.messages.batches.results(batch_id)`, then `async for item in result_stream`.
- Test fake rebuilt to match the real two-step shape: `results()` is now a plain `async def` returning a `_FakeResultPage` (`__aiter__`/`__anext__`), not a generator.

## Verification
Mutation-tested: reverted just the `collect()` fix (kept the corrected fake) and reran — reproduces the exact live `TypeError`, confirming the fake now genuinely catches this class of bug instead of masking it.

## Test plan
- [x] `pytest tests/test_batch_extract.py` (14 passed)
- [x] Full suite (1803 passed)
- [x] `ruff check src tests` clean