### PR TITLE
Add uv/uvx support for installing watchdog-intel

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ pipx install watchdog-intel
 watchdog setup
 ```
 
+Prefer [uv](https://docs.astral.sh/uv/)? Use `uv tool install watchdog-intel` instead of the first line.
+
 Never used a terminal? The [install guide](https://github.com/tomcardoso/watchdog/blob/main/docs/install.md) walks through every step, starting from how to open one.
 
 ## Quick start

--- a/docs/install.md
+++ b/docs/install.md
@@ -45,6 +45,8 @@ Terminal is a built-in app that lets you type commands to your computer. You'll 
 
 Watchdog needs two tools for processing PDFs — **qpdf** and **Ghostscript** — and **pipx**, a tool for installing Python programs. On Linux and Windows it also needs **Tesseract**, which handles OCR (optical character recognition — turning scanned pages into searchable text).
 
+If you already use [uv](https://docs.astral.sh/uv/), Astral's Python package and tool manager, you can use it instead of pipx for this step and the next — see [Installing with uv instead of pipx](#optional-installing-with-uv-instead-of-pipx) below, then come back to Step 6.
+
 **macOS:**
 
 ```bash
@@ -165,6 +167,47 @@ pipx inject watchdog-intel playwright
 ```
 
 This adds about 150 MB (the browser itself). If it isn't installed, `watchdog research` and `watchdog fetch` fall back to the plain sanitized fetch automatically — nothing breaks either way.
+
+## Optional: installing with uv instead of pipx
+
+If you already use [uv](https://docs.astral.sh/uv/) — Astral's Python package and tool manager — you can use it instead of pipx for the whole install. Everything past this point (`watchdog setup`, day-to-day use, upgrades) works exactly the same either way; only the install and upgrade commands differ.
+
+Install uv, if you don't have it already:
+
+**macOS:**
+
+```bash
+brew install uv
+```
+
+**Linux:**
+
+```bash
+curl -LsSf https://astral.sh/uv/install.sh | sh
+```
+
+**Windows:**
+
+```powershell
+powershell -c "irm https://astral.sh/uv/install.ps1 | iex"
+```
+
+Then install Watchdog:
+
+```bash
+uv tool install watchdog-intel
+```
+
+If that prints a warning that its tool directory isn't on your `PATH`, run `uv tool update-shell`, then close and reopen Terminal. From here, skip Step 5 above and continue with Step 6 (`watchdog setup`).
+
+Wherever the rest of this page says a `pipx` command, use its `uv` equivalent instead:
+
+| pipx | uv |
+|------|-----|
+| `pipx install watchdog-intel` | `uv tool install watchdog-intel` |
+| `pipx install "watchdog-intel[asr]" --force` | `uv tool install "watchdog-intel[asr]"` |
+| `pipx inject watchdog-intel playwright` | `uv tool install watchdog-intel --with playwright` |
+| `pipx upgrade watchdog-intel` | `uv tool upgrade watchdog-intel` |
 
 ## Where next
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -10,6 +10,12 @@ The install didn't add `watchdog` to your path (the list of places your terminal
 pipx ensurepath
 ```
 
+If you installed with uv instead of pipx, the equivalent is:
+
+```bash
+uv tool update-shell
+```
+
 Then close and reopen your terminal.
 
 ## "Watchdog isn't set up yet"
@@ -140,7 +146,7 @@ You can omit the name when running from inside the vault directory.
 
 ## Skills look outdated after an upgrade
 
