### PR TITLE
Pin digest's cache-prefix stability with regression tests (#586 diagnosis)

### DIFF
--- a/tests/test_model_client.py
+++ b/tests/test_model_client.py
@@ -1087,6 +1087,26 @@ def test_prompt_cache_key_shared_across_documents_with_the_same_skill_and_by_the
     assert key1 == key2 == key_verify
 
 
+def test_prompt_cache_key_shared_across_digest_calls_with_the_same_skill():
+    """Digest (#586) uses the same block layout as extract (A1) — the cacheable prefix is
+    instructions+brief then skill, with filename/title/type/page_count/sidecar/key_facts confined
+    to the volatile block after the breakpoint. Two digest prompts for different documents that
+    share a skill must derive the same cache key, same as extract's."""
+    kwargs = dict(skill_text="SKILL TEXT", brief="Investigate the fraud")
+    doc1 = prompts.build_digest_prompt(filename="doc-a.pdf", title="Doc A",
+                                       document_type="Annual Report", page_count=12,
+                                       sidecar="sidecar A", key_facts=[{"fact": "Fact about A"}],
+                                       **kwargs)
+    doc2 = prompts.build_digest_prompt(filename="doc-b.pdf", title="Doc B",
+                                       document_type="Affidavit", page_count=99,
+                                       sidecar="a different sidecar",
+                                       key_facts=[{"fact": "A different fact"}], **kwargs)
+    key1 = mc._prompt_cache_key(doc1)
+    key2 = mc._prompt_cache_key(doc2)
+    assert key1 is not None
+    assert key1 == key2
+
+
 def test_prompt_cache_key_differs_by_skill():
     kwargs = dict(pages_text="x", sidecar=None, brief=None, known_document_types=[])
     a = prompts.build_extract_prompt(skill_text="SKILL A", **kwargs)

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -137,6 +137,27 @@ def test_build_digest_prompt_caches_skill_ahead_of_volatile_data():
     assert text.index("THE DOMAIN SKILL") < text.index("acme-ar.pdf")
 
 
+def test_build_digest_prompt_cache_prefix_is_stable_across_documents():
+    """Mirrors test_extract_prompt_cache_prefix_is_stable_across_volatile_data and
+    test_section_prompt_cache_prefix_is_stable_across_sections (issue #586): the cacheable
+    prefix (instructions+brief, then skill) must be byte-identical for two different documents
+    that share a skill, with everything document-specific (filename/title/type/page_count/
+    sidecar/key_facts) confined to the volatile block after the breakpoint."""
+    kwargs = dict(skill_text="SKILL TEXT", brief="Investigate the fraud")
+    p1 = prompts.build_digest_prompt(filename="doc-a.pdf", title="Doc A",
+                                     document_type="Annual Report", page_count=12,
+                                     sidecar="sidecar A", key_facts=[{"fact": "Fact about A"}],
+                                     **kwargs)
+    p2 = prompts.build_digest_prompt(filename="doc-b.pdf", title="Doc B — a different filing",
+                                     document_type="Affidavit", page_count=99,
+                                     sidecar="a longer, unrelated sidecar for B",
+                                     key_facts=[{"fact": "A completely different fact about B"}],
+                                     **kwargs)
+    assert [b["text"] for b in p1[:2]] == [b["text"] for b in p2[:2]]
+    assert p1[2]["text"] != p2[2]["text"]         # volatile block does differ
+    assert model_client._prompt_cache_key(p1) == model_client._prompt_cache_key(p2)
+
+
 def test_extract_prompt_includes_instructions_and_data():
     p = prompts.build_extract_prompt(
         pages_text="DOCBODY", skill_text="SKILL", sidecar=None, brief=None, known_document_types=[])


### PR DESCRIPTION
Investigation of #586 — why `digest` has never read a cached token on `gpt-5.6-luna`. **This is a diagnosis, not a fix.** No root cause was proven, so nothing speculative was changed. What ships here is the regression coverage the investigation showed was missing.

## What was proven, offline

Two `build_digest_prompt` calls were constructed with different filename, title, document type, page count, sidecar and key facts, sharing a skill and brief, then diffed at the wire level:

- block 0 (instructions + brief) and block 1 (skill, carrying the `cache_control` breakpoint) are **byte-identical**
- `_prompt_cache_key()` returns the **same key** for both
- `_flatten_prompt()` output shares a byte-identical prefix through the end of block 1; divergence begins exactly at the volatile block

So the prompt construction is doing its job. The zero is not ours as far as the prefix is concerned.

## Ruled out with evidence

- **Prefix instability / cache-key bug** — disproved directly above.
- **Ambiguity about which run this was** — the `2026-08-09-1443` call counts match `benchmarks/selfconsistency.yaml` exactly: 5 byte-identical arms over the 3-document self-consistency corpus. Reading the committed `.yml` sidecars confirms two documents share the `bankruptcy` skill and only the third is long enough to be digested. So all 5 digest calls genuinely share one prefix, and "different documents use different skills" is ruled out for this run.
- **`cache_control` TTL** — irrelevant on this backend; `_flatten_prompt` strips it entirely.
- **Schema collision with `extract`** — already ruled out upstream; `schemas.DIGEST` is static and unaffected by per-call input.

## Leading hypothesis, held loosely

Digest is the only task in that run with **no intra-arm cache-warming opportunity**. `extract` gets two same-skill calls seconds apart within every arm; `extract-section` gets two sections of one document. `digest` fires exactly once per arm, so its only possible warm source is the previous arm's digest ~50-80s earlier — a single-touch, cross-arm-only dependency no other task has to rely on.

Corroborating but not conclusive: the one model with any positive digest cache reads hit an *identical* ~2,816-token read on every digest call regardless of which skill was in play, which points at a skill-independent shared sub-prefix rather than skill matching.

**Confidence: moderate. Not verified.** Settling it needs a live probe, deliberately not run — three sequential digest calls (cold, +3s, +90s) at roughly **\$0.01 total**, which would discriminate between "digest can't cache at all on this model" and "the cache doesn't survive the cross-arm gap."

## What ships

Two regression tests mirroring existing `extract`/`extract-section` coverage that had no digest counterpart:

- `test_build_digest_prompt_cache_prefix_is_stable_across_documents`
- `test_prompt_cache_key_shared_across_digest_calls_with_the_same_skill`

These pin the half that is provably correct, so a future change can't silently break it while the provider-side question stays open.

Full suite 2268 passed, `ruff check src tests` clean. No `DECISIONS.md` entry — no decision was made. #586 stays open.