### PR TITLE
Record the gpt-mini effort judge pass, and fix three runbook gaps

### DIFF
--- a/benchmarks/FINDINGS.md
+++ b/benchmarks/FINDINGS.md
@@ -303,6 +303,120 @@ reasoning extractor, and treat the help text's recall claim as unverified for Op
 Related: #542 (the section-size constant, measured from the same run), #558 (starvation is a
 distinct failure from truncation and the re-split recovery cannot fix it).
 
+---
+
+**2026-08-08 — the qualitative judge pass on the three `gpt-mini` effort tiers reverses the entry
+above: on the judged slice `medium` wins both metrics, not `low`. But once the document `high`
+lost is set aside, all three arms are within noise of each other — what separates them is
+reliability, not comprehension.** Artifacts:
+`benchmarks/2026-08-08-judge-qualitative-mini/` (blinded packets, per-document judgments, mapping,
+raw pre-conversion judgments in `raw-flat/`). Same protocol and same key items as the 2026-07-29
+and 2026-08-03 passes — six Sonnet subagents, one per document, arms blinded X/Y/Z with the
+mapping randomized independently per document. **This is the qualitative slice; the entry above is
+the numeric-anchored slice of the same extractions.** No new extraction was run: the judging reads
+the vaults the 2026-08-06 arms left behind.
+
+| Arm | Facts (hit/total) | must_not_miss (hit/total) | Cost |
+|---|---|---|---|
+| `gpt-mini-low` | 75% (65/87) | 57% (30/53) | $0.53 |
+| `gpt-mini-med` | **77% (67/87)** | **68% (36/53)** | $2.47 |
+| `gpt-mini-high` | 51% (44/87) | 47% (25/53) | $5.17 |
+
+Excluding *Laurentian Pre-Filing Report* — the document `high` lost to reasoning starvation, and
+the single largest item block in the corpus (31 of 140):
+
+| Arm | Facts (hit/total) | must_not_miss (hit/total) |
+|---|---|---|
+| `gpt-mini-low` | 69% (47/68) | 54% (22/41) |
+| `gpt-mini-med` | 71% (48/68) | 59% (24/41) |
+| `gpt-mini-high` | 65% (44/68) | **61% (25/41)** |
+
+**Read the second table for quality and the first for what a user receives.** `high` is last
+overall only because it lost a document; on the five it completed it leads `must_not_miss`. Unlike
+`score_arms.py`, this pass charges a lost document to the arm that lost it rather than crediting
+the items from siblings — which is why `high`'s honest figures here (51%/47%) are so much worse
+than the numeric slice's (97%/88%).
+
+**The low-vs-medium gap is real but half of it is one document.** Medium's 11-point
+`must_not_miss` lead shrinks to 5 points once the pre-filing report is excluded (it scored 12/12
+there against low's 8/12). The direction replicates the 2026-08-03 `gpt-luna` pass, which found
+the same +11 low→med move on `must_not_miss` — two models, two independent passes, same sign — so
+the effect is probably real, but at 4.7x the cost it is not obviously worth buying.
+
+**Extraction volume is not coverage.** On the pre-filing report `low` emitted 159 `key_facts` to
+`medium`'s 90 and still scored worse on the keyed items (8/12 vs 12/12). Fact count is not a proxy
+for recall and should not be used as one.
+
+### What the misses actually are — and why model choice will not fix them
+
+`must_not_miss` items caught by **at least one** arm: 43/53 (81%). Missed by **every** arm:
+**10/53 (19%)**. That 19% is the current pipeline's ceiling: no effort level and no backend
+reaches it, so the low/medium/high argument is a fight over the ~13-point band between 68% and
+81% while a fifth of the keyed items sits off the table for reasons unrelated to model capability.
+**Model selection is not where the remaining recall is.**
+
+Reading the missed items individually (rather than counting them) gives three causes, none of
+which is reasoning effort:
+
+**1. The extraction records end-states and discards transitions.** `first-report-monitor` M6 asks
+for the Administration Charge tripling ($400K → $1.25M) and the Directors' Charge more than
+doubling ($2M → $5M). The document states this in one clause — *"an increase in the Administration
+Charge from $400,000 to $1,250,000; ... the Directors' Charge from $2,000,000 to $5,000,000"* — so
+no arithmetic and no cross-document lookup is involved. All three arms captured the **new** figure
+and dropped the **prior** one ("increase the administration charge to $1,250,000"). A `key_fact` is
+naturally written as a current-state assertion, so the *change* — which is the newsworthy part —
+is normalised away. Any keyed item phrased as a delta is systematically exposed to this.
+(`medium` additionally recorded the Directors' Charge as "$2 million", the DIP-priority sub-cap,
+rather than the $5M total; `high` got the split right. A substantive error, not just an omission.)
+
+**2. Salience, not context or linkage.** `pension-order` M6 asks that Derek Harland be noticed in
+two capacities — deponent of the Affidavit of Service (p. 1) and counsel at TGF (p. 5). The
+document is five pages and ran as a **single whole-document call** (8,751 input tokens): both
+mentions were in the same prompt, with no sectioning and no context pressure. The extraction
+mentions Harland **zero times** — not in `key_facts`, not in `entities`. This is not a cross-page
+reasoning failure; the name was simply never judged worth recording. Procedural boilerplate that
+carries a signal to a reporter is invisible to a salience judgment tuned for operative content.
+
+**3. Curator's angle vs. stated content.** Several items encode a characterisation the document
+never uses ("triples" appears nowhere in the First Report) or reach across documents (M8's caveat
+"repeated from the Pre-Filing Report" cannot be satisfied by a single-document pass, though the
+erroneous affidavit date it hinges on *is* in the document).
+
+All three point at the skill/schema and the salience instruction, not at the model. Worth weighing
+against #551 and #555, which both assume the extraction-benchmark axis is where the headroom is.
+
+### The `must_not_miss` key items are weaker instruments than the `facts` items
+
+Found while reading the misses, and it bears on every figure in the qualitative column of this
+file, including the 2026-07-29 and 2026-08-03 passes:
+
+- **No quotes.** In `benchmarks/keys/*.yaml`, every `facts` entry carries a verbatim `quote`
+  (21/21 in `first-report-monitor.yaml`); **no `must_not_miss` entry carries one** (0/10). They
+  have `id`, `item`, `page`, `paragraph` and a `why`, but nothing anchoring the assertion to
+  document text. A `facts` item is self-verifying; a `must_not_miss` item can only be checked by
+  going back to the PDF by hand, so a mis-keyed one is invisible.
+- **Bundled sub-facts, graded all-or-nothing.** M6 bundles three claims (admin charge triples,
+  directors' charge more than doubles, both rank ahead of every secured creditor). An arm holding
+  two of three lands on the judge's discretion, and judges in this pass flagged exactly that
+  ("credited for capturing half a two-part item"). This makes `must_not_miss` both noisier and
+  more pessimistic than the facts column, and the two are not on the same footing.
+
+Neither defect explains away the misses above — the dropped "$400,000" and the absent Harland are
+real regardless of how the key is written. But the `must_not_miss` percentages should be read as
+a stress test with a soft denominator, not as a calibrated recall figure. Adding quotes and
+splitting bundled items would make the next pass measurably sharper.
+
+**Caveats.** One model, one corpus, six documents; the excluding-table differences (2–7 points on
+n=68/41) are within noise and should not be used to rank the arms. The arms' extraction predates
+the provenance stamping added in #554 (merged 22:58 on 2026-08-05, after all three arms ran at
+21:45–22:45), so the exact extraction commit is not recorded — only the date. The judging ran at
+`5819dfa`.
+
+**Bearing on #361.** `low` remains defensible on cost and `high` is ruled out on this backend
+(cost plus the starvation loss), but the earlier reading that effort above `low` buys nothing does
+not survive the judged slice. The open question is whether medium's small edge is worth 4.7x, and
+that is a product call rather than a measurement gap.
+
 ## Corrections logged along the way
 
 - The original `bench-ex-sonnet-high`/`bench-ex-sonnet-med` vaults (run 2026-07-15, before #403's
@@ -362,3 +476,18 @@ distinct failure from truncation and the re-split recovery cannot fix it).
   from the answer keys rather than from the judgments that came back, so a keyed item nobody
   graded counts as a miss and is reported by id — adding documents or key items raises the bar
   for later passes automatically, and a shortfall like this one can no longer pass unremarked.
+- 2026-08-08: **the 2026-08-06 entry's headline — "reasoning effort above `low` does not buy
+  extraction quality" — is not supported.** It rests on the numeric-anchored slice alone, where
+  `low` scored 39/39 and the metric is saturated: an arm cannot be ranked above a ceiling its
+  rival already hit. The judged slice run on the same extractions two days later puts `medium`
+  ahead on both metrics. The entry's *cost* argument is unaffected and still stands — `low` is 5x
+  cheaper than `medium` and was the only arm that never failed — but that is a
+  price-and-reliability case, not a quality one. **General lesson: do not draw a quality
+  conclusion from the numeric slice alone when the leading arm is at or near 100% on it.** It
+  covers roughly a third of the key items, and they are the anchored, easy ones.
+- 2026-08-08: `RUNBOOK.md`'s judge prompt specified a return shape (`{id: {X: "tier"}}`) that
+  `aggregate.py` cannot read — it reads `["judgments"][id][label]["tier"]` and raises
+  `KeyError: 'judgments'`. Any judgments produced by following the runbook literally before this
+  date need converting before they will tally. Fixed in the runbook, along with two related traps:
+  `bench packets --out` defaults to `qualitative/` and silently overwrites the previous pass's
+  artifacts, and the prompt did not ask judges for the per-verdict `note` the hand-check relies on.

--- a/benchmarks/RUNBOOK.md
+++ b/benchmarks/RUNBOOK.md
@@ -97,11 +97,18 @@ qualitative pass below; the two slices have disagreed on the winner before.
 because the judgments are opinions and the prompt is what constrains them.
 
 ```
-benchmarks/bench packets --arms sonnet-4.6-high,sonnet-4.6-med,gpt-mini-low
+benchmarks/bench packets --arms sonnet-4.6-high,sonnet-4.6-med,gpt-mini-low \
+    --out benchmarks/<date>-judge-qualitative-<what>
 ```
 
 Arms are ids from `benchmark.yaml`. It writes one blinded packet per document plus a
 `mapping.json` that is **judge-eyes-only** — never show it to whoever or whatever is judging.
+
+**Always pass `--out`.** It defaults to `benchmarks/qualitative/`, which is where the *last*
+pass's packets and judgments already sit — so the default silently overwrites the previous
+comparison, and those files are the only durable record of it (`FINDINGS.md` carries the totals
+but not the per-item verdicts). Name the directory for the date and the question, as the
+`2026-07-29-judge-qualitative` and `2026-08-03-judge-qualitative-luna` directories do.
 
 **To judge an earlier run, add `--run benchmarks/runs/<run-id>/`.** Without it the live vaults are
 read, and those are reset the next time that arm runs — so once you have run anything twice, the
@@ -134,7 +141,24 @@ Give the judge exactly this prompt, with nothing added:
 > extraction seems generally good, and do not penalise an extraction for including extra material
 > beyond the key items. If an extraction is empty for this document, every item is `ungrounded`.
 >
-> Return JSON: `{"<item id>": {"X": "<tier>", "Y": "<tier>", "Z": "<tier>"}, ...}`.
+> Return JSON in exactly this shape, with one short `note` per verdict saying what in the
+> extraction you graded against:
+>
+> ```json
+> {"document": "<the packet's document id>",
+>  "judgments": {
+>    "<item id>": {"X": {"tier": "<tier>", "note": "<one clause>"},
+>                  "Y": {"tier": "<tier>", "note": "<one clause>"},
+>                  "Z": {"tier": "<tier>", "note": "<one clause>"}}
+>  }}
+> ```
+
+Grade every id from both `items.facts` and `items.must_not_miss`; they go in one flat
+`judgments` object.
+
+**The shape is not cosmetic** — `aggregate.py` reads `["judgments"][id][label]["tier"]` and
+raises `KeyError: 'judgments'` on anything flatter. The `note` is what makes the mandatory
+hand-check cheap: without it you re-derive every verdict from the vaults by hand.
 
 Judgments go in `judgment-<document>.json` beside each packet, then:
 
@@ -143,6 +167,13 @@ benchmarks/bench judge [out-dir]
 ```
 
 `verbatim` + `credited` count as a hit; `ungrounded` does not.
+
+**If any arm lost a document, report the totals twice** — whole corpus, and again excluding that
+document. The two answer different questions and can rank the arms differently: the whole-corpus
+figure is what a user would actually receive (a lost document is a real loss, and unlike
+`score_arms.py` this pass charges it to the right arm instead of crediting it from siblings),
+while the excluding figure is the only one that isolates extraction *quality* from reliability. A
+single lost document is worth tens of items and will otherwise silently drive the entire ranking.
 
 ## 7. Verifier precision (only for a verify/noverify pair)
 


### PR DESCRIPTION
Runs the qualitative judge pass over the three `gpt-mini` effort arms that the 2026-08-06 entry left unjudged. **No new extraction** — the judging reads the vaults those arms already left behind, so this cost six Sonnet judge calls and no extraction spend.

## The result reverses the 2026-08-06 headline

| Arm | Facts | must_not_miss | Cost |
|---|---|---|---|
| `gpt-mini-low` | 75% (65/87) | 57% (30/53) | $0.53 |
| `gpt-mini-med` | **77% (67/87)** | **68% (36/53)** | $2.47 |
| `gpt-mini-high` | 51% (44/87) | 47% (25/53) | $5.17 |

That entry concluded reasoning effort above `low` buys no quality. It rested on the numeric-anchored slice, where `low` scored **39/39** — an arm cannot be ranked above a ceiling its rival already hit. On the judged slice `medium` wins both metrics. The entry's *cost* argument is untouched and still stands; only the quality claim goes. Logged as a correction rather than an edit to the original, per the runbook.

Excluding the document `high` lost to starvation, the three arms are within noise (69/71/65% facts, 54/59/61% mnm) — `high` is last overall only because it lost a document, and leads `must_not_miss` on the five it finished.

## The more consequential finding

`must_not_miss` items caught by at least one arm: **43/53 (81%)**. Missed by **every** arm: **10/53 (19%)**. So the low/med/high argument is a fight over a 13-point band while a fifth of the keyed items sits off the table for reasons unrelated to model capability. Reading those items individually gives causes that are not reasoning effort:

- **Extraction records end-states and discards transitions.** The First Report states *"an increase in the Administration Charge from \$400,000 to \$1,250,000"* in one clause — no arithmetic, no cross-document lookup. All three arms took the new figure and dropped the old one.
- **Salience, not context or linkage.** A name appearing on pages 1 and 5 of a five-page document that ran as a **single whole-document call** was never recorded at all — not in `key_facts`, not in `entities`. Both mentions were in the same prompt.

Both are skill/schema problems. Filed separately.

## Key-item quality

Found while reading the misses, and it bears on the 2026-07-29 and 2026-08-03 passes too, since the same keys produced those numbers: every `facts` entry carries a verbatim `quote` (21/21 in `first-report-monitor.yaml`), and **no `must_not_miss` entry carries one** (0/10). Several also bundle sub-facts that get graded all-or-nothing. Filed separately.

## Runbook fixes, all hit during the pass

- The judge prompt specified a return shape `aggregate.py` cannot read — it reads `["judgments"][id][label]["tier"]`, the prompt asked for a flat map, and following the runbook literally raises `KeyError: 'judgments'`.
- `bench packets --out` defaults to `qualitative/`, silently overwriting the previous pass's only per-item record.
- The prompt never asked for the per-verdict `note` the mandatory hand-check depends on.
- Added a rule to report totals twice when an arm loses a document.

## Verification

Docs-only change, so no tests or lint per the project convention. The pass itself was checked: all 6 judgments structurally validated (140/140 item-judgments, all three arms per item, legal tiers only), and the runbook's mandatory hand-check run against the raw vault files — confirmed the packet build and blinding mapping are correct, and that the arm judged `ungrounded` genuinely lacks the term while the one credited genuinely carries both figures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)