-When you upgrade Watchdog (`pipx upgrade watchdog-intel`), the record skills — the document-type knowledge — update automatically, because they are read straight from the package. But each vault's Claude Code command skills (the `/watchdog-*` commands) are copied into the vault and keep their old versions. Refresh them from inside the vault:
+When you upgrade Watchdog (`pipx upgrade watchdog-intel`, or `uv tool upgrade watchdog-intel` if you installed with uv), the record skills — the document-type knowledge — update automatically, because they are read straight from the package. But each vault's Claude Code command skills (the `/watchdog-*` commands) are copied into the vault and keep their old versions. Refresh them from inside the vault:
 
 ```bash
 cd ~/Investigations/your-investigation

--- a/src/watchdog/cmd/base.py
+++ b/src/watchdog/cmd/base.py
@@ -451,6 +451,37 @@ def _perf_cpu_count() -> int:
     return os.cpu_count() or 4
 
 
+def _detected_install_manager() -> str:
+    """Best-effort detection of which packaging tool manages this watchdog install, so a
+    printed follow-up command for adding an optional extra afterwards (`pipx inject` vs
+    `uv tool install --with`) matches how it was actually installed (#610). Inspects
+    sys.executable's private-venv path — pipx: `.../pipx/venvs/<pkg>/bin/python`, uv tool:
+    `.../uv/tools/<pkg>/bin/python` — and defaults to pipx, the long-documented default,
+    when neither layout is recognized."""
+    parts = Path(sys.executable).parts
+    if "uv" in parts and "tools" in parts:
+        return "uv"
+    return "pipx"
+
+
+def _extra_install_cmd(extra: str) -> str:
+    """Command that adds an optional extra (e.g. "playwright", "gliner") to an
+    already-installed watchdog, matching whichever tool installed it. Re-running `uv tool
+    install` with a new `--with` picks it up on its own — confirmed against uv 0.12 — so no
+    `--reinstall`/`--force` flag is needed, mirroring how plain `pipx inject` needs none either."""
+    if _detected_install_manager() == "uv":
+        return f"uv tool install watchdog-intel --with {extra}"
+    return f"pipx inject watchdog-intel {extra}"
+
+
+def _venv_bin(name: str) -> str:
+    """Path to `name` inside watchdog's own install venv if it's there — pipx and uv tool both
+    put an injected extra's console scripts alongside watchdog's own interpreter, off PATH —
+    else the bare name, so a plain PATH lookup still has a chance."""
+    candidate = Path(sys.executable).parent / name
+    return str(candidate) if candidate.exists() else name
+
+
 def _render_template(filename: str, **vars: str) -> str:
     text = (_TEMPLATES_DIR / filename).read_text()
     for key, value in vars.items():

--- a/src/watchdog/cmd/research.py
+++ b/src/watchdog/cmd/research.py
@@ -24,8 +24,10 @@ from watchdog.cmd.base import (
     _RESET,
     _YELLOW,
     CONFIG_FILE,
+    _extra_install_cmd,
     _find_project,
     _resolve_vault,
+    _venv_bin,
     load_projects,
 )
 from watchdog.pipeline import capture, research
@@ -85,8 +87,8 @@ def _report_deposits(results: list, *, wayback, requeued_failures: bool) -> int:
     if any(r.path.suffix in (".html", ".xhtml") for r in deposited) and not capture.render_available():
         print(f"\n  {_DIM}Tip: for full page snapshots (images, styles, client-rendered pages) "
               f"install the capture browser:{_RESET}")
-        print(f"    {_CYAN}pipx inject watchdog-intel playwright{_RESET}")
-        print(f"    {_CYAN}~/.local/pipx/venvs/watchdog-intel/bin/playwright install chromium{_RESET}")
+        print(f"    {_CYAN}{_extra_install_cmd('playwright')}{_RESET}")
+        print(f"    {_CYAN}{_venv_bin('playwright')} install chromium{_RESET}")
     if failed:
         note = (f" {_DIM}(left queued — retry with {_RESET}{_CYAN}watchdog research-fetch{_RESET}{_DIM}){_RESET}"
                 if requeued_failures else "")

--- a/src/watchdog/setup_cmd.py
+++ b/src/watchdog/setup_cmd.py
@@ -16,6 +16,8 @@ from watchdog.cmd.base import (
     _YELLOW,
     _GREEN,
     _RESET,
+    _extra_install_cmd,
+    _venv_bin,
 )
 
 WATCHDOG_HOME = Path.home() / ".watchdog"
@@ -83,8 +85,8 @@ def _check_playwright() -> None:
           f"  Optional — everything else works without it. Adds ~150 MB (Chromium browser).{_RESET}")
     if not interactive.confirm("  Install web-capture support now?", default=False):
         print(f"  {_DIM}Skipped. Install later with:{_RESET}")
-        print(f"    {_CYAN}pipx inject watchdog-intel playwright{_RESET}")
-        print(f"    {_CYAN}~/.local/pipx/venvs/watchdog-intel/bin/playwright install chromium{_RESET}")
+        print(f"    {_CYAN}{_extra_install_cmd('playwright')}{_RESET}")
+        print(f"    {_CYAN}{_venv_bin('playwright')} install chromium{_RESET}")
         return
 
     print(f"\n  {_DIM}Installing playwright...{_RESET}")
@@ -156,10 +158,9 @@ _COMPLETION_MARKER = "register-python-argcomplete watchdog"
 
 def _install_completion(shell: str, profile: Path | None, force: bool = False) -> str | None:
     """Install completions. Returns description of what was done, or None if skipped."""
-    # Prefer the register-python-argcomplete binary from the same venv as this Python,
-    # since pipx installs it there but does not expose it on the user's PATH.
-    rpa = Path(sys.executable).parent / "register-python-argcomplete"
-    rpa_str = str(rpa) if rpa.exists() else "register-python-argcomplete"
+    # Prefer the register-python-argcomplete binary from the same venv as this Python — both
+    # pipx and uv tool install it there but don't expose it on the user's PATH.
+    rpa_str = _venv_bin("register-python-argcomplete")
 
     if shell == "fish":
         fish_dir = Path.home() / ".config" / "fish" / "completions"
@@ -234,7 +235,7 @@ def _ensure_gliner() -> None:
         if not gliner_ready:
             _warn("gliner not installed — the candidate harvest will skip name detection")
             print(f"      {_DIM}Install it later with:{_RESET}")
-            print(f"        {_CYAN}pipx inject watchdog-intel gliner{_RESET}")
+            print(f"        {_CYAN}{_extra_install_cmd('gliner')}{_RESET}")
     except Exception as e:
         _warn(f"GLiNER model download failed: {e}")
 
@@ -343,7 +344,7 @@ def run(force: bool = False) -> None:
         except Exception as e:
             _warn(f"Docling model download failed: {e}")
         # GLiNER (local named-entity recognition) is an optional extra, not installed by
-        # `pipx install watchdog-intel` — it feeds the extraction candidate harvest's
+        # a base `watchdog-intel` install — it feeds the extraction candidate harvest's
         # person/org/location detection (#361).
         _ensure_gliner()
 

--- a/tests/test_setup_playwright.py
+++ b/tests/test_setup_playwright.py
@@ -1,5 +1,6 @@
 """Tests for the Playwright/Chromium check in `watchdog setup` (#246)."""
 
+import watchdog.cmd.base as base
 import watchdog.setup_cmd as sc
 
 
@@ -18,6 +19,7 @@ def test_playwright_already_available_skips_prompt(monkeypatch, capsys):
 def test_playwright_missing_declined_prints_manual_hint(monkeypatch, capsys):
     monkeypatch.setattr("watchdog.pipeline.capture.render_available", lambda: False)
     monkeypatch.setattr("builtins.input", lambda prompt="": "n")
+    monkeypatch.setattr(sc.sys, "executable", "/Users/x/.local/pipx/venvs/watchdog-intel/bin/python")
 
     def _boom(*a, **k):
         raise AssertionError("should not install when declined")
@@ -27,6 +29,25 @@ def test_playwright_missing_declined_prints_manual_hint(monkeypatch, capsys):
     out = capsys.readouterr().out
     assert "Skipped" in out
     assert "pipx inject watchdog-intel playwright" in out
+    assert "playwright install chromium" in out
+
+
+def test_playwright_missing_declined_uv_install_prints_uv_hint(monkeypatch, capsys):
+    """Under a `uv tool install` install, the fallback hint should tell the user the `uv`
+    equivalent of `pipx inject`, not a pipx command that wouldn't work for them (#610)."""
+    monkeypatch.setattr("watchdog.pipeline.capture.render_available", lambda: False)
+    monkeypatch.setattr("builtins.input", lambda prompt="": "n")
+    monkeypatch.setattr(sc.sys, "executable", "/Users/x/.local/share/uv/tools/watchdog-intel/bin/python")
+
+    def _boom(*a, **k):
+        raise AssertionError("should not install when declined")
+    monkeypatch.setattr(sc.subprocess, "run", _boom)
+
+    sc._check_playwright()
+    out = capsys.readouterr().out
+    assert "Skipped" in out
+    assert "uv tool install watchdog-intel --with playwright" in out
+    assert "pipx" not in out
     assert "playwright install chromium" in out
 
 
@@ -75,3 +96,45 @@ def test_playwright_pip_install_failure_warns_and_stops(monkeypatch, capsys):
     out = capsys.readouterr().out
     assert "could not install playwright" in out
     assert len(calls) == 1  # never attempted the chromium download after pip failed
+
+
+def test_detected_install_manager_pipx(monkeypatch):
+    monkeypatch.setattr(base.sys, "executable", "/Users/x/.local/pipx/venvs/watchdog-intel/bin/python")
+    assert base._detected_install_manager() == "pipx"
+
+
+def test_detected_install_manager_uv(monkeypatch):
+    monkeypatch.setattr(base.sys, "executable", "/Users/x/.local/share/uv/tools/watchdog-intel/bin/python")
+    assert base._detected_install_manager() == "uv"
+
+
+def test_detected_install_manager_defaults_to_pipx(monkeypatch):
+    """Neither pipx's nor uv tool's private-venv layout — e.g. a plain venv in CI — falls back
+    to pipx, the long-documented default."""
+    monkeypatch.setattr(base.sys, "executable", "/opt/hostedtoolcache/Python/3.12.0/x64/bin/python")
+    assert base._detected_install_manager() == "pipx"
+
+
+def test_extra_install_cmd_matches_detected_manager(monkeypatch):
+    monkeypatch.setattr(base.sys, "executable", "/Users/x/.local/pipx/venvs/watchdog-intel/bin/python")
+    assert base._extra_install_cmd("gliner") == "pipx inject watchdog-intel gliner"
+
+    monkeypatch.setattr(base.sys, "executable", "/Users/x/.local/share/uv/tools/watchdog-intel/bin/python")
+    assert base._extra_install_cmd("gliner") == "uv tool install watchdog-intel --with gliner"
+
+
+def test_venv_bin_prefers_sibling_of_executable_when_present(monkeypatch, tmp_path):
+    fake_python = tmp_path / "bin" / "python"
+    fake_python.parent.mkdir(parents=True)
+    fake_python.touch()
+    (fake_python.parent / "playwright").touch()
+    monkeypatch.setattr(base.sys, "executable", str(fake_python))
+    assert base._venv_bin("playwright") == str(fake_python.parent / "playwright")
+
+
+def test_venv_bin_falls_back_to_bare_name_when_absent(monkeypatch, tmp_path):
+    fake_python = tmp_path / "bin" / "python"
+    fake_python.parent.mkdir(parents=True)
+    fake_python.touch()
+    monkeypatch.setattr(base.sys, "executable", str(fake_python))
+    assert base._venv_bin("playwright") == "playwright"


### PR DESCRIPTION
## Summary
- The package already installs cleanly via `uv tool install watchdog-intel` — it's a normal PyPI console-script tool, no packaging changes needed (verified live: resolves and installs from PyPI). What was missing was documentation and correct follow-up guidance.
- Added a "uv" alternative alongside pipx in `docs/install.md`, `docs/troubleshooting.md`, and the README two-liner.
- `watchdog setup`/`watchdog research` printed hardcoded `pipx inject watchdog-intel <extra>` hints for optional extras (Playwright, GLiNER) — wrong advice for a `uv tool install` user. Added `_detected_install_manager()` in `src/watchdog/cmd/base.py`, which inspects `sys.executable`'s path to tell pipx and uv-tool installs apart, plus `_extra_install_cmd()`/`_venv_bin()` helpers so the printed command matches how watchdog was actually installed.

Closes #610.

## Test plan
- [x] `~/.local/pipx/venvs/watchdog-intel/bin/pytest` — 2396 passed (added new coverage for the detection helper and both pipx/uv hint branches)
- [x] `pipx run ruff check src tests` — clean
- [x] Manually verified `uv tool install watchdog-intel` resolves and installs the published package from PyPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)