### PR TITLE
CLAUDE.md: stop recommending deprecated watchdog ingest

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,7 +132,9 @@ Ingest runs entirely in the terminal — the Python orchestrator (`pipeline/orch
 **Intended workflow:**
 
 1. `watchdog chew` — OCR/Docling (terminal, local, no API tokens)
-2. `watchdog ingest` — lock + queue + extraction + synthesis + briefing (terminal)
+2. `watchdog` (bare, guided walk) or `watchdog dig` then `watchdog bark` for manual control — lock +
+   queue + extraction + synthesis + briefing (terminal). `watchdog ingest` still works but is
+   deprecated (#441/D138) in favour of these two paths; don't recommend it in new code or docs.
 3. Open a Claude Code session in the vault → ask investigation questions; the session reads `hot.md`, `briefings/`, and the registry fresh, with no ingest-time context baggage
 
 Investigation sessions stay separate from ingest by construction, so a session's context is spent only on Q&A.


### PR DESCRIPTION
## Summary
- Part 1 of 3 for #390 (documentation pass). This is the smallest, standalone piece.
- CLAUDE.md's "Ingest workflow" section listed `watchdog ingest` as the intended step-2 command, with no note that it's deprecated. The live CLI (`cli.py`) prints a deprecation warning on every `watchdog ingest` invocation, recommending the bare guided `watchdog` walk or `watchdog dig` + `watchdog bark` instead (#441/D138). This doc had drifted from that — it's the exact staleness Tom flagged in #390's comment thread (2026-08-20: "CLAUDE.md also needs some work... referencing watchdog ingest").
- Fixed by naming the two current recommended paths and a one-line note that `ingest` still works but is deprecated.

## Test plan
- Comment/docs-only change (no runnable code touched) — per this repo's own CLAUDE.md carve-out, skipped pytest/ruff.
- Confirmed the deprecation warning text against the actual source (`src/watchdog/cli.py:614-618`) to make sure this doc now matches it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DooQppPvxWCWuDgX6fSzVG