### PR TITLE
Point the benchmark configs at keys-v2.sha256; the harness has been broken since #573

### DIFF
--- a/benchmarks/BENCHMARKING.md
+++ b/benchmarks/BENCHMARKING.md
@@ -219,8 +219,13 @@ invalidates every comparison made against the earlier version. Review them (see 
 then:
 
 ```
-cd benchmarks/keys && shasum -a 256 *.yaml > keys-v1.sha256
+cd benchmarks/keys && shasum -a 256 *.yaml > keys-v<next>.sha256
 ```
+
+Cut a **new** version rather than re-hashing the current one (`keys/README.md` explains why), and
+update the `keys:` line in `benchmark.yaml` *and* any other config that pins a manifest —
+`selfconsistency.yaml` today — in the same change. `verify_freeze` exits on a manifest it can't
+find, so a rename that misses a config takes every benchmark run down until it's caught.
 
 ## Step 1 — verify the corpus
 

--- a/benchmarks/benchmark.yaml
+++ b/benchmarks/benchmark.yaml
@@ -1,12 +1,12 @@
 # Benchmark arm matrix (#361 / #215 / #466), consumed by run_benchmark.py.
 #
 # Frozen references this run verifies before spending anything:
-# corpora/extract/corpus-v1.sha256 (the extractor/finalizer corpus) and keys/keys-v1.sha256
+# corpora/extract/corpus-v1.sha256 (the extractor/finalizer corpus) and keys/keys-v2.sha256
 # (the answer keys). See BENCHMARKING.md for the protocol this file and run_benchmark.py
 # automate; runs are written to the gitignored benchmarks/runs/.
 
 corpus: {dir: corpora/extract, sha256: corpora/extract/corpus-v1.sha256}
-keys: {dir: keys, sha256: keys/keys-v1.sha256}
+keys: {dir: keys, sha256: keys/keys-v2.sha256}
 
 master_vault:
   name: bench-master                     # sidecar'd, reused by extractor + finalizer-base arms

--- a/benchmarks/selfconsistency.yaml
+++ b/benchmarks/selfconsistency.yaml
@@ -41,7 +41,7 @@
 # result still needs re-checking on a stronger model before it becomes a default.
 
 corpus: {dir: corpora/selfconsistency, sha256: corpora/selfconsistency/corpus.sha256}
-keys: {dir: keys, sha256: keys/keys-v1.sha256}
+keys: {dir: keys, sha256: keys/keys-v2.sha256}
 
 master_vault:
   name: bench-sc-master


### PR DESCRIPTION
Every benchmark invocation on `main` fails at the first step:

```
Error: freeze manifest not found: .../benchmarks/keys/keys-v1.sha256
```

#573 correctly cut a new frozen key version — `keys-v1.sha256` moved to `keys/v1/`, `keys-v2.sha256` took its place — but no config was updated to follow it. Both `benchmark.yaml:9` and `selfconsistency.yaml:44` still pinned `keys/keys-v1.sha256`. `verify_freeze` exits on a manifest it can't find and runs before anything else, so nothing has been runnable since that merge.

Found while trying to run the verify A/B.

## Also fixed

`BENCHMARKING.md`'s freeze step hardcoded the output filename:

```
cd benchmarks/keys && shasum -a 256 *.yaml > keys-v1.sha256
```

Following that verbatim re-hashes the current version in place — precisely what `keys/README.md` says not to do ("cut a new version rather than re-hashing the old one... silently re-freezing would leave every archived comparison claiming to be scored against a key that no longer exists"). Now `keys-v<next>.sha256`, plus the step the rename actually missed: update every config that pins a manifest, not just `benchmark.yaml`.

`keys/README.md`'s version table keeps its `keys-v1.sha256` row — that one is history, not a stale path.

## Worth knowing: v2 materially improves what's measurable

Not a change in this PR, just a consequence of #573 that hadn't been quantified. `score_arms` can only score a key item that carries a ≥4-digit numeric anchor:

| | items | numerically scorable |
|---|---|---|
| v1 | 77 | 24 (31%) |
| v2 | 131 | 47 (36%) |

Nearly double the scorable surface. That directly loosens the ceiling flagged in #581 — where 23 of 24 scorable `must_not_miss` items were already hit by a single pass, leaving almost no room for a recall measurement to move.

I re-scored #581's five-sample run against v2 (free — the extractions are staged). The verdict holds and is now measured on 2.5× the items:

```
                     N=1     N=2     N=3     N=4     N=5
v1  must_not_miss    3/6     3/6     3/6     3/6     3/6
v2  must_not_miss    7/15    7/15    7/15    7/15    7/15
    facts           14/15   15/15   15/15   15/15   15/15
```

Still flat at every N, still the same single late recovery (`annual-financial-report-19-20:F18` at N=2). Eight items now provably unrecoverable by resampling, up from three. Anything in `FINDINGS.md` scored under v1 stays reported under v1, per `keys/README.md`.

## Verification

`2252 passed` · `ruff: All checks passed!` · `run_benchmark.py --estimate-only` now gets past freeze verification and previews normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)