### PR TITLE
Add a self-consistency benchmark: does resampling recover what one pass misses?

### DIFF
--- a/benchmarks/corpora/selfconsistency/Annual-Financial-Report-19-20.pdf
+++ b/benchmarks/corpora/selfconsistency/Annual-Financial-Report-19-20.pdf
@@ -1,0 +1,1 @@
+../extract/Annual-Financial-Report-19-20.pdf

--- a/benchmarks/corpora/selfconsistency/Annual-Financial-Report-19-20.pdf.yml
+++ b/benchmarks/corpora/selfconsistency/Annual-Financial-Report-19-20.pdf.yml
@@ -1,0 +1,1 @@
+../extract/Annual-Financial-Report-19-20.pdf.yml

--- a/benchmarks/corpora/selfconsistency/CV-21-00656040-00CL Laurentian U Initial Order 1 FEB 2021.pdf
+++ b/benchmarks/corpora/selfconsistency/CV-21-00656040-00CL Laurentian U Initial Order 1 FEB 2021.pdf
@@ -1,0 +1,1 @@
+../extract/CV-21-00656040-00CL Laurentian U Initial Order 1 FEB 2021.pdf

--- a/benchmarks/corpora/selfconsistency/CV-21-00656040-00CL Laurentian U Initial Order 1 FEB 2021.pdf.yml
+++ b/benchmarks/corpora/selfconsistency/CV-21-00656040-00CL Laurentian U Initial Order 1 FEB 2021.pdf.yml
@@ -1,0 +1,1 @@
+../extract/CV-21-00656040-00CL Laurentian U Initial Order 1 FEB 2021.pdf.yml

--- a/benchmarks/corpora/selfconsistency/Pension Order Morawetz CJ- March 17 2021(as stamped by Court).PDF
+++ b/benchmarks/corpora/selfconsistency/Pension Order Morawetz CJ- March 17 2021(as stamped by Court).PDF
@@ -1,0 +1,1 @@
+../extract/Pension Order Morawetz CJ- March 17 2021(as stamped by Court).PDF

--- a/benchmarks/corpora/selfconsistency/Pension Order Morawetz CJ- March 17 2021(as stamped by Court).PDF.yml
+++ b/benchmarks/corpora/selfconsistency/Pension Order Morawetz CJ- March 17 2021(as stamped by Court).PDF.yml
@@ -1,0 +1,1 @@
+../extract/Pension Order Morawetz CJ- March 17 2021(as stamped by Court).PDF.yml

--- a/benchmarks/corpora/selfconsistency/README.md
+++ b/benchmarks/corpora/selfconsistency/README.md
@@ -1,0 +1,35 @@
+# Self-consistency subset (issue #562 follow-up)
+
+Three of corpus-v1's six documents, **symlinked** into `../extract/` rather than copied — the
+bytes are identical by construction, so a self-consistency run scores against the same frozen
+answer keys as any other arm, with no second copy of a 3.7 MB PDF in the repo. `corpus.sha256`
+is generated from the link targets and is verified by `run_benchmark.py` exactly like
+`corpus-v1.sha256`; if the source files ever drift, this run refuses to start too.
+
+## Why these three
+
+This subset exists to measure whether repeated sampling recovers `must_not_miss` items, so it is
+picked for **headroom**, not coverage. Pooling every archived arm (43 of them) and joining each
+scorable `M*` item's hit/miss to its position, five items sit below 100% recall. Three of them
+are here:
+
+| item | doc | recall across all archived arms | what it is |
+|---|---|---|---|
+| `annual-financial-report-19-20:M9` | AFR 19-20 (36p) | **0.0%** (0/40) | budget-to-actual reconciliation table: revenues $160,983 = expenses $160,983, net (0.0) |
+| `initial-order-2021-02-01:M1` | Initial Order (17p) | 53.5% (23/43) | the backsheet — counsel names, **rotated 90°** (OCR hazard H5) |
+| `pension-order-2021-03-17:M2` | Pension Order (5p) | 53.5% (23/43) | last page of a 5-page order |
+
+`M9` is the interesting one: nothing has ever extracted it, across every model, effort, and
+backend tried. If five Luna samples don't recover it, resampling is not the lever for
+table-shaped misses and the anchored-verifier route (Tier 0 anchors differenced against the
+extracted facts) is the one worth building.
+
+The other two documents in corpus-v1 that carry sub-100% items — the 70-page AFR 20-21 and the
+47-page Pre-Filing Report — are deliberately left out to keep the run cheap. Add them if the
+first result is ambiguous.
+
+## Cost
+
+~$0.15 per arm on `gpt-5.6-luna` at `low` effort (measured from `2026-08-03-0048`'s
+`bench-ex-gpt-luna-low` usage records for these same three documents: 4 extract/extract-section
+calls, 67K input, 13K output). Five arms ≈ **$0.73**.

