### PR TITLE
Treat a vault whose queue is all queue/_failed as stale

### DIFF
--- a/benchmarks/run_benchmark.py
+++ b/benchmarks/run_benchmark.py
@@ -312,6 +312,8 @@ def _stale_reason(vault: Path) -> str | None:
     queue = wd / "queue"
     if queue.is_dir() and any(queue.glob("*.json")):
         return "already has a queued/staged batch"
+    if (queue / "_failed").is_dir() and any((queue / "_failed").glob("*.json")):
+        return "has documents that failed a previous attempt (queue/_failed)"
     if any((wd / "tmp").glob("result_*.json")):
         return "has a batch pending finalization (extracted but not yet finalized)"
     if (wd / "registry" / "batch-pending.json").exists():

--- a/tests/test_benchmark_runner.py
+++ b/tests/test_benchmark_runner.py
@@ -183,6 +183,13 @@ def test_stale_reason_flags_queued_batch(tmp_path):
     assert "queued" in rb._stale_reason(vault)
 
 
+def test_stale_reason_flags_failed_queue(tmp_path):
+    vault = tmp_path / "vault"
+    (vault / ".watchdog" / "queue" / "_failed").mkdir(parents=True)
+    (vault / ".watchdog" / "queue" / "_failed" / "abc.json").write_text("{}")
+    assert "_failed" in rb._stale_reason(vault)
+
+
 def test_stale_reason_flags_pending_finalization(tmp_path):
     vault = tmp_path / "vault"
     (vault / ".watchdog" / "tmp").mkdir(parents=True)


### PR DESCRIPTION
## Summary
- `_stale_reason()` (benchmark runner pre-flight staleness gate, #494) only checked the top-level `queue/*.json` and `extracted/*.json` — it never looked in `queue/_failed/`.
- A vault where every document had already failed a previous attempt (e.g. hit a billing/auth error) has an empty top-level queue, so it read as "fresh." Re-running that arm skipped reseeding (the vault already existed) and saw 0 pending documents — the arm silently reported success on zero work instead of refusing or reseeding, with `$0.000` cost and no facts scored.
- Found while re-running `sonnet-5-med`/`sonnet-5-high` after an earlier credit-balance failure; the re-run "succeeded" in 0 seconds against a vault that had never actually extracted anything.

## Test plan
- [x] New unit test `test_stale_reason_flags_failed_queue` — red without the fix (`TypeError: argument of type 'NoneType' is not a container`), green with it.
- [x] Full `tests/test_benchmark_runner.py` suite: 184 passed.
- [x] `pipx run ruff check src tests benchmarks`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)