### PR TITLE
Parametrize the non-reasoning-model scaffold test beyond Haiku (#570)

### DIFF
--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -223,10 +223,22 @@ def test_extract_prompt_carries_no_vault_state():
 
 # ── explicit scaffold for non-reasoning models (#570 Phase 1) ─────────────────────────────
 
-def test_extract_prompt_adds_scaffold_for_a_non_reasoning_model():
+@pytest.mark.parametrize("model", [
+    "haiku",                # Claude, no thinking control at all
+    "deepseek-v4-flash",    # DeepSeek's plain (non "-thinking") id
+    "gemini-3.5-flash",     # Gemini — no reasoning field in the catalog
+    "not-a-real-model",     # uncatalogued — conservative default is "no channel"
+])
+def test_extract_prompt_adds_scaffold_for_a_non_reasoning_model(model):
+    """The branch is resolved from the catalog (`catalog_has_reasoning`), not hardcoded to
+    Haiku — every model family the catalog doesn't confirm a reasoning channel for gets the
+    scaffold, not just the one this was built and benchmarked against (#570 Phase 1). `model`
+    here is always the bare catalog id, never a `provider:model` CLI form — `cmd/ingest.py`'s
+    `_resolve_stage` strips that prefix into a separate `backend` before `model` ever reaches
+    this layer, so a bare id is what `orchestrate.py` actually threads through in production."""
     p = prompts.build_extract_prompt(
         pages_text="x", skill_text="", sidecar=None, brief=None, known_document_types=[],
-        model="haiku")
+        model=model)
     text = _flat(p)
     assert "no private reasoning channel" in text
     assert "document.plan" in text


### PR DESCRIPTION
## Summary
- Tom asked whether D208's explicit scaffold (#640) had been verified to apply beyond Haiku. Answer: yes by construction — the branch is `catalog_has_reasoning(model)`, never a hardcoded model name — but the prompt-level test only ever exercised Haiku, even though `catalog_has_reasoning`'s own standalone test already covered DeepSeek/Gemini returning `False`.
- Parametrizes `test_extract_prompt_adds_scaffold_for_a_non_reasoning_model` across `haiku`, `deepseek-v4-flash`, `gemini-3.5-flash`, and an uncatalogued id — all bare catalog ids, matching what `orchestrate.py` actually threads through (`cmd/ingest.py`'s `_resolve_stage` strips any `provider:` prefix before `model` reaches this layer).
- Live-confirmed separately (small live spend, approved, not part of this commit's test suite): `deepseek-v4-flash` and `gemini-3.1-flash-lite` both extract successfully with the scaffold and the new `document.plan` field, no errors, on `Laurentian First Report of the Monitor.pdf` — $0.018 total, 2 calls.

## Test plan
- [x] `PYTHONPATH=src pytest` — 2563 passed
- [x] `pipx run ruff check src tests` — clean
- [x] Mutation check: forcing `catalog_has_reasoning` to always return `True` fails all 5 scaffold-presence tests (4 parametrized + the section-prompt one), confirming they'd catch a real regression