### PR TITLE
Surface batch lifecycle and real error detail from the Batches API

### DIFF
--- a/benchmarks/BENCHMARKING.md
+++ b/benchmarks/BENCHMARKING.md
@@ -13,6 +13,23 @@ paying for the whole ~$15 sweep. An unknown id is a hard error, not a silent ful
 run_benchmark.py --stages extractor --arms sonnet-med-sdk,sonnet-med-api
 ```
 
+**Redoing an already-run arm needs its vault deleted first.** Each arm's vault is a fixed path
+(`bench-ex-<arm-id>`, etc.) — rerunning the same arm id against an existing vault does not start
+over: `seed_arm_vault` refuses to reseed a vault that already has queue files
+(`"already seeded — refusing to reseed"`), and any document already extracted there is skipped
+outright, so the arm would just report "already extracted" for everything instead of producing
+new results. This comes up whenever an arm's config changes after it already ran once (an
+`extractor_effort` pin, a corrected model id) — delete that arm's folder(s), then rerun:
+
+```
+rm -rf benchmarks/.vaults/bench-ex-gpt-nano benchmarks/.vaults/bench-ex-gpt-mini
+run_benchmark.py --stages extractor --arms gpt-nano,gpt-mini
+```
+
+No separate deregistration step needed — shadow vaults under `benchmarks/.vaults/` are never
+added to `~/.watchdog/projects.json` or Obsidian's vault switcher in the first place (D146,
+below), so a plain folder delete is the whole cleanup.
+
 **A real run is terse — one line per arm, not the underlying pipeline's own verbose output.**
 This is developer-only tooling, so `watchdog dig`/`watchdog bark`'s usual per-document progress,
 warnings, and elapsed ticker are suppressed; you get `[i/N] stage:arm  ✓/✗  duration` and nothing

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -277,6 +277,8 @@ When a run used a Claude subscription, the costs shown are what the same work wo
 
 Each call's usage is written to disk as soon as it completes, not just when the run finishes — so a crash, a hard interrupt, or a stop mid-finalize still leaves that run's spend on record. If a run never reaches a clean end, its in-progress file is folded into a normal recorded run the next time you run `watchdog dig` or `watchdog bark`, and shows up in `watchdog usage` from then on.
 
+A batch-collected extractor stage (the Batches API's cheaper, asynchronous extraction path) gets an extra line under its header showing the batch's full lifecycle: when it was submitted, when Anthropic finished processing it, and when this vault actually collected the results — the last two routinely differ by hours, since a batch is submit-and-exit and only a *later* `watchdog dig` invocation notices it has finished and pulls the results in.
+
 ### watchdog export
 
 Exports the investigation's entity and relationship graph for network-analysis tools. The default writes Neo4j-import CSV (`nodes.csv` and `relationships.csv`, also loadable in Gephi); `--format cypher` writes a single `graph.cypher` of `MERGE` statements instead, and `--output DIR` sets the destination (default: `<slug>-export/`). The export is deterministic — it reads the registry, with no model calls. Only stated-direction relationships are exported (auto-generated reverse edges are skipped), and edges to never-profiled entities are dropped so the import stays valid.

--- a/src/watchdog/cmd/usage.py
+++ b/src/watchdog/cmd/usage.py
@@ -41,6 +41,36 @@ def _fmt_secs(s: float) -> str:
     return f"{s:.1f}s" if s < 60 else f"{s / 60:.1f}m"
 
 
+_BATCH_TS_FMT = "%Y-%m-%dT%H:%M:%SZ"
+
+
+def _batch_span(start: str | None, end: str | None) -> str | None:
+    """Human duration between two batch-lifecycle timestamps (orchestrate.py's `_BATCH_TS_FMT`
+    strings), or None if either is missing — `ended_at` predates this feature for any batch
+    collected before it shipped, and `collected_at` is absent from a non-batch call entirely."""
+    if not start or not end:
+        return None
+    import datetime
+    secs = (datetime.datetime.strptime(end, _BATCH_TS_FMT)
+           - datetime.datetime.strptime(start, _BATCH_TS_FMT)).total_seconds()
+    return _fmt_secs(max(secs, 0))
+
+
+def _batch_lifecycle_note(call: dict) -> str:
+    """`submitted -> ended -> collected` summary for a batch-collected stage — the middle and
+    last of those routinely differ by hours under D52's submit-and-exit design, since collection
+    happens whenever a later, unrelated `watchdog dig` invocation happens to notice the batch has
+    ended, not right after it does."""
+    submitted, ended, collected = (call.get("batch_submitted_at"), call.get("batch_ended_at"),
+                                   call.get("batch_collected_at"))
+    processed, idle = _batch_span(submitted, ended), _batch_span(ended, collected)
+    return (
+        f"batch {call.get('batch_id') or '?'} · submitted {submitted or '?'} · "
+        f"ended {ended or '?'}" + (f" (processed {processed})" if processed else "") +
+        f" · collected {collected or '?'}" + (f" (idle {idle})" if idle else "")
+    )
+
+
 def _wall_span(calls: list[dict]) -> float | None:
     """Wall-clock elapsed across `calls` — max(end) − min(start), where each call's start is
     `end_ts − latency_s`. This is the real time the calls took together, which for a stage that
@@ -363,6 +393,9 @@ def _analyze_run(usage_file: Path, vault: Path) -> None:
             # A local model's $0 cost is real, but it isn't "free" the way it reads at a glance
             # (#380) — it's paid in wall-clock time instead of tokens. Latency is the real signal.
             print(f"  {_DIM}local model — no per-token cost; Latency is the real cost signal here{_RESET}")
+        batch_call = next((c for c in stage_calls if c.get("batch_id")), None)
+        if batch_call:
+            print(f"  {_DIM}↳ {_batch_lifecycle_note(batch_call)}{_RESET}")
         totals = _print_stage(stage_calls)
         _accumulate(grand, totals)
         n_calls += len(stage_calls)

--- a/src/watchdog/pipeline/batch_extract.py
+++ b/src/watchdog/pipeline/batch_extract.py
@@ -110,13 +110,41 @@ def _model_dump(obj) -> dict:
     return obj.model_dump() if hasattr(obj, "model_dump") else dict(obj)
 
 
+def _iso(dt: datetime.datetime | None) -> str | None:
+    """A `MessageBatch` timestamp (a real `datetime`, per the SDK's own type) in the same
+    `%Y-%m-%dT%H:%M:%SZ` string shape `write_state` already stamps `submitted_at` with — so the
+    two are directly comparable without a second timestamp format anywhere in a batch's
+    lifecycle. `ended_at` is None until processing ends; passed through as None rather than a
+    placeholder string, since a caller that hasn't checked `processing_status` first shouldn't
+    be able to mistake "not finished yet" for a real timestamp."""
+    return dt.strftime("%Y-%m-%dT%H:%M:%SZ") if dt is not None else None
+
+
 async def status(batch_id: str, api_key: str) -> dict:
-    """Current `{"processing_status", "request_counts"}` for a submitted batch. Status starts
-    `in_progress` and becomes `ended` once every request has finished (succeeded/errored/
-    canceled/expired) and results are ready to collect."""
+    """Current `{"processing_status", "request_counts", "created_at", "ended_at"}` for a
+    submitted batch. Status starts `in_progress` and becomes `ended` once every request has
+    finished (succeeded/errored/canceled/expired) and results are ready to collect. `ended_at`
+    is None until then — Anthropic's own record of when processing finished, distinct from
+    `submitted_at` (this run's own clock, in the persisted batch state) and from whenever a
+    *later* run happens to notice `ended` and calls `collect` (D52's submit-and-exit design
+    means those two moments routinely differ by hours)."""
     client = _client(api_key)
     b = await client.messages.batches.retrieve(batch_id)
-    return {"processing_status": b.processing_status, "request_counts": _model_dump(b.request_counts)}
+    return {"processing_status": b.processing_status, "request_counts": _model_dump(b.request_counts),
+           "created_at": _iso(b.created_at), "ended_at": _iso(b.ended_at)}
+
+
+def _batch_error_text(err) -> str:
+    """Human string for a `MessageBatchErroredResult.error` (an `ErrorResponse` wrapping an
+    `ErrorObject` variant — every variant carries `type`/`message`) — falls back to `str(err)`
+    if the SDK's shape doesn't match what's expected here, since collection must never crash
+    over an error shape it didn't anticipate."""
+    inner = getattr(err, "error", None)
+    msg = getattr(inner, "message", None) if inner is not None else None
+    etype = getattr(inner, "type", None) if inner is not None else None
+    if msg:
+        return f"{etype}: {msg}" if etype else msg
+    return str(err)
 
 
 async def collect(batch_id: str, api_key: str, model_id: str) -> dict[str, dict]:
@@ -125,7 +153,14 @@ async def collect(batch_id: str, api_key: str, model_id: str) -> dict[str, dict]
     treatment a single call gets (`model_client._extract_json`/`_validate`), so the caller
     (`orchestrate._run_batch`) can feed a result straight into the same post-flight path used for
     any other extraction. `ok=True` only means schema-valid JSON came back — post-flight's own
-    business-rule validation still runs afterward, exactly as it does for a synchronous call."""
+    business-rule validation still runs afterward, exactly as it does for a synchronous call.
+
+    A succeeded item's `usage` carries `stop_reason` alongside the token counts (D125-style
+    truncation visibility — a batch call has no continuation/repair path the way a live call
+    does, so `"max_tokens"` here is the only signal that a result may be an incomplete JSON
+    fragment rather than genuinely malformed). An `errored` item's `error` is the real reason
+    Anthropic gave, not a generic "wasn't succeeded" placeholder — `canceled`/`expired` have no
+    further detail to give, so those stay generic."""
     client = _client(api_key)
     out: dict[str, dict] = {}
     result_stream = await client.messages.batches.results(batch_id)
@@ -133,13 +168,18 @@ async def collect(batch_id: str, api_key: str, model_id: str) -> dict[str, dict]
         sha = item.custom_id
         rtype = item.result.type
         if rtype != "succeeded":
+            reason = (f"batch result errored: {_batch_error_text(item.result.error)}"
+                      if rtype == "errored" else f"batch result was '{rtype}', not 'succeeded'")
             out[sha] = {"ok": False, "parsed": None, "usage": None, "cost_usd": None,
-                       "error": f"batch result was '{rtype}', not 'succeeded'"}
+                       "error": reason}
             continue
         message = item.result.message
         text = next((b.text for b in message.content if getattr(b, "type", None) == "text"), "")
         parsed = model_client._extract_json(text)
         usage_dict = _model_dump(message.usage)
+        stop_reason = getattr(message, "stop_reason", None)
+        if stop_reason:
+            usage_dict["stop_reason"] = stop_reason
         cost = model_client._batch_cost(model_id, message.usage)
         if parsed is None:
             out[sha] = {"ok": False, "parsed": None, "usage": usage_dict, "cost_usd": cost,

--- a/src/watchdog/pipeline/orchestrate.py
+++ b/src/watchdog/pipeline/orchestrate.py
@@ -86,7 +86,8 @@ def _record_usage(task: str, *, model: str, backend: str, usage: dict | None,
                   cost_usd: float | None, attempts: int = 1, latency_s: float = 0.0,
                   effort: str | None = None, auth_mode: str | None = None,
                   filename: str | None = None, detail: str | None = None,
-                  pruned: list[str] | None = None, failed: bool = False) -> None:
+                  pruned: list[str] | None = None, failed: bool = False,
+                  batch_meta: dict | None = None) -> None:
     """Append one call's usage to the run-scoped `_usage` accumulator, if one is active.
     Tolerates both Anthropic-style (`input_tokens`/`output_tokens`) and OpenAI-compatible
     (`prompt_tokens`/`completion_tokens`) usage dicts (D37) — the latter's cache-token fields
@@ -117,7 +118,15 @@ def _record_usage(task: str, *, model: str, backend: str, usage: dict | None,
 
     `failed` (D125): True when this record is a call that ultimately raised `ModelError` rather
     than returning — every attempt still spent real tokens, so it's recorded like any other call
-    (and counted in the same subtotals) rather than vanishing from telemetry."""
+    (and counted in the same subtotals) rather than vanishing from telemetry.
+
+    `usage["stop_reason"]`, when present (currently only `batch_extract.collect`'s items carry
+    it), is copied to the record — a batch call's only truncation signal, since it has no
+    continuation/repair path a live call gets. `batch_meta`
+    (`{batch_id, submitted_at, ended_at, collected_at}`, from `_resume_batch`) is copied onto the
+    record when given, so a batch-collected item's usage row carries its own full lifecycle
+    instead of that living only in the transient `batch-pending.json` state that's deleted once
+    collection succeeds."""
     if _usage is None:
         return
     u = usage or {}
@@ -134,10 +143,17 @@ def _record_usage(task: str, *, model: str, backend: str, usage: dict | None,
         record["api_ms"] = u["duration_api_ms"]
     if u.get("num_turns") is not None:
         record["num_turns"] = u["num_turns"]
+    if u.get("stop_reason"):
+        record["stop_reason"] = u["stop_reason"]
     if pruned:
         record["pruned"] = pruned
     if failed:
         record["failed"] = True
+    if batch_meta:
+        record["batch_id"] = batch_meta.get("batch_id")
+        record["batch_submitted_at"] = batch_meta.get("submitted_at")
+        record["batch_ended_at"] = batch_meta.get("ended_at")
+        record["batch_collected_at"] = batch_meta.get("collected_at")
     _usage.append(record)
     if _usage_partial_path is not None:
         # Durable per-call persistence (#407): appended synchronously, so a crash or a hard
@@ -922,7 +938,7 @@ def _finish_extraction(vault: Path, sha: str, filename: str, extraction: dict, s
 async def _finish_batch_item(vault: Path, sha: str, item: dict | None, skill_text: str,
                              skill_label: str, brief: str | None, api_key: str,
                              model: str | None = None, effort: str | None = None,
-                             force: bool = False) -> dict:
+                             force: bool = False, batch_meta: dict | None = None) -> dict:
     """Turn one collected batch result into a finished document. `item` is `batch_extract.collect`'s
     per-sha entry (or None if the batch has no result for this sha at all). A batch response that
     didn't pass schema validation gets exactly one synchronous claude-api repair attempt — not a
@@ -935,7 +951,9 @@ async def _finish_batch_item(vault: Path, sha: str, item: dict | None, skill_tex
     would silently never reach `usage-<ts>.json` — and, with `effort`, to stamp this document's
     extraction provenance (#268). `force` (#424) bypasses both "already done" skip checks below,
     same as `_extract_document` — the batch already ran, so bypassing just means the collected
-    result is staged/committed instead of discarded."""
+    result is staged/committed instead of discarded. `batch_meta` (from `_resume_batch`) is
+    passed straight through to `_record_usage` so this item's usage row carries the batch's own
+    submitted/ended/collected lifecycle, not just this call's own token counts."""
     pf = preflight.run(vault, sha)
     if pf.get("error"):
         return _fail(vault, sha, "", pf["error"])
@@ -963,7 +981,7 @@ async def _finish_batch_item(vault: Path, sha: str, item: dict | None, skill_tex
         # one _record_usage call site where auth_mode is a known constant, not a live result field.
         _record_usage("extract", model=model, backend="claude-batch", usage=item["usage"],
                       cost_usd=item.get("cost_usd"), effort=effort, auth_mode="api-key",
-                      filename=filename, detail=f"pages 1–{page_count}")
+                      filename=filename, detail=f"pages 1–{page_count}", batch_meta=batch_meta)
     if not item["ok"]:
         text = _pages_text(pf["pages"])
         # Off the event loop — see the comment in `_simple_extract`.
@@ -1018,6 +1036,45 @@ def _batch_skill(state: dict, sha: str, pinned_skill: str | None) -> tuple[str, 
         f"cannot rebuild its extraction prompt")
 
 
+_BATCH_TS_FMT = "%Y-%m-%dT%H:%M:%SZ"
+
+
+def _fmt_span(start_iso: str | None, end_iso: str | None) -> str | None:
+    """Human duration between two batch-lifecycle timestamps (`_BATCH_TS_FMT` strings), or None
+    if either is missing — `ended_at` is None until a batch finishes, and older persisted state
+    (written before this) has no `submitted_at`."""
+    if not start_iso or not end_iso:
+        return None
+    secs = int((datetime.datetime.strptime(end_iso, _BATCH_TS_FMT)
+               - datetime.datetime.strptime(start_iso, _BATCH_TS_FMT)).total_seconds())
+    m, s = divmod(max(secs, 0), 60)
+    h, m = divmod(m, 60)
+    return f"{h}h{m:02d}m{s:02d}s" if h else (f"{m}m{s:02d}s" if m else f"{s}s")
+
+
+def _batch_log_line(state: dict, st: dict, collected_at: str) -> str:
+    """One-line `ingest.log` summary of a collected batch's full lifecycle: submitted (this
+    run's own clock, persisted in batch state at submit time) -> ended (Anthropic's own record
+    of when processing finished) -> collected (right now) — the middle and last of those
+    routinely differ by hours under D52's submit-and-exit design, since collection happens in
+    a later, unrelated invocation that only reacts once it notices `ended`. Also carries
+    Anthropic's own request-count breakdown (succeeded/errored/etc.), so a partially-failed
+    batch is visible here even though `_finish_batch_item` reports each failure separately too."""
+    submitted, ended = state.get("submitted_at"), st.get("ended_at")
+    counts = st.get("request_counts") or {}
+    count_bits = ", ".join(f"{v} {k}" for k, v in counts.items() if v)
+    processed, idle = _fmt_span(submitted, ended), _fmt_span(ended, collected_at)
+    bits = [
+        f"BATCH {state['batch_id']}",
+        f"submitted {submitted or '?'}",
+        f"ended {ended or '?'}" + (f" (processed {processed})" if processed else ""),
+        f"collected {collected_at}" + (f" (idle {idle})" if idle else ""),
+    ]
+    if count_bits:
+        bits.append(count_bits)
+    return " · ".join(bits)
+
+
 async def _resume_batch(vault: Path, state: dict, pinned_skill: str | None, brief: str | None,
                         api_key: str, force: bool = False) -> dict:
     """Check a pending batch's status; collect and write it if `ended`, otherwise report
@@ -1034,6 +1091,9 @@ async def _resume_batch(vault: Path, state: dict, pinned_skill: str | None, brie
     _say(f"{_DIM}→  batch {state['batch_id']} finished — collecting {len(state['shas'])} "
          f"document{'s' if len(state['shas']) != 1 else ''}…{_RESET}")
     collected = await batch_extract.collect(state["batch_id"], api_key, state["model"])
+    collected_at = datetime.datetime.now(datetime.timezone.utc).strftime(_BATCH_TS_FMT)
+    batch_meta = {"batch_id": state["batch_id"], "submitted_at": state.get("submitted_at"),
+                 "ended_at": st.get("ended_at"), "collected_at": collected_at}
 
     results = []
     try:
@@ -1042,7 +1102,7 @@ async def _resume_batch(vault: Path, state: dict, pinned_skill: str | None, brie
             results.append(await _finish_batch_item(vault, sha, collected.get(sha), skill_text,
                                                      skill_label, brief, api_key,
                                                      model=state["model"], effort=state.get("effort"),
-                                                     force=force))
+                                                     force=force, batch_meta=batch_meta))
     except model_client.RateLimitError as e:
         # A repair-retry call (claude-api) hit a rate limit partway through collection. Leave
         # the batch state in place — already-written documents are safe (preflight's
@@ -1052,6 +1112,7 @@ async def _resume_batch(vault: Path, state: dict, pinned_skill: str | None, brie
              f"{_CYAN}{_resume_hint}{_RESET}{_DIM} to finish once it resets.{_RESET}")
         return {"results": results, "batch_pending": True}
 
+    _log(vault, _batch_log_line(state, st, collected_at))
     batch_extract.clear_state(vault)
     return {"results": results, "batch_pending": False}
 

--- a/tests/test_batch_extract.py
+++ b/tests/test_batch_extract.py
@@ -3,6 +3,7 @@ collect. The Anthropic SDK client is mocked at the `_client` boundary, matching 
 test_model_client.py mocks _ABACKENDS rather than the real (uninstalled) anthropic package."""
 
 import asyncio
+import datetime
 import json
 
 import pytest
@@ -67,11 +68,13 @@ class _FakeResultPage:
 
 class FakeBatches:
     def __init__(self, batch_id="batch_123", processing_status="ended",
-                request_counts=None, results=None):
+                request_counts=None, results=None, created_at=None, ended_at=None):
         self.batch_id = batch_id
         self.processing_status = processing_status
         self.request_counts = request_counts or {}
         self._results = results or []
+        self.created_at = created_at
+        self.ended_at = ended_at
         self.create_calls = []
 
     async def create(self, *, requests):
@@ -79,7 +82,8 @@ class FakeBatches:
         return _Obj(id=self.batch_id)
 
     async def retrieve(self, batch_id):
-        return _Obj(processing_status=self.processing_status, request_counts=self.request_counts)
+        return _Obj(processing_status=self.processing_status, request_counts=self.request_counts,
+                    created_at=self.created_at, ended_at=self.ended_at)
 
     async def results(self, batch_id):
         return _FakeResultPage(self._results)
@@ -90,17 +94,23 @@ class FakeClient:
         self.messages = _Obj(batches=batches)
 
 
-def _succeeded(custom_id, obj: dict, *, input_tokens=100, output_tokens=20):
+def _succeeded(custom_id, obj: dict, *, input_tokens=100, output_tokens=20, stop_reason="end_turn"):
     message = _Obj(
         content=[_Obj(type="text", text=json.dumps(obj))],
         usage=_Obj(input_tokens=input_tokens, output_tokens=output_tokens,
                   cache_creation_input_tokens=0, cache_read_input_tokens=0),
+        stop_reason=stop_reason,
     )
     return _Obj(custom_id=custom_id, result=_Obj(type="succeeded", message=message))
 
 
 def _not_succeeded(custom_id, rtype):
     return _Obj(custom_id=custom_id, result=_Obj(type=rtype, message=None))
+
+
+def _errored(custom_id, error_type, error_message):
+    err = _Obj(error=_Obj(type=error_type, message=error_message), type="error")
+    return _Obj(custom_id=custom_id, result=_Obj(type="errored", error=err))
 
 
 VALID_EXTRACTION = {
@@ -171,6 +181,23 @@ def test_status_reports_processing_state(monkeypatch):
     assert s["request_counts"] == {"processing": 5, "succeeded": 3}
 
 
+def test_status_reports_created_and_ended_at(monkeypatch):
+    created = datetime.datetime(2026, 7, 29, 2, 54, 46, tzinfo=datetime.timezone.utc)
+    ended = datetime.datetime(2026, 7, 29, 3, 36, 2, tzinfo=datetime.timezone.utc)
+    fake = FakeBatches(processing_status="ended", created_at=created, ended_at=ended)
+    monkeypatch.setattr(be, "_client", lambda api_key: FakeClient(fake))
+    s = asyncio.run(be.status("batch_abc", "sk-x"))
+    assert s["created_at"] == "2026-07-29T02:54:46Z"
+    assert s["ended_at"] == "2026-07-29T03:36:02Z"
+
+
+def test_status_ended_at_is_none_while_still_processing(monkeypatch):
+    fake = FakeBatches(processing_status="in_progress", ended_at=None)
+    monkeypatch.setattr(be, "_client", lambda api_key: FakeClient(fake))
+    s = asyncio.run(be.status("batch_abc", "sk-x"))
+    assert s["ended_at"] is None
+
+
 # ── collect ───────────────────────────────────────────────────────────────────
 
 def test_collect_maps_succeeded_results_by_sha(monkeypatch):
@@ -194,13 +221,34 @@ def test_collect_prices_at_half_the_standard_rate(monkeypatch):
     assert out["sha1"]["cost_usd"] == pytest.approx(1.5)   # $3/MTok input, batch halves it
 
 
-@pytest.mark.parametrize("rtype", ["errored", "canceled", "expired"])
+@pytest.mark.parametrize("rtype", ["canceled", "expired"])
 def test_collect_reports_non_succeeded_results(monkeypatch, rtype):
     fake = FakeBatches(results=[_not_succeeded("sha1", rtype)])
     monkeypatch.setattr(be, "_client", lambda api_key: FakeClient(fake))
     out = asyncio.run(be.collect("batch_abc", "sk-x", "claude-sonnet-4-6"))
     assert out["sha1"]["ok"] is False
     assert rtype in out["sha1"]["error"]
+
+
+def test_collect_surfaces_the_real_reason_for_an_errored_result(monkeypatch):
+    """An `errored` result carries Anthropic's actual reason (ErrorResponse.error.{type,
+    message}) — collapsing it to a generic "wasn't succeeded" string (the old behaviour, still
+    correct for canceled/expired, which carry no further detail) throws away real debugging
+    signal a live call's ModelError would have kept."""
+    fake = FakeBatches(results=[_errored("sha1", "invalid_request_error", "prompt too long")])
+    monkeypatch.setattr(be, "_client", lambda api_key: FakeClient(fake))
+    out = asyncio.run(be.collect("batch_abc", "sk-x", "claude-sonnet-4-6"))
+    assert out["sha1"]["ok"] is False
+    assert "invalid_request_error" in out["sha1"]["error"]
+    assert "prompt too long" in out["sha1"]["error"]
+
+
+def test_collect_includes_stop_reason_in_usage(monkeypatch):
+    results = [_succeeded("sha1", VALID_EXTRACTION, stop_reason="max_tokens")]
+    fake = FakeBatches(results=results)
+    monkeypatch.setattr(be, "_client", lambda api_key: FakeClient(fake))
+    out = asyncio.run(be.collect("batch_abc", "sk-x", "claude-sonnet-4-6"))
+    assert out["sha1"]["usage"]["stop_reason"] == "max_tokens"
 
 
 def test_collect_flags_unparseable_text_without_crashing(monkeypatch):

--- a/tests/test_orchestrate.py
+++ b/tests/test_orchestrate.py
@@ -2611,6 +2611,75 @@ def test_resume_batch_collects_and_clears_state_when_ended(tmp_path, monkeypatch
     assert batch_extract.read_state(vault) is None   # state cleared on a clean collection
 
 
+def test_fmt_span_formats_seconds_minutes_and_hours():
+    fmt = orchestrate._BATCH_TS_FMT
+    t0 = "2026-07-29T02:54:46Z"
+    assert orchestrate._fmt_span(t0, "2026-07-29T02:54:51Z") == "5s"
+    assert orchestrate._fmt_span(t0, "2026-07-29T03:36:02Z") == "41m16s"
+    assert orchestrate._fmt_span(t0, "2026-07-29T04:55:02Z") == "2h00m16s"
+    assert fmt == "%Y-%m-%dT%H:%M:%SZ"   # sanity: the format both sides actually use
+
+
+def test_fmt_span_is_none_when_either_timestamp_is_missing():
+    assert orchestrate._fmt_span(None, "2026-07-29T02:54:51Z") is None
+    assert orchestrate._fmt_span("2026-07-29T02:54:46Z", None) is None
+
+
+def test_resume_batch_logs_lifecycle_line_to_ingest_log(tmp_path, monkeypatch):
+    vault = make_vault(tmp_path)
+    _queue_doc(vault, sha="sha1", filename="a.pdf")
+    state = {"batch_id": "b1", "shas": ["sha1"], "model": "claude-sonnet-4-6",
+            "skill_label": "financial-statements", "effort": None,
+            "submitted_at": "2026-07-29T02:54:46Z"}
+    batch_extract.write_state(vault, state)
+
+    async def fake_status(batch_id, api_key):
+        return {"processing_status": "ended", "request_counts": {"succeeded": 1, "errored": 0},
+               "ended_at": "2026-07-29T03:36:02Z"}
+    monkeypatch.setattr(orchestrate.batch_extract, "status", fake_status)
+
+    async def fake_collect(batch_id, api_key, model_id):
+        return {"sha1": {"ok": True, "parsed": _extraction(sha="sha1", filename="a.pdf"),
+                         "usage": {}, "cost_usd": 0.02, "error": None}}
+    monkeypatch.setattr(orchestrate.batch_extract, "collect", fake_collect)
+
+    skill_file = tmp_path / "pinned.md"
+    skill_file.write_text("SKILL")
+    asyncio.run(orchestrate._resume_batch(vault, state, str(skill_file), None, "sk-x"))
+
+    log = (vault / ".watchdog" / "registry" / "ingest.log").read_text(encoding="utf-8")
+    assert "BATCH b1" in log
+    assert "submitted 2026-07-29T02:54:46Z" in log
+    assert "ended 2026-07-29T03:36:02Z (processed 41m16s)" in log
+    assert "collected" in log
+    assert "1 succeeded" in log
+
+
+def test_finish_batch_item_records_batch_lifecycle_when_batch_meta_given(tmp_path):
+    """`_resume_batch` threads `batch_meta` through so a batch item's usage row carries its own
+    submitted/ended/collected lifecycle — otherwise that only ever lived in the transient
+    `batch-pending.json` state, deleted the moment collection succeeds."""
+    vault = make_vault(tmp_path)
+    _queue_doc(vault, sha="sha1", filename="a.pdf")
+    item = {"ok": True, "parsed": _extraction(sha="sha1", filename="a.pdf"),
+           "usage": {"input_tokens": 500, "output_tokens": 80}, "cost_usd": 0.015, "error": None}
+    batch_meta = {"batch_id": "b1", "submitted_at": "2026-07-29T02:54:46Z",
+                 "ended_at": "2026-07-29T03:36:02Z", "collected_at": "2026-07-29T04:10:00Z"}
+
+    orchestrate._usage = []
+    try:
+        asyncio.run(orchestrate._finish_batch_item(
+            vault, "sha1", item, "SKILL BODY", "annual-report", None, "sk-x",
+            model="claude-sonnet-4-6", batch_meta=batch_meta))
+        calls = [c for c in orchestrate._usage if c["task"] == "extract"]
+        assert calls[0]["batch_id"] == "b1"
+        assert calls[0]["batch_submitted_at"] == "2026-07-29T02:54:46Z"
+        assert calls[0]["batch_ended_at"] == "2026-07-29T03:36:02Z"
+        assert calls[0]["batch_collected_at"] == "2026-07-29T04:10:00Z"
+    finally:
+        orchestrate._usage = None
+
+
 def test_finish_batch_item_repairs_invalid_result_via_claude_api(tmp_path, monkeypatch):
     vault = make_vault(tmp_path)
     _queue_doc(vault, sha="sha1", filename="a.pdf")

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -13,7 +13,8 @@ from watchdog.cmd.usage import cmd_usage
 def _call(task="extract", filename="doc.pdf", detail="pages 1–1", model="claude-sonnet-4-6",
           cost_usd=0.01, input_tokens=100, output_tokens=20, latency_s=1.5,
           effort=None, auth_mode="api-key", attempts=1, end_ts=None, api_ms=None, num_turns=None,
-          failed=False, backend="claude-api"):
+          failed=False, backend="claude-api", batch_id=None, batch_submitted_at=None,
+          batch_ended_at=None, batch_collected_at=None):
     call = {
         "task": task, "model": model, "backend": backend,
         "input_tokens": input_tokens, "output_tokens": output_tokens,
@@ -29,6 +30,13 @@ def _call(task="extract", filename="doc.pdf", detail="pages 1–1", model="claud
         call["num_turns"] = num_turns
     if failed:
         call["failed"] = True
+    # batch_* fields are only present on claude-batch-collected records — same "omitted by
+    # default" convention as api_ms/num_turns above.
+    if batch_id is not None:
+        call["batch_id"] = batch_id
+        call["batch_submitted_at"] = batch_submitted_at
+        call["batch_ended_at"] = batch_ended_at
+        call["batch_collected_at"] = batch_collected_at
     return call
 
 
@@ -286,6 +294,40 @@ def test_cmd_usage_flags_local_backend_as_not_actually_free(tmp_path, monkeypatc
     classifier_section, extractor_section = out.split("EXTRACTOR")
     assert "local model" not in classifier_section
     assert "local model" in extractor_section
+
+
+def test_cmd_usage_shows_batch_lifecycle_note_for_a_batch_collected_stage(tmp_path, monkeypatch, capsys):
+    """A claude-batch-collected extractor stage gets a submitted->ended->collected lifecycle
+    note under its header — the only place that lifecycle is visible once `_resume_batch` clears
+    the transient batch-pending.json state on a clean collection."""
+    vault = _build_vault(tmp_path, runs={
+        "usage-2026-01-01T00-00-00": [
+            _call(task="extract", backend="claude-batch", filename="a.pdf",
+                 batch_id="b1", batch_submitted_at="2026-07-29T02:54:46Z",
+                 batch_ended_at="2026-07-29T03:36:02Z", batch_collected_at="2026-07-29T04:10:00Z"),
+            _call(task="classify", model="gemini-3.1-flash-lite", cost_usd=0.001),
+        ],
+    })
+    monkeypatch.chdir(vault)
+
+    cmd_usage(_args())
+
+    out = capsys.readouterr().out
+    classifier_section, extractor_section = out.split("EXTRACTOR")
+    assert "batch b1" not in classifier_section
+    assert "batch b1" in extractor_section
+    assert "submitted 2026-07-29T02:54:46Z" in extractor_section
+    assert "ended 2026-07-29T03:36:02Z (processed 41.3m)" in extractor_section
+    assert "collected 2026-07-29T04:10:00Z (idle 34.0m)" in extractor_section
+
+
+def test_cmd_usage_no_batch_note_for_a_non_batch_stage(tmp_path, monkeypatch, capsys):
+    vault = _build_vault(tmp_path, runs={
+        "usage-2026-01-01T00-00-00": [_call(task="extract", backend="claude-api")],
+    })
+    monkeypatch.chdir(vault)
+    cmd_usage(_args())
+    assert "batch " not in capsys.readouterr().out
 
 
 def test_cmd_usage_reconcile_task_groups_under_finalizer(tmp_path, monkeypatch, capsys):


### PR DESCRIPTION
## Summary

While reviewing exactly what info a collected batch's response carries (prompted by finally getting `batch-sonnet-med` to collect after #489), found two real gaps between what the Anthropic SDK returns and what watchdog kept:

- **Errored items lost their real reason.** `collect()` collapsed every non-succeeded result to a generic `"batch result was 'errored', not 'succeeded'"` — but an `errored` item's `result.error` (`ErrorResponse.error.{type, message}`) carries the actual cause. Worse diagnostics than a live call's `ModelError` gets.
- **`stop_reason` was dropped.** A batch call has no continuation/repair path the way a live call does, so `"max_tokens"` is the only signal a succeeded result might be a truncated JSON fragment rather than genuinely malformed.
- **`status()` discarded `created_at`/`ended_at`.** No record anywhere of how long Anthropic actually took to process a batch.

## Changes

- `batch_extract.collect()`/`status()` surface `stop_reason`, real error text, and `created_at`/`ended_at`.
- `orchestrate._resume_batch` builds a `submitted -> ended -> collected` lifecycle (batch state's own `submitted_at`, the SDK's `ended_at`, this run's own clock) and logs it to `ingest.log` once collection succeeds — the only place that full picture is visible, since `batch-pending.json` is deleted right after a clean collection.
- `_record_usage` carries `batch_meta`/`stop_reason` onto each collected item's `usage.json` record when present.
- `watchdog usage` prints the `submitted -> ended -> collected` note under a batch-collected extractor stage's header.
- `docs/commands.md` and `benchmarks/BENCHMARKING.md` updated (the latter also gets a note on redoing an already-run arm — vault deletion is required, `seed_arm_vault` refuses to reseed).

## Test plan
- [x] New/updated tests in `test_batch_extract.py`, `test_orchestrate.py`, `test_usage.py`
- [x] Mutation-tested each addition (reverted just that piece, confirmed the matching test goes red, restored)
- [x] Full suite (1812 passed)
- [x] `ruff check src tests benchmarks` clean