### PR TITLE
Regroup extractor_sweep by provider and pin every arm's effort

### DIFF
--- a/benchmarks/BENCHMARKING.md
+++ b/benchmarks/BENCHMARKING.md
@@ -21,8 +21,8 @@ touched, naming which vault(s) and the `rm -rf` to clear them (#494) — this co
 arm's config changes after it already ran once (an `extractor_effort` pin, a corrected model id):
 
 ```
-rm -rf benchmarks/.vaults/bench-ex-gpt-nano benchmarks/.vaults/bench-ex-gpt-mini
-run_benchmark.py --stages extractor --arms gpt-nano,gpt-mini
+rm -rf benchmarks/.vaults/bench-ex-gpt-nano-low benchmarks/.vaults/bench-ex-gpt-mini-low
+run_benchmark.py --stages extractor --arms gpt-nano-low,gpt-mini-low
 ```
 
 No separate deregistration step needed — shadow vaults under `benchmarks/.vaults/` are never
@@ -263,6 +263,13 @@ cp -r .watchdog/extracted ../captures/<vault>-extracted/   # what score_arms.py 
 
 ## Step 4 — extractor sweep (the spend)
 
+**Every arm pins an explicit effort, and that is deliberate.** An unpinned arm runs at whatever
+the provider defaults to, which is neither reproducible nor comparable across providers. On OpenAI
+that default was measured burning a median 12K-24K *output* tokens per section call on this corpus
+(`gpt-mini` peaked at 46K against a 48K ceiling) — reasoning tokens dwarfing the JSON, on sections
+capped at ~7K estimated input tokens. Haiku and DeepSeek are the exceptions: they have no effort
+control at all (no `effort_levels` in `model_catalog.yaml`), and asking for one errors.
+
 `watchdog dig` only — **no `bark`**. Everything this step scores (material-fact recall,
 `must_not_miss`, coverage warnings) is in the staged extraction artifacts before any finalizer
 call runs, so finalizing here would just spend money and time on a stage this step doesn't
@@ -394,14 +401,21 @@ First used for the Tier 0 checklist A/B (#412).
 
 ## Step 8 — the verification pass A/B (#535)
 
-The `gpt-mini-verify` / `gpt-mini-noverify` arm pair in `benchmark.yaml` is the same extractor with
-and without the second-read verification pass, so the difference between them is the pass and
-nothing else. Run the pair on its own:
+`benchmark.yaml` carries a verify/noverify pair for each of the three candidate models — Sonnet
+4.6, `gpt-mini` and Luna. Each pair is the same extractor with and without the second-read
+verification pass, so the difference within a pair is the pass and nothing else. Run **one pair at
+a time**, on its own:
 
 ```
 ~/.local/pipx/venvs/watchdog-intel/bin/python benchmarks/run_benchmark.py \
-    --stages extractor --arms gpt-mini-verify,gpt-mini-noverify
+    --stages extractor --arms gpt-mini-low-verify,gpt-mini-low-noverify
 ```
+
+**On the cost preview.** `cost_reference._matches` only reuses an archived usage file when every
+call in it shares one effort, so a verify arm's own history is reusable as a reference only when
+`extractor_effort` equals the `verifier_effort` config value (default `low`). The `gpt-mini` and
+Luna pairs satisfy that. The Sonnet pair is pinned `medium` — the judged candidate config, not
+`low` — so expect its preview to fall back to the static projection and say so.
 
 Score **recall** with `score_arms.py` and the judge pass, exactly as for any other arm pair — the
 question is whether `must_not_miss` closes the gap it has never closed by raising effort.

--- a/benchmarks/FINDINGS.md
+++ b/benchmarks/FINDINGS.md
@@ -239,3 +239,16 @@ Per-document win pattern (hit % of that document's qualitative items): `sonnet-h
   (DeepSeek/Gemini/OpenAI backends were never affected). Do not compare a pre-D145 Claude cost
   against a post-D145 one. The recall figures above are unaffected — this changed the bill, not
   the output.
+- 2026-08-05: `extractor_sweep` was regrouped by provider and every arm's effort pinned
+  explicitly, which **renamed most arm ids**. Historical rows above use the old names; the
+  mapping is `sonnet-{high,med,low}` → `sonnet-4.6-{high,med,low}` (bare `sonnet` already
+  resolved to 4.6, so the model is unchanged), `gpt-{nano,mini,luna}` → `gpt-{nano,mini,luna}-low`
+  (all three were pinned low), `gemini-flash` → `gemini-flash-low`, and
+  `gpt-mini-{verify,noverify}` → `gpt-mini-low-{verify,noverify}`. Nothing was dropped and the
+  model/effort combinations behind those rows are unchanged, so the figures remain comparable —
+  only the labels moved. One genuine change: `gemini-flash-lite` now pins `low` instead of
+  leaving effort unset, so its historical row measured Google's implicit default and a fresh run
+  will not. Tooling is unaffected either way — `cost_reference` matches archived runs on
+  model/effort/backend, never on arm id. BENCHMARKING.md's Step 3 walkthrough is the
+  pre-#466 hand-run protocol and keeps its own older vault names throughout — it documents
+  a different workflow, not these arms.

--- a/benchmarks/benchmark.yaml
+++ b/benchmarks/benchmark.yaml
@@ -13,104 +13,58 @@ master_vault:
 
 extractor_sweep:
   vault_prefix: bench-ex
+  # Grouped by provider, then model, then effort. Haiku and DeepSeek have no effort control —
+  # asking for one errors. Everything else pins its effort explicitly. See BENCHMARKING.md for
+  # how to run these and FINDINGS.md for what past runs measured.
   arms:
-    - {id: sonnet-high,       extractor_model: sonnet, extractor_effort: high}
-    - {id: sonnet-med,        extractor_model: sonnet, extractor_effort: medium}
-    # Thinking tokens bill as output and were measured at ~70-80% of Sonnet's own output tokens
-    # at medium effort (#475) — the largest untested cost lever left. D140 already found medium
-    # ties high on recall at meaningfully lower cost; low has never been benchmarked.
-    - {id: sonnet-low,        extractor_model: sonnet, extractor_effort: low}
+    # ── Anthropic ──
     - {id: haiku,             extractor_model: haiku}
+    - {id: sonnet-4.6-low,    extractor_model: sonnet-4.6, extractor_effort: low}
+    - {id: sonnet-4.6-med,    extractor_model: sonnet-4.6, extractor_effort: medium}
+    - {id: sonnet-4.6-high,   extractor_model: sonnet-4.6, extractor_effort: high}
+    - {id: sonnet-5-low,      extractor_model: sonnet-5, extractor_effort: low}
+    - {id: sonnet-5-med,      extractor_model: sonnet-5, extractor_effort: medium}
+    - {id: sonnet-5-high,     extractor_model: sonnet-5, extractor_effort: high}
+
+    # ── OpenAI ──
+    - {id: gpt-nano-low,      extractor_model: "openai:gpt-5.4-nano", extractor_effort: low}
+    - {id: gpt-nano-med,      extractor_model: "openai:gpt-5.4-nano", extractor_effort: medium}
+    - {id: gpt-nano-high,     extractor_model: "openai:gpt-5.4-nano", extractor_effort: high}
+    - {id: gpt-mini-low,      extractor_model: "openai:gpt-5.4-mini", extractor_effort: low}
+    - {id: gpt-mini-med,      extractor_model: "openai:gpt-5.4-mini", extractor_effort: medium}
+    - {id: gpt-mini-high,     extractor_model: "openai:gpt-5.4-mini", extractor_effort: high}
+    - {id: gpt-luna-low,      extractor_model: "openai:gpt-5.6-luna", extractor_effort: low}
+    - {id: gpt-luna-med,      extractor_model: "openai:gpt-5.6-luna", extractor_effort: medium}
+    - {id: gpt-luna-high,     extractor_model: "openai:gpt-5.6-luna", extractor_effort: high}
+
+    # ── Gemini ──
+    - {id: gemini-flash-lite, extractor_model: "gemini:gemini-3.1-flash-lite", extractor_effort: low}
+    - {id: gemini-flash-low,  extractor_model: "gemini:gemini-3.5-flash", extractor_effort: low}
+    - {id: gemini-flash-med,  extractor_model: "gemini:gemini-3.5-flash", extractor_effort: medium}
+    - {id: gemini-flash-high, extractor_model: "gemini:gemini-3.5-flash", extractor_effort: high}
+
+    # ── DeepSeek ── (the `-thinking` suffix is the only knob)
     - {id: ds-flash,          extractor_model: "deepseek:deepseek-v4-flash"}
     - {id: ds-flash-think,    extractor_model: "deepseek:deepseek-v4-flash-thinking"}
     - {id: ds-pro,            extractor_model: "deepseek:deepseek-v4-pro"}
     - {id: ds-pro-think,      extractor_model: "deepseek:deepseek-v4-pro-thinking"}
-    - {id: gemini-flash-lite, extractor_model: "gemini:gemini-3.1-flash-lite"}   # cheap tier
-    # No effort pinned above means no `reasoning_effort` is sent at all — Gemini accepts the knob
-    # unconditionally (unlike OpenAI, no reasoning-capability gate), so this ran on whatever
-    # implicit thinking budget Google defaults to. Measured at 15m21s for this corpus, the same
-    # ~51-call section split every enforces-max-tokens backend gets (see the gpt-* comment below)
-    # even though its output tokens stayed well under the per-call ceiling — the time cost here is
-    # pure section-count overhead, not runaway reasoning tokens.
+
+    # ── Paired comparisons ──
+    # Each group isolates one variable and is meant to be run on its own with --arms, not as part
+    # of a full sweep. Read BENCHMARKING.md before running either — both have setup requirements.
     #
-    # Gemini effort ladder (#541/#547, middle tier). D171's reserve table is a reasoned placeholder
-    # — no high-effort Gemini run existed to measure it against. These three are that run: same
-    # model, effort the only variable, so the per-effort reasoning volume can be read straight off
-    # `watchdog usage` (which reports Gemini's reasoning tokens only as of #547 — before that they
-    # were invisible *and* unbilled, so any pre-#547 Gemini cost is a floor, not a measurement).
-    # `-low` also stands in for the arm FINDINGS.md still lists as plain `gemini-flash`, which was
-    # this same model pinned low and is dropped here as an exact duplicate: pinned rather than left
-    # unset for the same reason as the OpenAI arms — measure the model's real minimum-effort cost,
-    # not an unstated default.
-    - {id: gemini-flash-low,  extractor_model: "gemini:gemini-3.5-flash", extractor_effort: low}
-    - {id: gemini-flash-med,  extractor_model: "gemini:gemini-3.5-flash", extractor_effort: medium}
-    - {id: gemini-flash-high, extractor_model: "gemini:gemini-3.5-flash", extractor_effort: high}
-    # Opus dropped (not worth testing this round).
-    #
-    # Backend A/B (#475). The arms above name a bare Claude tier, which resolves to
-    # claude-agent-sdk or claude-api by whatever auth mode the machine is in — so their cost is
-    # only interpretable alongside the backend the report now records. These two pin it
-    # explicitly and are the *only* way to measure the difference, which telemetry puts at ~2.4x
-    # actual/estimated input tokens on the agent SDK vs ~1.24x elsewhere, plus a cache-write
-    # premium the SDK pays and never reads back. Run them as a pair, on their own:
-    #     run_benchmark.py --stages extractor --arms sonnet-med-sdk,sonnet-med-api
-    # Both need api-key auth to be comparable — claude-api cannot run on a subscription.
+    # Backend A/B (#475) — needs api-key auth.
     - {id: sonnet-med-sdk,    extractor_model: "claude-agent-sdk:sonnet", extractor_effort: medium}
     - {id: sonnet-med-api,    extractor_model: "claude-api:sonnet",       extractor_effort: medium}
-    # sdk_check (below) adds the third leg once this pair's metered numbers are in: the same
-    # claude-agent-sdk pin, run later under subscription auth.
-    # Batch API: 50% off every token, stacking with prompt caching. Needs no `skill:` pin — since
-    # D144 each document resolves its own skill, so corpus-v1's per-document sidecar pins (D120)
-    # carry through and the two-skill corpus batches correctly. Submit-and-exit: the arm returns
-    # once submitted, and a later run collects it (see BENCHMARKING.md).
     - {id: batch-sonnet-med,  extractor_model: "claude-batch:sonnet",     extractor_effort: medium}
-    # OpenAI arms (#453 closed, adapter unchanged — the deferral that used to sit here no longer
-    # applies). Cheap/middle tier only, mirroring the Gemini split above: #475's goal is finding
-    # something cheaper than Sonnet, and gpt-5.5/gpt-5.4/gpt-5.6-terra price at $15-30/Mtok
-    # output — the same league as Sonnet, which is already the quality reference in this sweep,
-    # so spending real money to benchmark them would answer a question nobody asked. Needs a
-    # stored OpenAI key (`watchdog auth`).
     #
-    # D98 caveat: OpenAI does support real Structured Outputs, but Watchdog doesn't use them here
-    # — strict mode requires every property in `required`, and our schema deliberately isn't
-    # all-required (optional fields are meant to be omitted, not nulled; post-flight relies on
-    # that). So an OpenAI arm measures the model plus our weaker prompt-only enforcement, not the
-    # model alone — a poor result here is genuinely ambiguous in a way a Gemini arm's isn't, by
-    # our own schema-design choice rather than a model or provider defect. See D98.
-    #
-    # All three are reasoning models (model_catalog.yaml's `reasoning: true`) and, unlike every
-    # Claude arm above, none pinned `extractor_effort` — so `reasoning_effort` was omitted from
-    # the request entirely and OpenAI applied its own default. Measured on this corpus, that
-    # default burned a median 12K-24K *output* tokens per section call (`gpt-mini` peaked at 46K,
-    # against a 48K hard ceiling) — reasoning tokens dwarfing the actual JSON, on section inputs
-    # capped at ~7K estimated tokens by the same conservative sectioning ceiling. That drove
-    # gpt-nano to 26min/$0.89 and gpt-mini to 43min/$5.71 for a 6-document corpus — see the
-    # investigation notes for the full numbers. Pinned to `low` so these arms measure each model's
-    # real minimum controllable cost instead of an unbounded implicit default. The section-count
-    # side of this (51 calls, ~22 of them for the 70-page report alone) is a separate, deeper
-    # issue in `output_ceiling_for_sectioning` shared with production `watchdog dig` — tracked
-    # separately rather than fixed here, since it needs real data on how much `low` effort alone
-    # changes the picture before touching sectioning math every ingest relies on.
-    - {id: gpt-nano,          extractor_model: "openai:gpt-5.4-nano", extractor_effort: low}   # cheap tier
-    - {id: gpt-mini,          extractor_model: "openai:gpt-5.4-mini", extractor_effort: low}   # middle tier
-    - {id: gpt-luna,          extractor_model: "openai:gpt-5.6-luna", extractor_effort: low}   # middle tier, 1.05M window
-    # Verification pass A/B (#535). `verify: true` adds a second, cheap read of each document (or
-    # section) that lists only the material facts the extraction missed; the two arms below are
-    # the *same* extractor otherwise, so the difference between them is the pass and nothing else.
-    # Run them as a pair, on their own:
-    #     run_benchmark.py --stages extractor --arms gpt-mini-verify,gpt-mini-noverify
-    # gpt-mini is the arm to test it on: #535's root-cause classification put 10 of the 23
-    # must_not_miss misses on gpt-mini alone, every one of them present in the text the model was
-    # given and schema-compatible — recoverable omissions rather than comprehension, which is the
-    # case for "cheap extractor + verifier" rather than a bigger extractor. Score recall with
-    # score_arms.py / the qualitative judge as usual, then score the ADDED facts for precision
-    # with verifier_precision.py — a recall win alone does not settle whether this ships (D172).
-    # Note on the cost preview: cost_reference._matches requires every call in an archived usage
-    # file to share one effort, so a verify arm's own history is only reusable as a reference when
-    # extractor_effort equals verifier_effort (both `low` here — keep them equal, or expect the
-    # preview to fall back to the static projection and say so).
-    - {id: gpt-mini-verify,   extractor_model: "openai:gpt-5.4-mini", extractor_effort: low, verify: true}
-    - {id: gpt-mini-noverify, extractor_model: "openai:gpt-5.4-mini", extractor_effort: low, verify: false}
+    # Verification pass A/B (#535), on the three candidate models.
+    - {id: sonnet-4.6-med-verify,   extractor_model: sonnet-4.6, extractor_effort: medium, verify: true}
+    - {id: sonnet-4.6-med-noverify, extractor_model: sonnet-4.6, extractor_effort: medium, verify: false}
+    - {id: gpt-mini-low-verify,     extractor_model: "openai:gpt-5.4-mini", extractor_effort: low, verify: true}
+    - {id: gpt-mini-low-noverify,   extractor_model: "openai:gpt-5.4-mini", extractor_effort: low, verify: false}
+    - {id: gpt-luna-low-verify,     extractor_model: "openai:gpt-5.6-luna", extractor_effort: low, verify: true}
+    - {id: gpt-luna-low-noverify,   extractor_model: "openai:gpt-5.6-luna", extractor_effort: low, verify: false}
 
 finalizer_sweep:
   vault_prefix: bench-fn


### PR DESCRIPTION
Restructures `benchmark.yaml`'s `extractor_sweep` so it reads as a matrix instead of an accretion, and cuts the comment block from ~60 lines to ~14.

## Grouping

Provider → model → effort. Every model that supports an effort knob gets a full `low`/`medium`/`high` ladder; Haiku and DeepSeek have none (no `effort_levels` in `model_catalog.yaml`, and asking for one errors), so DeepSeek's ladder is thinking-vs-not and Haiku is a single arm.

**Nothing is dropped.** The full matrix is meant to stay runnable as a whole-sweep comparison whatever the current shortlist is. 20 arms → 33:

- Sonnet 5 ladder — selectable since D165 as #361 groundwork, never actually benchmarked
- `medium`/`high` for `gpt-nano`/`gpt-mini`/`gpt-luna`, which previously existed at `low` only
- verify/noverify pairs for the three candidates `FINDINGS.md`'s judge pass left standing (Sonnet 4.6, `gpt-mini`, Luna) — the verify A/B is the one group narrowed to candidates, since it's about a specific shipping decision rather than coverage

## Renames

Pinning effort into the id renames most arms: `sonnet-{high,med,low}` → `sonnet-4.6-{...}` (bare `sonnet` already resolved to 4.6, so the model is unchanged), `gpt-{nano,mini,luna}` → `-low`, `gemini-flash` → `gemini-flash-low`, `gpt-mini-{verify,noverify}` → `gpt-mini-low-{...}`.

Verified safe: `cost_reference._matches` borrows archived runs on model/effort/backend and never on arm id, so cost-preview history reuse is unaffected. No code references these ids. `FINDINGS.md` records the mapping so its historical rows stay readable, and notes that `BENCHMARKING.md`'s Step 3 walkthrough is the pre-#466 hand-run protocol with its own older vault names.

**One genuine behaviour change:** `gemini-flash-lite` now pins `low` instead of leaving effort unset. Every other arm was already pinned, and an unset arm measures Google's implicit default, which isn't reproducible — but it does mean a fresh run isn't directly comparable to that model's historical row. Easy to revert if you'd rather keep the continuity.

## Comments

`benchmark.yaml` is configuration; findings belong in `FINDINGS.md` and protocol in `BENCHMARKING.md`. Most of what was inlined here duplicated those files already — the backend A/B and the verification pass each have a full section in `BENCHMARKING.md`. Two facts lived *only* in the yaml and were moved rather than deleted:

- **why every arm pins an effort** (the measurement that OpenAI's implicit default burned 12–24K output tokens per section call, peaking at 46K against a 48K ceiling) → Step 4
- **the cost-preview effort-matching quirk** (`cost_reference._matches` needs every call in an archived file to share one effort, so the Sonnet verify pair pinned at `medium` will fall back to the static projection) → Step 8

Step 8 also now covers all three candidate pairs rather than `gpt-mini` alone.

## Verification

- Every one of the 33 extractor arms and all 10 finalizer arms resolves: model id resolves and the effort level is accepted by `_resolve_effort`, checked programmatically against `model_catalog.yaml`.
- Diffed old against new on `(model, effort, verify)` to confirm no combination was lost — the only delta is the `gemini-flash-lite` pin above.
- Full suite green (2,108), ruff clean. No live model calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)