### PR TITLE
Re-seed a benchmark arm vault the reset deleted, instead of running the arm on nothing

### DIFF
--- a/benchmarks/run_benchmark.py
+++ b/benchmarks/run_benchmark.py
@@ -279,6 +279,27 @@ def arm_vault(prefix: str, arm_id: str, root: Path) -> Path:
     return root / f"{prefix}-{arm_id}"
 
 
+def _seed_if_absent(vault: Path, seed, reseed: dict) -> None:
+    """Seed `vault` if it isn't there yet, and record *how*, so the post-confirmation reset can
+    put it back.
+
+    Seeding has to happen in the plan phase, before the go-ahead: `preview_*_arm` reads the
+    seeded queue to size the arm, so there is nothing to preview until the vault exists. But
+    `reset_vaults` deliberately runs *after* the go-ahead — deleting a vault is a real action and
+    must not precede consent. Those two orderings together left a hole: a stale vault was
+    skipped here (it already existed), deleted by the reset, and then never re-created, so its
+    arm ran against a path that was gone and died in `_in_vault`'s chdir with a bare
+    FileNotFoundError. Recording the seed closure is what lets the reset restore each one.
+
+    This is not an edge case: `--estimate-only` runs the same plan phase, so it seeds every arm
+    vault it previews. The documented workflow — estimate first, then re-run for real — therefore
+    hit this every single time on a fresh config.
+    """
+    reseed[vault.resolve()] = seed
+    if not vault.exists():
+        seed()
+
+
 def _stale_reason(vault: Path) -> str | None:
     """Why `vault` isn't safe to start a fresh arm run against, or None if it's fresh (either
     absent, or present but untouched). Checked up front for every arm targeted by this run,
@@ -810,6 +831,10 @@ def main(argv: list[str] | None = None) -> int:
     results: list[ArmResult] = []
     previews: list[tuple[str, dict, dict]] = []
     plan: list[tuple[str, dict]] = []   # (kind, arm-plus-context) queued for real execution
+    # resolved vault path -> how to (re)seed it, populated as the plan is built. Insertion order
+    # is plan order, which matters on restore: a finalizer arm is copied from the base vault, so
+    # the base has to come back first. See _seed_if_absent.
+    reseed: dict[Path, object] = {}
 
     if "extractor" in stages and config.get("extractor_sweep"):
         sweep = config["extractor_sweep"]
@@ -824,8 +849,7 @@ def main(argv: list[str] | None = None) -> int:
                 continue
             arm = {**defaults, **arm}
             vault = arm_vault(sweep["vault_prefix"], arm["id"], root)
-            if not vault.exists():
-                seed_arm_vault(master, vault)
+            _seed_if_absent(vault, lambda m=master, v=vault: seed_arm_vault(m, v), reseed)
             est = preview_extractor_arm(vault, arm["extractor_model"], arm.get("extractor_effort"),
                                         args.out)
             meta = {"backend": arm_backend(arm["extractor_model"], default="sonnet"),
@@ -847,8 +871,7 @@ def main(argv: list[str] | None = None) -> int:
             if not _selected(arm):
                 continue
             vault = arm_vault(sweep["vault_prefix"], arm["id"], root)
-            if not vault.exists():
-                shutil.copytree(base_vault, vault)
+            _seed_if_absent(vault, lambda b=base_vault, v=vault: shutil.copytree(b, v), reseed)
             est = preview_finalizer_arm(vault, arm["finalizer_model"], arm.get("finalizer_effort"),
                                         args.out)
             meta = {"backend": arm_backend(arm["finalizer_model"], default="haiku"),
@@ -862,8 +885,7 @@ def main(argv: list[str] | None = None) -> int:
                                      with_sidecars=False, root=root)
         if _selected(smoke["arm"]):
             vault = arm_vault(smoke["vault_prefix"], smoke["arm"]["id"], root)
-            if not vault.exists():
-                seed_arm_vault(master, vault)
+            _seed_if_absent(vault, lambda m=master, v=vault: seed_arm_vault(m, v), reseed)
             est = preview_extractor_arm(vault, smoke["arm"]["extractor_model"],
                                         smoke["arm"].get("extractor_effort"), args.out)
             meta = {"backend": arm_backend(smoke["arm"]["extractor_model"], default="sonnet"),
@@ -884,8 +906,7 @@ def main(argv: list[str] | None = None) -> int:
                 if not _selected(arm):
                     continue
                 vault = arm_vault(sweep["vault_prefix"], arm["id"], root)
-                if not vault.exists():
-                    seed_arm_vault(cc_master, vault)
+                _seed_if_absent(vault, lambda m=cc_master, v=vault: seed_arm_vault(m, v), reseed)
                 est = preview_extractor_arm(vault, sweep["fixed"]["extractor_model"],
                                             sweep["fixed"].get("extractor_effort"), args.out)
                 previews.append((f"classifier-sweep:{arm['id']}", est, {}))
@@ -912,8 +933,7 @@ def main(argv: list[str] | None = None) -> int:
             if not _selected(arm):
                 continue
             vault = arm_vault(sweep["vault_prefix"], arm["id"], root)
-            if not vault.exists():
-                seed_arm_vault(sc_master, vault)
+            _seed_if_absent(vault, lambda m=sc_master, v=vault: seed_arm_vault(m, v), reseed)
             est = preview_extractor_arm(vault, arm["extractor_model"], arm.get("extractor_effort"),
                                         args.out)
             meta = {"backend": arm_backend(arm["extractor_model"], default="sonnet"),
@@ -929,10 +949,16 @@ def main(argv: list[str] | None = None) -> int:
     if not proceed:
         return 0
 
-    # After the go-ahead, before anything is seeded or spent.
+    # After the go-ahead, before anything is spent. A reset vault must be re-seeded before its
+    # arm runs — see _seed_if_absent. Restored in plan order rather than deletion order, so a
+    # base vault is back before anything copied from it.
     if stale:
-        for v in reset_vaults([v for v, _ in stale], root):
+        removed = set(reset_vaults([v for v, _ in stale], root))
+        for v in removed:
             print(f"  reset {v}")
+        for v, restore in reseed.items():
+            if v in removed:
+                restore()
 
     from watchdog.cmd.ingest import _caffeinate
     from watchdog import fixture_capture

--- a/tests/test_benchmark_runner.py
+++ b/tests/test_benchmark_runner.py
@@ -259,6 +259,49 @@ def test_main_lists_a_stale_vault_before_the_prompt_and_resets_it_after(tmp_path
     assert stale_vault.exists()
 
 
+def test_main_reseeds_a_vault_it_reset(tmp_path, monkeypatch, capsys):
+    """A reset vault must be put back before its arm runs.
+
+    Seeding happens in the plan phase (previewing an arm needs its queue) but `reset_vaults`
+    runs after the go-ahead, so a *stale* vault was skipped by the seed (it existed), deleted by
+    the reset, and never re-created — the arm then ran against a path that was gone. Because
+    `--estimate-only` also seeds, the documented estimate-then-run workflow hit this every time.
+    """
+    cfg = _matrix_config(tmp_path)   # sonnet-med-sdk, sonnet-med-api, haiku
+    monkeypatch.setattr(rb, "verify_freeze", lambda *a, **k: None)
+    monkeypatch.setattr(rb, "corpus_documents", lambda d: [Path("a.pdf")])
+    root = tmp_path / ".vaults"
+    stale_vault = root / "bench-ex3-haiku"
+    (stale_vault / ".watchdog" / "queue").mkdir(parents=True)
+    (stale_vault / ".watchdog" / "queue" / "abc.json").write_text("{}")
+
+    seeded: list[Path] = []
+
+    def fake_seed(master, dest):
+        seeded.append(dest)
+        (dest / ".watchdog" / "queue").mkdir(parents=True, exist_ok=True)
+        return 1
+
+    monkeypatch.setattr(rb, "arm_vault", lambda prefix, aid, r: root / f"{prefix}-{aid}")
+    monkeypatch.setattr(rb, "vault_root", lambda *a, **k: root)
+    monkeypatch.setattr(rb, "ensure_master_vault", lambda *a, **k: tmp_path / "master")
+    monkeypatch.setattr(rb, "seed_arm_vault", fake_seed)
+    monkeypatch.setattr(rb, "preview_extractor_arm", lambda *a, **k: {"cost_low": 0.0,
+                                                                     "cost_high": 0.0})
+    monkeypatch.setattr(wd_interactive, "confirm", lambda *a, **k: True)   # accept
+    monkeypatch.setattr(rb, "run_extractor_arm",
+                        lambda arm, vault: rb.ArmResult(arm_id=arm["id"], stage="extractor",
+                                                        vault=vault, ok=True))
+    import bench_report
+    monkeypatch.setattr(bench_report, "write_run", lambda *a, **k: tmp_path / "run")
+
+    rb.main(["--config", str(cfg), "--stages", "extractor"])
+
+    # It was deleted (so the arm started clean) *and* put back (so the arm had a vault at all).
+    assert stale_vault.exists(), "reset vault was never re-seeded — the arm would run on nothing"
+    assert stale_vault in seeded
+
+
 def test_main_does_not_reset_anything_on_an_estimate_only_run(tmp_path, monkeypatch):
     """`--estimate-only` is the free, always-safe path; it must stay side-effect free."""
     cfg = _matrix_config(tmp_path)


### PR DESCRIPTION
Found while running the self-consistency benchmark (#581). Every arm of a re-run failed instantly, before any model call.

```
  [1/5] extractor:luna-low-r1        running…
FileNotFoundError: [Errno 2] No such file or directory: '.../benchmarks/.vaults/bench-sc-luna-low-r1'
0 of 5 arm(s) completed. Writing a report for what finished…
```

## The hole

Two orderings, each correct on its own:

- **Seeding runs in the plan phase, before the go-ahead** — `preview_*_arm` reads the seeded queue to size the arm, so there is nothing to preview until the vault exists.
- **`reset_vaults` runs after the go-ahead** — deleting a vault is a real action and must not be a surprise consequence of agreeing to spend money (#494, D-log).

Together they leave a stale vault seeded-then-deleted with nothing to restore it. The five seed call sites all guard on `if not vault.exists()`, so a *stale* vault is skipped (it exists), then deleted by the reset, then never re-created. The arm runs against a path that is gone and dies in `_in_vault`'s chdir.

The comment sitting above the reset — "After the go-ahead, before anything is seeded or spent" — describes an ordering the code doesn't have.

**This is not an edge case.** `--estimate-only` runs the same plan phase, so it seeds every arm vault it previews. The workflow the module docstring recommends — estimate first, then re-run for real — hits this every single time on a fresh config. The only way to get a clean run today is to `rm -rf benchmarks/.vaults` by hand first, which is exactly the tedium #494's auto-reset was added to remove.

## The fix

`_seed_if_absent(vault, seed, reseed)` records how each planned vault was seeded as the plan is built, then whatever `reset_vaults` actually removed is restored before the run loop. Applied at all five seed sites plus the finalizer's `copytree`.

Restoration walks the plan order rather than the deletion order, because a finalizer arm vault is copied from the base vault and the base has to be back first. `reseed` is a plain dict, so insertion order is plan order and that falls out for free.

## Verification

`2252 passed` · `ruff: All checks passed!`

New test `test_main_reseeds_a_vault_it_reset` asserts both halves — the stale vault is deleted (so the arm starts clean) *and* re-seeded (so the arm has a vault at all). Mutation-tested: replacing the restore loop with `pass` turns it red with exactly the original symptom.

## Not fixed here

`--estimate-only` seeding real vaults at all is arguably the deeper oddity — a free, side-effect-free preview that writes seven directories into `.vaults/`. Changing that means teaching `preview_*_arm` to size an arm without a seeded queue, which is a bigger change than this bug needs. Left alone; this PR makes the existing behaviour correct rather than redesigning it.

Separately, `cost_reference`'s no-history fallback under-reports by roughly 10x (previewed ~$0.07 for a run that cost $0.1235, and the pre-cache-fix projection from real usage records was $0.73). Also untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)