--- a/benchmarks/corpora/selfconsistency/corpus.sha256
+++ b/benchmarks/corpora/selfconsistency/corpus.sha256
@@ -1,0 +1,3 @@
+40df3314772023baee9c229d62d23336e99f08012a94ec3ca6c72418a94bc8df  Pension Order Morawetz CJ- March 17 2021(as stamped by Court).PDF
+66788b16ad5cbfff78a6c5d01f96125affe248e79af7b5f6d4441477ef40a837  Annual-Financial-Report-19-20.pdf
+e943be8173383b5d077a492401ce783a50e188cc5336547acd5090acb1d73408  CV-21-00656040-00CL Laurentian U Initial Order 1 FEB 2021.pdf

--- a/benchmarks/selfconsistency.yaml
+++ b/benchmarks/selfconsistency.yaml
@@ -1,0 +1,63 @@
+# Self-consistency benchmark — do repeated samples recover the facts one pass misses? (#562 f/u)
+#
+# A separate config rather than arms in benchmark.yaml: the corpus is a three-document subset
+# (corpora/selfconsistency), so these arms are not comparable to the six-document sweep and must
+# never be pooled into its recall table — the same reason sdk_check carries its own corpus_dir.
+#
+# Run it on its own:
+#     ~/.local/pipx/venvs/watchdog-intel/bin/python benchmarks/run_benchmark.py \
+#         --config benchmarks/selfconsistency.yaml --stages extractor --estimate-only
+#     # then, once the estimate is approved, drop --estimate-only
+#
+# Then read the union curve (this is the actual measurement — the per-arm REPORT.md is not):
+#     ~/.local/pipx/venvs/watchdog-intel/bin/python benchmarks/union_recall.py \
+#         benchmarks/runs/<run>/artifacts/bench-sc-luna-low-r*
+#
+# WHAT IT MEASURES
+#
+# Five identical arms. Nothing pins `temperature` anywhere in model_client, so every arm runs at
+# the provider default and the five samples genuinely differ. Scoring the union of the first N
+# arms, for N = 1..5, gives a recall curve:
+#
+#   - Curve rises steeply    -> misses are independent draws. Union-of-N is the cheapest recall
+#                               lever available, and cheap-model-times-N beats one strong model.
+#   - Curve is flat          -> misses are correlated (the same salience judgment fails every
+#                               time). The whole ensembling family is dead; build the anchored
+#                               verifier instead (Tier 0 anchors differenced against extracted
+#                               facts in Python, so the second call answers a lookup rather than
+#                               re-running the judgment that just failed).
+#
+# The flat case is the one archived data already hints at: `annual-financial-report-19-20:M9` has
+# never been extracted by any arm ever run (0/40). But those 40 are different models and efforts,
+# not repeated samples of one config, so they cannot settle within-config variance. That is
+# exactly the gap this file closes.
+#
+# WHY LUNA LOW
+#
+# Cheapest arm in the catalog that is still a real reasoning model, ~$0.15 per pass over this
+# subset. If resampling works anywhere it should work here: a low-effort cheap model has the most
+# recall headroom to recover, so this is the friendliest possible test of the hypothesis. A null
+# result on Luna low is therefore strong evidence against ensembling generally, while a positive
+# result still needs re-checking on a stronger model before it becomes a default.
+
+corpus: {dir: corpora/selfconsistency, sha256: corpora/selfconsistency/corpus.sha256}
+keys: {dir: keys, sha256: keys/keys-v1.sha256}
+
+master_vault:
+  name: bench-sc-master
+  classify_name: bench-sc-classify-master
+
+extractor_sweep:
+  vault_prefix: bench-sc
+  # concurrency 3 = one slot per document, so the run is one wave and finishes in ~30s. Well
+  # under the TPM ceiling #559 bracketed (a 236,608 tok/min peak succeeded); this subset is a
+  # third of the corpus and carries no verification pass.
+  defaults: {concurrency: 3, max_rate_limit_waits: 2}
+  arms:
+    # Five identical arms. The ids differ only by suffix — that is the point; any config
+    # difference between them would confound sampling variance with the thing that differs.
+    - {id: luna-low-r1, extractor_model: "openai:gpt-5.6-luna", extractor_effort: low}
+    - {id: luna-low-r2, extractor_model: "openai:gpt-5.6-luna", extractor_effort: low}
+    - {id: luna-low-r3, extractor_model: "openai:gpt-5.6-luna", extractor_effort: low}
+    - {id: luna-low-r4, extractor_model: "openai:gpt-5.6-luna", extractor_effort: low}
+    - {id: luna-low-r5, extractor_model: "openai:gpt-5.6-luna", extractor_effort: low}

