### PR TITLE
Fix cache_read_tokens telemetry for OpenAI/DeepSeek backends (#495)

### DIFF
--- a/src/watchdog/pipeline/orchestrate.py
+++ b/src/watchdog/pipeline/orchestrate.py
@@ -134,7 +134,15 @@ def _record_usage(task: str, *, model: str, backend: str, usage: dict | None,
         "task": task, "model": model, "backend": backend,
         "input_tokens": u.get("input_tokens", u.get("prompt_tokens", 0)) or 0,
         "output_tokens": u.get("output_tokens", u.get("completion_tokens", 0)) or 0,
-        "cache_read_tokens": u.get("cache_read_input_tokens", 0) or 0,
+        # Cache-read count, normalised across provider usage shapes: Anthropic reports
+        # `cache_read_input_tokens`; OpenAI nests it under `prompt_tokens_details.cached_tokens`;
+        # DeepSeek reports `prompt_cache_hit_tokens` (mirrors model_client._cached_input_tokens,
+        # which does the same normalisation for cost calculation — this one was missed when the
+        # OpenAI-compatible backends were added, so their real cache hits were logged as 0 even
+        # though `cost_usd` already billed the discount correctly, issue #495).
+        "cache_read_tokens": (u.get("cache_read_input_tokens")
+                              or (u.get("prompt_tokens_details") or {}).get("cached_tokens")
+                              or u.get("prompt_cache_hit_tokens") or 0),
         "cache_write_tokens": u.get("cache_creation_input_tokens", 0) or 0,
         "cost_usd": cost_usd, "attempts": attempts, "latency_s": latency_s, "effort": effort,
         "auth_mode": auth_mode, "filename": filename, "detail": detail, "end_ts": time.time(),

--- a/tests/test_orchestrate.py
+++ b/tests/test_orchestrate.py
@@ -2132,6 +2132,38 @@ def test_record_usage_omits_harness_timing_keys_for_other_backends():
         orchestrate._usage = None
 
 
+def test_record_usage_reads_cache_read_tokens_from_openai_usage_shape():
+    """#495: OpenAI nests its cache-hit count under `prompt_tokens_details.cached_tokens`
+    rather than Anthropic's flat `cache_read_input_tokens` — before this fix, an OpenAI call's
+    real cache hits (already billed at the discounted rate in `cost_usd`) were silently logged
+    as `cache_read_tokens: 0`."""
+    orchestrate._usage = []
+    try:
+        orchestrate._record_usage(
+            "extract-section", model="gpt-5.4-nano", backend="openai",
+            usage={"prompt_tokens": 20000, "completion_tokens": 5000,
+                  "prompt_tokens_details": {"cached_tokens": 5900}},
+            cost_usd=0.01, latency_s=1.0)
+        assert orchestrate._usage[0]["cache_read_tokens"] == 5900
+    finally:
+        orchestrate._usage = None
+
+
+def test_record_usage_reads_cache_read_tokens_from_deepseek_usage_shape():
+    """#495: DeepSeek reports its cache-hit count as a flat `prompt_cache_hit_tokens` field —
+    a third shape distinct from both Anthropic's and OpenAI's."""
+    orchestrate._usage = []
+    try:
+        orchestrate._record_usage(
+            "extract-section", model="deepseek-v4-flash", backend="deepseek",
+            usage={"prompt_tokens": 20000, "completion_tokens": 5000,
+                  "prompt_cache_hit_tokens": 3200},
+            cost_usd=0.01, latency_s=1.0)
+        assert orchestrate._usage[0]["cache_read_tokens"] == 3200
+    finally:
+        orchestrate._usage = None
+
+
 def test_record_usage_includes_pruned_keys_when_present():
     """#412/D124: pruned key paths ride along on the usage record so schema drift stays
     visible in `watchdog usage`, not just ingest.log."""


### PR DESCRIPTION
## Summary
- `_record_usage` normalized `input_tokens`/`output_tokens` across provider usage shapes but not `cache_read_tokens` — it only checked Anthropic's `cache_read_input_tokens`, so OpenAI (`prompt_tokens_details.cached_tokens`) and DeepSeek (`prompt_cache_hit_tokens`) calls always logged `cache_read_tokens: 0`
- `cost_usd` already billed the real cache discount correctly (`model_client._openai_cost`/`_cached_input_tokens` do their own normalization for pricing) — this was purely a telemetry blind spot, not a billing bug
- Surfaced while investigating #495 (migrating the OpenAI backend to the Responses API for input-token caching): checking real benchmark usage data to see whether caching was already happening on the plain Chat Completions path showed `cache_read_tokens: 0` across the board despite `cost_usd` figures that only make sense with real cache hits (~5,900 tokens/call, consistent with the stable prefix `build_section_prompt` already puts first)

## Test plan
- [x] Added `test_record_usage_reads_cache_read_tokens_from_openai_usage_shape` and `test_record_usage_reads_cache_read_tokens_from_deepseek_usage_shape`
- [x] Full suite green: `PYTHONPATH=src pytest` (1916 passed)
- [x] `pipx run ruff check src tests` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)