### PR TITLE
Path-qualify schema validation error messages

### DIFF
--- a/src/watchdog/model_client.py
+++ b/src/watchdog/model_client.py
@@ -275,9 +275,17 @@ def _extract_json(text: str) -> dict | None:
 
 
 def _validate(obj: dict, schema: dict) -> list[str]:
-    """Return schema-validation error messages (empty list = valid)."""
+    """Return schema-validation error messages, path-qualified (empty list = valid). Bare
+    `e.message` (e.g. "None is not of type 'string'") is identical across every field of the
+    same type gone wrong, which made a real live failure undiagnosable from the log alone (issue
+    #490 follow-up) — three fields nulled at once produced the exact same three-line message
+    whichever fields they were, with no way to tell which from the error text itself."""
     import jsonschema
-    return [e.message for e in jsonschema.Draft202012Validator(schema).iter_errors(obj)]
+    errors = []
+    for e in jsonschema.Draft202012Validator(schema).iter_errors(obj):
+        path = "".join(f"[{p}]" if isinstance(p, int) else f".{p}" for p in e.path)
+        errors.append(f"{path.lstrip('.') or '$'}: {e.message}")
+    return errors
 
 
 def _prune_unknown(obj, schema, _path: str = "") -> list[str]:
@@ -989,6 +997,8 @@ async def acomplete_json(*, task: str, prompt: str | list[dict], schema: dict, m
                     pruned=pruned_all or None,
                 )
             last_err = "; ".join(errors[:3])
+            if len(errors) > 3:
+                last_err += f" (+{len(errors) - 3} more)"
 
     # Every attempt's usage was real spend even though none produced valid JSON — attach it so
     # the caller can still record it (D125), instead of the failure burning tokens invisibly.

--- a/tests/test_model_client.py
+++ b/tests/test_model_client.py
@@ -743,6 +743,28 @@ def test_validate_reports_errors():
     assert mc._validate({"name": "ok"}, SCHEMA) == []
 
 
+def test_validate_error_messages_are_path_qualified():
+    """A live gpt-nano failure logged three identical 'None is not of type string' errors with
+    no way to tell which fields — bare jsonschema messages don't include the offending path.
+    Every error _validate returns must name its field, so a future failure like that one is
+    diagnosable straight from the log instead of requiring a live repro to find the culprit."""
+    nested_schema = {
+        "type": "object",
+        "properties": {
+            "items": {"type": "array", "items": {
+                "type": "object",
+                "properties": {"label": {"type": "string"}},
+                "required": ["label"],
+                "additionalProperties": False,
+            }},
+        },
+        "required": [],
+        "additionalProperties": False,
+    }
+    errors = mc._validate({"items": [{"label": None}]}, nested_schema)
+    assert errors == ["items[0].label: None is not of type 'string'"]
+
+
 def test_prune_unknown_removes_top_level_extra_key():
     obj = {"name": "Acme", "extra": "nope"}
     removed = mc._prune_unknown(obj, SCHEMA)


### PR DESCRIPTION
## Summary
- Rerunning `bench-ex-gpt-nano` after #501 merged still hit the identical `"None is not of type 'string'"` × 3 failure on the same two documents #501 was meant to fix.
- #501's fix was independently verified correct (mutation-tested, reproduces and clears the exact repro), so a recurrence with the identical error text almost certainly means **different** fields are null this time — but there's no way to tell from the log: `_validate` only kept jsonschema's bare `e.message`, discarding `e.path`, and the caller truncates to the first 3 errors with no note of how many more exist. Any 3 nulled fields of the same type produce the exact same 3-line message.
- `_validate` now prefixes each error with its JSON path (e.g. `document.entities[2].name: None is not of type 'string'`), and the caller appends `(+N more)` when errors are truncated.
- No behaviour change for any caller that only checks the error list's truthiness.

## Test plan
- [x] Added `test_validate_error_messages_are_path_qualified`, mutation-tested (reverted, confirmed red with the un-qualified message, restored)
- [x] Full suite: 1820 passed
- [x] `pipx run ruff check src tests`: clean

## Next step
Once merged, rerunning `bench-ex-gpt-nano` will show exactly which field(s) are null this time, instead of another unusable "None is not of type 'string' x3".

🤖 Generated with [Claude Code](https://claude.com/claude-code)