--- a/benchmarks/union_recall.py
+++ b/benchmarks/union_recall.py
@@ -1,0 +1,152 @@
+"""Union-of-N recall curve for a self-consistency run (#562 follow-up).
+
+Not a pytest module — a standalone benchmark tool, same posture as score_arms.py. Given the arm
+vaults (or archived `artifacts/<arm>` directories) of N identical arms, it scores the union of
+the first 1, 2, ... N of them and prints the `must_not_miss` recall curve:
+
+    ~/.local/pipx/venvs/watchdog-intel/bin/python benchmarks/union_recall.py \
+        benchmarks/runs/<run>/artifacts/bench-sc-luna-low-r*
+
+(Add `PYTHONPATH=<checkout>/src` if you are running from a worktree and want *its* copy of
+`pipeline/verify`'s dedup thresholds rather than the pipx-installed package's.)
+
+The curve is the measurement. A steep rise means each sample misses independently and union-of-N
+is a real recall lever; a flat curve means the misses are correlated — the same salience
+judgment failing every time — and no amount of resampling will fix them.
+
+Why no new scoring logic: `score_arms.score()` matches numeric anchors against the concatenated
+text of every `.watchdog/extracted/*.json` in a vault, so the union of N arms is literally a
+directory holding all N arms' artifacts. Arm 1's files keep their bare `<sha>.json` names (which
+is what `vault_extracted_shas` reads to decide whether a document was attempted at all); later
+arms' copies are suffixed so they add text without colliding.
+"""
+import os
+import shutil
+import sys
+import tempfile
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import score_arms  # noqa: E402
+
+
+def _extracted_dir(path):
+    """Accept either a real vault (`<v>/.watchdog/extracted`) or an archived `artifacts/<arm>`
+    directory (`<a>/extracted`), so a run can be re-scored straight out of benchmarks/runs/."""
+    for candidate in (os.path.join(path, ".watchdog", "extracted"),
+                      os.path.join(path, "extracted"), path):
+        if os.path.isdir(candidate):
+            return candidate
+    sys.exit(f"Error: no extracted/ directory under {path}")
+
+
+def build_union(arm_dirs, dest):
+    """A vault whose `.watchdog/extracted` holds every arm's artifacts."""
+    ex = os.path.join(dest, ".watchdog", "extracted")
+    os.makedirs(ex, exist_ok=True)
+    for i, arm in enumerate(arm_dirs):
+        src = _extracted_dir(arm)
+        for f in sorted(os.listdir(src)):
+            if not f.endswith(".json"):
+                continue
+            # Arm 0 keeps the bare <sha>.json name — that is what marks the document as attempted.
+            name = f if i == 0 else f"{f[:-5]}-r{i + 1}.json"
+            shutil.copyfile(os.path.join(src, f), os.path.join(ex, name))
+    return dest
+
+
+def main(arm_dirs):
+    tmp = tempfile.mkdtemp()
+    unions = []
+    for n in range(1, len(arm_dirs) + 1):
+        unions.append(build_union(arm_dirs[:n], os.path.join(tmp, f"union-{n:02d}")))
+
+    res = score_arms.score(unions)
+    mnm = res["totals"]["must_not_miss"]
+
+    print("\n=== must_not_miss recall, union of the first N samples ===")
+    print(f"{'N':>3} {'hit':>6} {'of':>6} {'recall':>9} {'marginal':>10}")
+    prev = None
+    for n, v in enumerate(unions, 1):
+        t = mnm[os.path.basename(v)]
+        r = t["hit"] / t["of"] if t["of"] else 0.0
+        marginal = "" if prev is None else f"{r - prev:+.1%}"
+        print(f"{n:>3} {t['hit']:6} {t['of']:6} {r:9.1%} {marginal:>10}")
+        prev = r
+
+    # Per-item, so a stubborn zero (e.g. annual-financial-report-19-20:M9) is visible rather than
+    # averaged away — that single item is the whole reason the subset was chosen.
+    print("\n=== per-item: recovered at which N? ===")
+    first, last = os.path.basename(unions[0]), os.path.basename(unions[-1])
+    for d in res["detail"]:
+        if ":M" not in d["qid"]:
+            continue
+        cells = d["cells"]
+        if cells.get(first, {}).get("hit") == "not_extracted":
+            continue
+        got = next((n for n, v in enumerate(unions, 1)
+                    if cells.get(os.path.basename(v), {}).get("hit") is True), None)
+        if got == 1:
+            continue    # already found by a single pass — no headroom, nothing to learn
+        verdict = f"recovered at N={got}" if got else "NEVER recovered"
+        print(f"  {d['qid']:46} {verdict}")
+    if res["unscorable"]:
+        print(f"\n({len(res['unscorable'])} key items have no numeric anchor and are unscorable "
+              f"here — hand or judge scoring only; see score_arms.py's caveats.)")
+    print(f"\n(scored against {last}'s union; blob-level matching, so sibling documents in the "
+          f"same vault can cross-credit — same caveat as score_arms.py.)")
+
+    distinct_fact_curve(arm_dirs)
+
+
+def distinct_fact_curve(arm_dirs):
+    """How many *distinct* facts do N samples produce between them?
+
+    This, not the recall curve above, is the measurement with headroom. Only ~24 must_not_miss
+    items carry a numeric anchor and ~23 of them are already hit by a single pass, so the frozen
+    key can barely move — it would print a flat line whether or not the samples differ, which is
+    the wrong reason to conclude anything. Counting distinct facts has no ceiling.
+
+    Two facts count as one using `pipeline/verify._is_restatement` — the pipeline's own
+    near-duplicate test (Jaccard 0.75 / containment 0.9), so "distinct" here means exactly what
+    it would mean if these facts were merged by an actual ingest. Facts are pooled per document,
+    never across documents.
+
+    Read it as a gate, not a verdict: a flat curve is decisive (the samples say the same things,
+    so there is nothing for a union to harvest and ensembling is dead). A rising curve is
+    necessary but not sufficient — the extra facts might be noise, and only precision scoring
+    (benchmarks/verifier_precision.py's judge packets) can say which.
+    """
+    from watchdog.pipeline import verify
+
+    print("\n=== distinct facts, union of the first N samples (verify._is_restatement dedup) ===")
+    print(f"{'N':>3} {'distinct':>9} {'vs N=1':>8} {'new':>6}")
+    accepted = {}       # sha -> [token-set, ...]
+    base = None
+    for n, arm in enumerate(arm_dirs, 1):
+        src = _extracted_dir(arm)
+        added = 0
+        for f in sorted(os.listdir(src)):
+            if not f.endswith(".json"):
+                continue
+            import json
+            with open(os.path.join(src, f), encoding="utf-8") as fh:
+                doc = json.load(fh)
+            sha = f[:-5]
+            seen = accepted.setdefault(sha, [])
+            for fact in (doc.get("document") or {}).get("key_facts") or []:
+                toks = verify._tokens(fact.get("fact") or "")
+                if not toks or any(verify._is_restatement(toks, e) for e in seen):
+                    continue
+                seen.append(toks)
+                added += 1
+        total = sum(len(v) for v in accepted.values())
+        base = base or total
+        print(f"{n:>3} {total:9} {total / base:7.2f}x {added:6}")
+
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 3:
+        sys.exit("usage: union_recall.py <arm-dir> <arm-dir> [<arm-dir> ...]   (2 or more)")
+    main(sys.argv[1:])


