### PR TITLE
Point benchmark.yaml/selfconsistency.yaml at keys-v4

### DIFF
--- a/benchmarks/benchmark.yaml
+++ b/benchmarks/benchmark.yaml
@@ -1,12 +1,12 @@
 # Benchmark arm matrix (#361 / #215 / #466), consumed by run_benchmark.py.
 #
 # Frozen references this run verifies before spending anything:
-# corpora/extract/corpus-v1.sha256 (the extractor/finalizer corpus) and keys/keys-v3.sha256
+# corpora/extract/corpus-v1.sha256 (the extractor/finalizer corpus) and keys/keys-v4.sha256
 # (the answer keys). See BENCHMARKING.md for the protocol this file and run_benchmark.py
 # automate; runs are written to the gitignored benchmarks/runs/.
 
 corpus: {dir: corpora/extract, sha256: corpora/extract/corpus-v1.sha256}
-keys: {dir: keys, sha256: keys/keys-v3.sha256}
+keys: {dir: keys, sha256: keys/keys-v4.sha256}
 
 master_vault:
   name: bench-master                     # sidecar'd, reused by extractor + finalizer-base arms

--- a/benchmarks/selfconsistency.yaml
+++ b/benchmarks/selfconsistency.yaml
@@ -41,7 +41,7 @@
 # result still needs re-checking on a stronger model before it becomes a default.
 
 corpus: {dir: corpora/selfconsistency, sha256: corpora/selfconsistency/corpus.sha256}
-keys: {dir: keys, sha256: keys/keys-v3.sha256}
+keys: {dir: keys, sha256: keys/keys-v4.sha256}
 
 master_vault:
   name: bench-sc-master


### PR DESCRIPTION
## Summary

- #625/PR #634 replaced `keys/keys-v3.sha256` with `keys/keys-v4.sha256` but missed the two config files that pin a manifest — `benchmark.yaml` and `selfconsistency.yaml` (BENCHMARKING.md's own freeze-bump instructions call out updating both "in the same change").
- `run_benchmark.py`'s `verify_freeze` hard-exits on a missing manifest file, so every benchmark run — the main sweep and the self-consistency arms — was broken until this lands. Confirmed: `run_benchmark.py --estimate-only --stages extractor --arms haiku` now gets past the freeze check.

## Test plan

- [x] `run_benchmark.py --estimate-only --stages extractor --arms haiku` — no longer errors on the freeze manifest
- [x] `grep -rn "keys-v3.sha256"` across the repo — no remaining config references (only the historical `keys/README.md` version table and `DECISIONS.md`, both correctly untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)