### PR DESCRIPTION
Follow-up to #562/#577. Answers a question that kept coming up when weighing "cheap model × N passes" against a stronger extractor: **does repeated sampling recover the facts a single pass misses?**

Answer, measured: barely, and not the ones that matter.

## What's here

- `benchmarks/corpora/selfconsistency/` — three of corpus-v1's six documents, **symlinked** into `../extract/` rather than copied, so there's no second copy of a 3.7 MB PDF in the repo and the bytes are identical by construction. `corpus.sha256` is generated from the link targets and freeze-verified like any other corpus.
- `benchmarks/selfconsistency.yaml` — five identical `gpt-5.6-luna` low arms. Nothing pins `temperature` anywhere in `model_client`, so the samples genuinely differ.
- `benchmarks/union_recall.py` — scores the union of the first N arms.

The subset is picked for **recall headroom**, not coverage: it carries three of the five key items that sit below 100% across all 43 archived arms, including `annual-financial-report-19-20:M9`, which nothing has ever extracted.

## Why two curves

`union_recall.py` reports frozen-key recall *and* a distinct-fact count. The second one is the point.

Only 24 `must_not_miss` items carry a numeric anchor and 23 are already hit by a single pass, so the frozen key is ceiling-limited — it prints a flat line whether or not the samples differ, which is the wrong reason to conclude anything. I nearly shipped a benchmark that could only have produced a null result. Counting distinct facts has no ceiling; two facts count as one via `pipeline/verify._is_restatement`, the pipeline's own near-duplicate test, so "distinct" means what it would mean to a real ingest merge.

## Results

Five Luna samples, three documents, $0.1235 total:

```
facts:           N=1  93.3%  ->  N=2 100.0%  (+6.7%)  ->  N=3,4,5  100.0%  (+0.0%)
must_not_miss:   N=1  50.0%  ->  N=5  50.0%  (flat at every step)
distinct facts:  N=1     72  ->  N=5     218  (3.03x, marginal still 26 at N=5)
```

N=2 recovers exactly one item (`annual-financial-report-19-20:F18`). N≥3 recovers nothing measurable while adding 99 more distinct facts. The three hard items are never recovered at any N. That's a saturating-then-diluting curve: for a reporter reading a fact ledger, 218 facts containing no more signal than 72 is strictly worse.

Caveat worth keeping: only 21 of 161 key items are numerically scorable, so "nothing measurable" is not "nothing" — the scorer cannot see the other 140.

## Incidental confirmation of #577

The run is the first cold-cache OpenAI run since `prompt_cache_key` landed:

```
extract          10 calls   115,500 in    92,376 cache read   80.0%
extract-section  10 calls   197,225 in    85,164 cache read   43.2%
digest            5 calls    29,366 in         0 cache read    0.0%
```

Before #577 a fresh run read **0 cached tokens across all 33 calls**. Actual spend came in at $0.1235 against a $0.73 pre-fix projection. Digest at 0% is consistent with D181's schema-prefix finding and deserves its own look.

## Notes

- No `ARCHITECTURE.md`/`DECISIONS.md` entry: this adds a benchmark and a scoring tool, and changes nothing about the pipeline's structure or the code/model split.
- `--estimate-only` on this config previews ~$0.07, roughly 10x under the measured cost. That is a pre-existing miscalibration in `cost_reference`'s no-history fallback, not something this PR introduces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)