### PR TITLE
Fix stale command references and trim oversized docstrings

### DIFF
--- a/src/watchdog/cmd/auth.py
+++ b/src/watchdog/cmd/auth.py
@@ -275,8 +275,8 @@ def _status() -> None:
     print()
 
     # Ingestion: which provider each pipeline stage is actually routed to, and whether that
-    # provider is ready — the thing that actually determines whether `watchdog ingest` will
-    # work, independent of Claude's mode above (#325).
+    # provider is ready — the thing that actually determines whether `watchdog dig`/`watchdog
+    # bark` will work, independent of Claude's mode above (#325).
     from watchdog.cmd.base import CONFIG_FILE
     config: dict = {}
     if CONFIG_FILE.exists():
@@ -457,22 +457,14 @@ def _ask_anthropic_mode() -> str | None:
 
 
 def setup_auth_interactive(interactive: bool | None = None) -> None:
-    """Interactive auth setup for `watchdog setup`.
-
-    Watchdog needs Claude Code to run: the interactive investigation commands
-    (/watchdog-query, /watchdog-surface, ...) always run on Claude, and it's the ingestion
-    default too — zero extra setup for a Claude-only user (D222 reaffirms this after briefly
-    trying an OpenAI default, D221; benchmark testing found OpenAI's GPT-5.6 Luna the stronger
-    ingestion choice, but making it the *shipped* default meant every install needed a second
-    provider's key even on a plain Claude subscription — recommended in the docs instead, not
-    forced). This sets up Claude access first (subscription or API key), and — on a
-    subscription — warns that ingesting more than a few documents can be token-heavy for a
-    Pro plan's session limits and offers to route ingestion to another provider instead —
-    a cheaper metered API (Luna named first, as the benchmark-recommended one), or a
-    local/self-hosted model (#380) — walking through picking that provider's models for the
-    three ingest stages if so (#325). Persists the choice; skips cleanly off a terminal.
-    `interactive` is overridable for testing.
-    """
+    """Interactive auth setup for `watchdog setup`. Claude stays the default for both the
+    interactive investigation commands and ingestion — zero extra setup for a Claude-only user
+    (D222). Sets up Claude access first (subscription or API key), then on a subscription warns
+    that ingesting more than a few documents can be token-heavy for a Pro plan's session limits
+    and offers to route ingestion elsewhere instead — a cheaper metered API (Luna named first, as
+    the benchmark-recommended one) or a local/self-hosted model (#380) — walking through picking
+    that provider's models for the three ingest stages if so (#325). Persists the choice; skips
+    cleanly off a terminal. `interactive` is overridable for testing."""
     if interactive is None:
         interactive = sys.stdin.isatty()
 

--- a/src/watchdog/cmd/base.py
+++ b/src/watchdog/cmd/base.py
@@ -72,7 +72,7 @@ _TEMPLATES_DIR = Path(__file__).parent.parent / "templates" / "vault"
 
 _VAULT_PERMISSIONS = [
     # watchdog commands the in-Claude-Code skills run (extraction is now a Python
-    # command — `watchdog ingest` — and needs no in-vault Bash permissions).
+    # command — `watchdog dig` / `watchdog bark` — and needs no in-vault Bash permissions).
     "Bash(watchdog entity-index)",
     "Bash(watchdog queue-status)",
     "Bash(watchdog is-duplicate *)",
@@ -362,7 +362,7 @@ _CMD_HELP: dict[str, dict] = {
         ],
         "notes": [
             "Reads `.watchdog/registry/usage/usage-<ts>.json`, written after every ingest run",
-            "(`watchdog ingest`, or `watchdog dig`/`watchdog bark`), and groups calls by stage (classifier/extractor/",
+            "(`watchdog dig`/`watchdog bark`), and groups calls by stage (classifier/extractor/",
             "finalizer, matching the CLI's own --classifier-model/--extractor-model/",
             "--finalizer-model flags). Extractor rows show the filename and page range (or",
             "section) each call covered.",

--- a/src/watchdog/cmd/merge_entities.py
+++ b/src/watchdog/cmd/merge_entities.py
@@ -6,7 +6,7 @@ two ids — the dashboard's "Possible duplicates" view, the `/watchdog-health`
 near-duplicate check, and D39's Neo4j-export tradeoff note — this command is the fix.
 No model calls: it must be run from inside the vault it mutates, the same
 "run from inside the vault" convention `watchdog is-duplicate` / `watchdog
-post-flight` already use, since there's no useful project-name lookup for a command
+write-vault` already use, since there's no useful project-name lookup for a command
 that edits the registry in place."""
 
 import json

--- a/src/watchdog/cmd/reindex.py
+++ b/src/watchdog/cmd/reindex.py
@@ -1,14 +1,12 @@
 """`watchdog reindex` — rebuild `.embeddings/` and `.fulltext/` from on-disk vault state,
 with zero model calls (#218, #109).
 
-D38's tradeoff note: "changing `embed_model` requires a full re-chew" — true when embedding
-ran at chew time, before D43 moved it into `write_vault` (which needs extraction's title/
-type/entities for the contextual prefix). For an already-ingested vault those outputs
-already live in `documents.json`/`entities.json`, and the full per-page text lives in the
-morgue `<stem>.md` sibling files (D26) — so a full re-embed needs no OCR re-run and no model
-tokens, just local `embed.py` calls. This also unlocks retroactively upgrading an older vault
-to the hybrid (BM25 + rerank) corpus path (D43) without re-ingesting. The same on-disk state
-rebuilds the full-text (exact-term) index (`fulltext.py`) alongside it.
+Possible because embedding now runs at `write_vault` time, not chew time (D43) — an
+already-ingested vault's title/type/entities live in `documents.json`/`entities.json` and the
+full per-page text lives in the morgue `<stem>.md` files (D26), so a full re-embed needs no OCR
+re-run and no model tokens, just local `embed.py` calls. This also unlocks retroactively
+upgrading an older vault to the hybrid (BM25 + rerank) corpus path (D43) without re-ingesting.
+The same on-disk state rebuilds the full-text (exact-term) index (`fulltext.py`) alongside it.
 """
 
 import json

--- a/src/watchdog/cmd/setup.py
+++ b/src/watchdog/cmd/setup.py
@@ -360,7 +360,7 @@ _CONFIGURE_KEYS = {
             "  Value: a Claude tier (haiku, sonnet, opus), or a backend:model form to route to\n"
             "  another provider (openai:gpt-5-mini, deepseek:deepseek-v4-flash, gemini:gemini-3.5-flash-lite).\n"
             "  Default: unset.\n"
-            "  Override for a single run with: watchdog ingest --finalizer-reconciliation-model M"
+            "  Override for a single run with: watchdog bark --finalizer-reconciliation-model M"
         ),
         "type": "string",
         "default": None,
@@ -374,7 +374,7 @@ _CONFIGURE_KEYS = {
             "  Value: a Claude tier (haiku, sonnet, opus), or a backend:model form to route to\n"
             "  another provider (openai:gpt-5-mini, deepseek:deepseek-v4-flash, gemini:gemini-3.5-flash-lite).\n"
             "  Default: unset.\n"
-            "  Override for a single run with: watchdog ingest --finalizer-synthesis-model M"
+            "  Override for a single run with: watchdog bark --finalizer-synthesis-model M"
         ),
         "type": "string",
         "default": None,
@@ -388,7 +388,7 @@ _CONFIGURE_KEYS = {
             "  Value: a Claude tier (haiku, sonnet, opus), or a backend:model form to route to\n"
             "  another provider (openai:gpt-5-mini, deepseek:deepseek-v4-flash, gemini:gemini-3.5-flash-lite).\n"
             "  Default: unset.\n"
-            "  Override for a single run with: watchdog ingest --finalizer-timeline-model M"
+            "  Override for a single run with: watchdog bark --finalizer-timeline-model M"
         ),
         "type": "string",
         "default": None,
@@ -401,7 +401,7 @@ _CONFIGURE_KEYS = {
             "  Value: a Claude tier (haiku, sonnet, opus), or a backend:model form to route to\n"
             "  another provider (openai:gpt-5-mini, deepseek:deepseek-v4-flash, gemini:gemini-3.5-flash-lite).\n"
             "  Default: unset.\n"
-            "  Override for a single run with: watchdog ingest --finalizer-briefing-model M"
+            "  Override for a single run with: watchdog bark --finalizer-briefing-model M"
         ),
         "type": "string",
         "default": None,
@@ -895,28 +895,13 @@ def _persist(config: dict) -> None:
 
 def _auto_resolved_hint(key: str, config: dict) -> str:
     """Render 'auto' for a model-aware section budget along with the concrete value it currently
-    resolves to for the configured extractor model/backend, e.g. 'auto (129032 — sonnet)' for
-    plain Claude, or 'auto (150000 — openai:gpt-5-mini)' for a non-Claude backend — a bare model
-    name there would be misleading, since the resolved number depends on the backend too (#606).
-    `extractor_model` is parsed the same tolerant `[backend:]model` way
-    `cmd/ingest.py:_resolve_stage` does (rpartition on the last ':'), but never exits on an
-    unrecognized value — this only previews an already-stored, already-validated config value, so
-    a hard error here would be the wrong failure mode. Every Claude backend
-    (`model_client.CLAUDE_BACKENDS` — including an explicit `claude-api:`/`claude-agent-sdk:`
-    prefix, not just a bare tier name) keeps the plain pre-#606 format with no backend suffix:
-    naming the backend there would be technically accurate but inert, since it would never explain
-    why the number is what it is, only add noise.
-
-    No effort suffix (#555): sectioning is sized from the context window and tokenizer ratio alone,
-    so the resolved number no longer varies with `extractor_effort` and naming it here would imply
-    a dependency that isn't there.
-
-    `watchdog configure` is a global, vault-independent command (`CONFIG_FILE` lives under
-    `~/.watchdog/`; `cmd_configure` never touches a vault path) — there is no usage history to
-    calibrate the tokenizer ratio against here (#574 follow-up), so this preview always reflects
-    the static catalog ratio. That's by design, not an oversight: only a real ingest run (which
-    has vault context) can benefit from the calibrated ratio — see `section.model_defaults`'s own
-    `vault` parameter."""
+    resolves to, e.g. 'auto (129032 — sonnet)' for plain Claude, 'auto (150000 —
+    openai:gpt-5-mini)' for a non-Claude backend — the resolved number depends on the backend too
+    (D190), so a bare model name would be misleading. No effort suffix: sectioning no longer
+    varies with `extractor_effort` (D202). No calibrated tokenizer ratio either — `watchdog
+    configure` is vault-independent, so there's no usage history to calibrate against here (#574
+    follow-up); this preview always reflects the static catalog ratio, and only a real ingest run
+    (with vault context) benefits from the calibrated one."""
     from watchdog import model_client
     from watchdog.pipeline import section
     raw = config.get("extractor_model") or _CONFIGURE_KEYS["extractor_model"]["default"]

--- a/src/watchdog/cmd/usage.py
+++ b/src/watchdog/cmd/usage.py
@@ -2,7 +2,7 @@
 
 Reads `.watchdog/registry/usage/usage-<ts>.json` (D50, relocated out of the flat Registry dir
 in #319) — the Python orchestrator's own per-call telemetry, written after every ingest run
-(`watchdog ingest`, or `watchdog dig`/`watchdog bark`) — and groups calls by stage (classifier / extractor / finalizer,
+(`watchdog dig`/`watchdog bark`) — and groups calls by stage (classifier / extractor / finalizer,
 matching the CLI's own `--classifier-model` / `--extractor-model` / `--finalizer-model`
 vocabulary). Extractor rows show the filename and page range (or section) each call covered.
 Cost is read directly from each record — there is no local pricing table to keep in sync, since

--- a/src/watchdog/cmd/vault.py
+++ b/src/watchdog/cmd/vault.py
@@ -1075,7 +1075,7 @@ def cmd_status(args) -> None:
         docs_data = _read_json(docs_file) if docs_file.exists() else {}
         ents_data = _read_json(ents_file) if ents_file.exists() else {}
     except json.JSONDecodeError as e:
-        sys.exit(f"Error: registry file is corrupt — {e}\nRun '/watchdog-health' to diagnose.")
+        sys.exit(f"Error: registry file is corrupt — {e}\nRun 'watchdog doctor' to diagnose.")
 
     total_pages = sum(d.get("page_count", 0) for d in docs_data.values())
     doc_types   = Counter(d["document_type"] for d in docs_data.values() if d.get("document_type"))

--- a/src/watchdog/model_catalog.py
+++ b/src/watchdog/model_catalog.py
@@ -158,21 +158,13 @@ _THINKING_BY_DEFAULT_TIERS = {"sonnet-5", "opus-5"}
 
 def catalog_has_reasoning(model_id: str) -> bool:
     """Whether `model_id` has a private reasoning channel it can use before committing to its
-    visible answer — an OpenAI reasoning model (`reasoning: true`) or a Claude model with
-    `thinking` engaged, whether sent explicitly (`thinking: true`, #635) or on by default (Sonnet
-    5, Opus 5). Feeds the extraction scaffold's branch (#570): a model with a channel gets a
-    compact nudge into it, one without gets the explicit step-by-step form written into the
-    visible completion instead, via `document.plan` (see extract_instructions.md).
-
-    A DeepSeek `-thinking` id counts too (D217): thinking mode returns `reasoning_content`
-    alongside `content`, which is a private channel by any reading, and the marker has to be
-    stripped for the entry to be found at all. Before that, every DeepSeek thinking call was handed
-    the explicit `document.plan` scaffold built for models with *no* channel — paying for a visible
-    plan while also thinking privately. The provider check keeps the stripping honest: a
-    non-DeepSeek id that merely ends in `-thinking` is not granted a channel by its name.
-
-    False — the conservative default — for every other catalogued model (Haiku, DeepSeek's plain
-    ids, Gemini) and for any uncatalogued id: never assume a channel that isn't confirmed."""
+    visible answer — an OpenAI reasoning model, a Claude model with `thinking` engaged (explicit
+    or on-by-default), or a DeepSeek `-thinking` id (D217: its `reasoning_content` is a private
+    channel by any reading; the provider check keeps the marker-stripping honest, since a
+    non-DeepSeek id ending in `-thinking` isn't granted a channel by its name alone). Feeds the
+    extraction scaffold's branch (#570): a model with a channel gets a compact nudge into it, one
+    without gets the explicit step-by-step `document.plan` form instead. False — the conservative
+    default — for every other catalogued model and any uncatalogued id."""
     bare, deepseek_thinking = _split_deepseek_thinking(model_id)
     entry = _MODELS.get(bare.lower())
     if not entry:

--- a/src/watchdog/model_client.py
+++ b/src/watchdog/model_client.py
@@ -308,22 +308,15 @@ class ModelError(RuntimeError):
     """The model could not return schema-valid JSON, or the chosen backend can't run.
 
     `usage`/`cost_usd`/`attempts`/`model`/`backend`/`auth_mode` (D125) are set only when the
-    failure happened after at least one attempt actually called the model — the JSON-validation-
-    failure path and the truncation path in `acomplete_json` — so the real spend on a failed call
-    isn't lost. A backend/transport exception (raised before any usage exists) leaves these None.
-
-    `truncated` (#540) flags the specific case of an authoritative max-token cut (see the
-    `out.get("truncated")` branch below) — a structured signal a caller can act on (e.g. the
-    orchestrator's section-level re-split fallback) instead of matching on `last_err`'s message
-    text, which is prose meant for a human and free to change (#547 already changed one of these
-    strings once).
-
-    `starved` (#558) is set only alongside `truncated` and narrows it further: the max-token cut
-    happened because reasoning consumed the whole output budget before an answer was written (or
-    outweighed it), not because the answer itself overflowed. The two need different recovery —
-    re-splitting the input helps truncation but does nothing for starvation, since a smaller
-    input still gets the same reasoning envelope — so a caller must be able to tell them apart
-    rather than applying one recovery to both."""
+    failure happened after at least one attempt actually called the model, so real spend on a
+    failed call isn't lost; a backend/transport exception raised before any usage exists leaves
+    these None. `truncated` (#540) is a structured signal for an authoritative max-token cut, so
+    a caller can act on it (e.g. a section re-split) instead of matching on `last_err`'s
+    message text, which is free to change (#547 already changed one). `starved` (#558) narrows
+    `truncated` further: reasoning consumed the output budget rather than the answer itself
+    overflowing — a caller needs to tell the two apart, since re-splitting the input fixes
+    truncation but does nothing for starvation (a smaller input gets the same reasoning
+    envelope)."""
 
     def __init__(self, message: str, *, usage: dict | None = None, cost_usd: float | None = None,
                 attempts: int = 0, model: str | None = None, backend: str | None = None,
@@ -553,29 +546,14 @@ def _flatten_prompt(prompt: str | list[dict]) -> str:
 
 
 def _prompt_cache_key(prompt: str | list[dict]) -> str | None:
-    """A `prompt_cache_key` for OpenAI's Chat Completions API (#562), derived from the FIRST
+    """A `prompt_cache_key` for OpenAI's Chat Completions API, derived from the FIRST
     `cache_control` breakpoint in a content-block prompt — None for a plain string or a block
-    prompt with no breakpoint at all.
-
-    OpenAI's prompt-caching guide is explicit that this parameter matters: "On GPT-5.6 models
-    and later model families, you must set `prompt_cache_key` to use the more reliable matching
-    for both implicit and explicit caching," and it should be held "consistently across requests
-    that share long, common prefixes." Without it, routing falls back to a hash of roughly the
-    first 256 tokens, which is why cache_read_tokens measured 0 across every OpenAI call in a
-    fresh benchmark run despite extract/extract-section sharing a ~3,300-token prefix (#562).
-
-    First breakpoint, not last: `build_extract_prompt`/`build_section_prompt` place two
-    breakpoints — the first after the skill block (blocks 1+2: run-stable instructions + brief +
-    domain skill, genuinely shared across every call in a run that uses that skill), the second
-    (added by `prompts._document_block` only when the verification pass is on) after the
-    per-document text, which is unique to one call. Keying on the second would give nearly every
-    request its own key and scatter exactly the cross-document, same-skill routing that can
-    actually produce a hit; keying on the first groups calls by what they truly share.
-
-    This is only a routing hint, not a cache guarantee: OpenAI still matches on the actual prefix
-    hash first, so two prompts with the same key but different `response_format` schemas (e.g.
-    extract vs. verify, each with its own JSON schema serialized ahead of the system message)
-    still cannot share a cache entry — see D181."""
+    prompt with no breakpoint. Required by OpenAI for reliable cache matching on GPT-5.6+ (D181).
+    Keyed on the first (run-stable instructions+skill), not the second breakpoint that
+    `prompts._document_block` adds for the verify pass, since keying on the per-document one
+    would scatter exactly the cross-document routing that can produce a hit. Only a routing
+    hint, not a guarantee: two prompts with the same key but different `response_format` schemas
+    (extract vs. verify) still can't share a cache entry (D181)."""
     if not isinstance(prompt, list):
         return None
     for i, block in enumerate(prompt):
@@ -588,39 +566,20 @@ def _prompt_cache_key(prompt: str | list[dict]) -> str | None:
 
 def _openai_cache_blocks(prompt: str | list[dict]) -> list[dict] | None:
     """The user message's `content` as OpenAI text parts, with an explicit
-    `prompt_cache_breakpoint` on the block that ends the cacheable prefix (#586, D195) — or None
-    when this prompt has no breakpoint to mark and should be sent flattened, exactly as before.
+    `prompt_cache_breakpoint` on the block that ends the cacheable prefix (D195) — or None when
+    this prompt has no breakpoint to mark and should be sent flattened, exactly as before.
 
-    Only for the GPT-5.6 family and later, which changed the caching contract: the service places
-    one implicit breakpoint at the latest user message and, per OpenAI's prompt-caching guide,
-    "unlike earlier models, it does not automatically fall back to the longest matching unmarked
-    prefix before that breakpoint." Since `_openai_complete_async` sends the whole prompt as a
-    single user message, that implicit breakpoint lands at the very end of it — so an unmarked
-    request can only hit on a byte-identical whole-prompt repeat, and never on the run-stable
-    instructions+skill head that `prompts.py` goes to such lengths to keep at the front. That is
-    exactly what the archives show: across 440 recorded `gpt-5.6-luna` calls, every hit had
-    `input - cache_read == 3` (a whole-prompt replay in a self-consistency benchmark) and not one
-    was a partial prefix hit, while `gpt-5.4-mini` — an earlier family, longest-prefix fallback
-    still in effect — cached partially all along, `digest` included (#586).
+    Only for GPT-5.6+, which places its one implicit breakpoint at the very end of the whole
+    prompt (`_openai_complete_async` sends it as a single user message) — so an unmarked request
+    can only ever hit on a byte-identical whole-prompt repeat, never the run-stable
+    instructions+skill head (D195 has the measured evidence: 440 `gpt-5.6-luna` calls, zero
+    partial hits). Marks the FIRST breakpoint only, same reasoning as `_prompt_cache_key`; the
+    verify pass's second breakpoint is deliberately left unmarked, since extract/verify diverge
+    before it regardless (D181), and marking it would pay a 1.25x write for nothing.
 
-    Marks the FIRST breakpoint only, matching `_prompt_cache_key`'s choice and for the same
-    reason: it is the boundary of what calls genuinely share. `prompts._document_block`'s second
-    breakpoint (the verification pass, #535) is deliberately left unmarked here — extraction and
-    verification each serialize their own structured-output schema ahead of the system message,
-    so their prefixes diverge before either reaches the document text and no marking of the
-    document block could make them share one (D181). Leaving it unmarked also avoids paying the
-    1.25x write on a document's text that nothing will read back.
-
-    A plain-string prompt, or a block prompt with no breakpoint at all, returns None: there is
-    nothing to mark, and the caller must not then switch the request into explicit mode — doing
-    so would disable the implicit breakpoint and remove even the whole-prompt caching such a call
-    has today.
-
-    The `"\\n"` appended to every block but the last is what `_flatten_prompt`'s `"\\n".join`
-    puts between them. Adjacent text parts are concatenated with no separator of their own, so
-    carrying the newline in the part's own text keeps the rendered prompt byte-identical to the
-    flattened form this replaces — this change is meant to alter the request's cache metadata and
-    nothing the model actually reads."""
+    The `"\\n"` appended to every block but the last replaces the separator
+    `_flatten_prompt`'s `"\\n".join` used to provide, so the rendered prompt stays
+    byte-identical to the flattened form — this changes only the request's cache metadata."""
     if not isinstance(prompt, list):
         return None
     marked = None
@@ -832,36 +791,24 @@ def _batch_cost(model_id: str, usage) -> float | None:
 async def _api_complete_async(prompt: str | list[dict], model_id: str, schema: dict,
                               api_key: str | None, max_tokens: int,
                               effort: str | None = None, prefix: str | None = None) -> dict:
-    """Raw Claude Messages API backend with structured outputs.
+    """Raw Claude Messages API backend with structured outputs. `prompt` may be a plain string
+    or a list of Anthropic content blocks with a `cache_control` breakpoint (A1) — the Messages
+    API's `content` field accepts either shape natively.
 
-    `prompt` may be a plain string or a list of Anthropic content blocks with a
-    `cache_control` breakpoint (A1) — the Messages API's `content` field accepts either
-    shape natively, so no conversion is needed here.
+    `prefix` (#343): a truncated call's partial output is prefilled as the assistant turn and
+    continued. `format` enforcement drops on a continuation (constrained decoding can't resume
+    mid-object; the shared shell validates the concatenation instead), and `thinking` drops too
+    (#635, D206) since Anthropic rejects prefilling while thinking is on — only the initial
+    attempt reasons, the resume-a-truncation retry doesn't. `finish_reason` mirrors `stop_reason`
+    so the shell can tell a max-token cut from a natural stop.
 
-    `prefix` (response pagination, #343): when set, the partial output of a truncated call is
-    prefilled as the assistant turn and the model continues it. Structured-output `format`
-    enforcement is dropped on a continuation (constrained decoding can't resume mid-object) —
-    the concatenation is validated by the shared shell — but `effort` is still carried so the
-    same reasoning depth applies (I4). `thinking` (#635, D206) is likewise dropped on a
-    continuation: Anthropic rejects prefilling the assistant turn while thinking is on, and this
-    is exactly what a continuation does. The initial attempt still thinks; only the retry-to-
-    resume-a-truncation path loses it, same shape as the `format` drop above. The returned
-    `finish_reason` mirrors `stop_reason` so the shell can tell a max-token cut (`max_tokens`)
-    from a natural stop.
-
-    Streams rather than calling `.create()` (#598). The Anthropic SDK refuses a *non-streaming*
-    request once `3600 * max_tokens / 128_000 > 600`, i.e. `max_tokens > 21,333`
-    (`Anthropic._calculate_nonstreaming_timeout`, anthropic 0.116.0) — comfortably below the
-    catalogued envelope this now sends (115,200 on Sonnet 4.6). Overriding the client's timeout
-    instead of switching to streaming would defeat the reason the guard exists in the first
-    place: a non-streaming call holds one silent connection open for the whole generation, and a
-    TLS-inspecting corporate proxy between here and the API will drop a long-idle one — trading a
-    self-healing truncation (caught by `finish_reason`, recovered by continuation) for a dropped
-    connection. Streaming keeps bytes flowing instead, so the connection stays alive for the
-    proxy. Do not revert this to `.create()` without re-deriving `max_tokens` back under 21,333.
-    `_MAX_CONTINUATIONS` pagination (below) stays as a safety net either way — it just stops
-    being a *routine* cost now that the wire ceiling is the model's real cap, not a fraction of
-    it."""
+    Streams rather than calling `.create()` (#598): the Anthropic SDK refuses a *non-streaming*
+    request once `max_tokens > 21,333` (`Anthropic._calculate_nonstreaming_timeout`, anthropic
+    0.116.0) — well below the catalogued envelope now sent (115,200 on Sonnet 4.6). Overriding
+    the client's timeout instead would defeat the point: a non-streaming call holds one silent
+    connection open for the whole generation, which a TLS-inspecting corporate proxy will drop —
+    streaming keeps bytes flowing so the connection stays alive. **Do not revert to `.create()`
+    without re-deriving `max_tokens` back under 21,333.**"""
     import anthropic
 
     messages = [{"role": "user", "content": prompt}]
@@ -1083,29 +1030,23 @@ async def _openai_complete_async(prompt: str | list[dict], model_id: str, schema
                                  effort: str | None = None, prefix: str | None = None,
                                  *, base_url: str) -> dict:
     """OpenAI-compatible Chat Completions backend — OpenAI, DeepSeek, Gemini (via its
-    OpenAI-compatibility endpoint, https://ai.google.dev/gemini-api/docs/openai), and any
-    other service that speaks the same wire format (selected by `base_url`).
+    OpenAI-compatibility endpoint), and any other service speaking the same wire format
+    (selected by `base_url`).
 
-    Structured output is requested via `_openai_response_format` (real `json_schema` enforcement
-    on Gemini; portable JSON-object mode + schema-in-prompt elsewhere, D98), then validated by
-    the shared `acomplete_json` shell either way — that local validation is a safety net, not the
-    only guard, once the provider itself enforces the schema. `effort` arrives already resolved
-    to the provider's native value (or None) and is sent as `reasoning_effort` (#125). No
-    provider-agnostic cache_control equivalent is wired here (A1 is Claude-only), so a
-    content-block prompt is flattened to plain text — but the first breakpoint's position (before
-    flattening) is still reused to derive a `prompt_cache_key` for the real OpenAI endpoint, per
-    `_prompt_cache_key` (#562).
+    Structured output goes via `_openai_response_format` (real `json_schema` enforcement on
+    Gemini; portable JSON-object mode + schema-in-prompt elsewhere, D98), then validated locally
+    as a safety net either way. `effort` arrives already resolved to the provider's native value
+    and is sent as `reasoning_effort` (#125). No provider-agnostic cache_control equivalent
+    exists here (A1 is Claude-only), so a content-block prompt is flattened, but the first
+    breakpoint's position is still reused to derive `prompt_cache_key` (D181) for the real
+    OpenAI endpoint.
 
-    DeepSeek carries an optional `-thinking` marker on the model id; it is stripped here and
-    translated into DeepSeek's explicit thinking toggle (default off — see #320).
-
-    `prefix` (response pagination, #343): DeepSeek's chat-prefix-completion beta continues a
-    truncated response — the partial output is appended as an assistant turn with `prefix: true`
-    against the `/beta` base, and structured-output enforcement is dropped (the model is
-    completing a partial object, not generating a fresh one). OpenAI and Gemini return a *new*
-    assistant message rather than continuing the given one, so they never prefill
-    (`supports_continuation=False` in `_BACKEND_META`) and always reach this with `prefix=None`. The returned
-    `finish_reason` lets the shell distinguish a max-token cut (`length`) from a natural stop."""
+    DeepSeek's optional `-thinking` model-id marker is stripped and translated to its explicit
+    thinking toggle (default off, #320). `prefix` (#343): only DeepSeek's chat-prefix-completion
+    beta continues a truncated response (partial output appended as an assistant turn with
+    `prefix: true`, structured-output enforcement dropped); OpenAI/Gemini return a *new*
+    assistant message instead and never prefill (`supports_continuation=False`). `finish_reason`
+    lets the shell distinguish a max-token cut (`length`) from a natural stop."""
     import ssl
 
     import httpx
@@ -1382,24 +1323,15 @@ def _wire_max_tokens(backend: str, model_id: str) -> int:
     """The `max_tokens` ceiling sent to the provider on the wire for `backend`/`model_id` — task-
     and effort-independent (#598).
 
-    `max_tokens` is a runaway guard, not a reservation: billing is on actual output, so there is
-    no cost to sending the model's real envelope on every call regardless of what the call is for
-    or how hard it's asked to think. The old per-task base (`_TASK_MAX_TOKENS`, 16,000) plus a
-    per-provider reasoning "reserve" bolted on top of it (DeepSeek thinking #337, OpenAI reasoning
-    models #354, Gemini #541) existed only because that base was itself a hardcoded guess shared
-    with chain-of-thought — every provider catalogued here draws reasoning/thinking tokens from
-    the SAME output budget as the visible answer (see `model_catalog.yaml`'s `max_output_tokens`
-    comment), so a ceiling sized only for the visible JSON starves reasoning the moment it grows.
-    Deriving the ceiling from the model's real catalogued cap removes that starvation mode at its
-    root, for every backend, instead of layering a per-provider patch on top of it.
-
-    Reasoning volume itself is not a function of effort alone — archived telemetry fit against
-    input length shows it also scales steeply with *input size* (up to ~2.3 tokens of thinking
-    per input token at high effort, roughly 12x the visible-output rate) — but that no longer
-    matters anywhere: the wire ceiling is the model's own envelope regardless, and as of #555
-    nothing reasons about how much of it reasoning will consume. `pipeline/section.py`'s
-    *input*-side sizing used to invert that estimate into a section budget; it no longer consults
-    this function at all (see D202), so this envelope is now purely a runaway guard on the wire."""
+    A runaway guard, not a reservation: billing is on actual output, so there's no cost to
+    sending the model's real catalogued envelope on every call. This replaced a hardcoded
+    per-task base (16,000) plus bolted-on per-provider reasoning "reserves" (#337/#354/#541),
+    which existed only because every provider draws reasoning tokens from the SAME output budget
+    as the visible answer — a ceiling sized for the visible JSON alone starves reasoning the
+    moment it grows. Deriving the ceiling from the real catalogued cap removes that starvation
+    mode at its root instead of patching it per provider. `pipeline/section.py`'s input-side
+    sizing no longer consults this function at all (D202) — this envelope is now purely a
+    runaway guard on the wire, not an input-budget input."""
     if backend == "deepseek":
         # `-thinking` is a Watchdog-only routing marker (D88), not a real catalog id — strip it
         # before consulting the catalog, the same normalization `_openai_complete_async` already

--- a/src/watchdog/pipeline/batch_extract.py
+++ b/src/watchdog/pipeline/batch_extract.py
@@ -1,26 +1,18 @@
 """Batch API integration for bulk whole-document extraction (#214, #530).
 
 Batch mode submits every whole-document (non-sectioned) extraction request in one provider batch
-— 50% off all token usage (stacking with the prompt caching wired in #213), at the cost of
-asynchronous completion (typically under an hour, up to 24h). `orchestrate._run_batch` is the
-sole caller; this module only knows the batch's own lifecycle (state, submit, status, collect) —
-it never touches the vault or calls postflight/write_vault, matching the existing
-preflight/postflight separation of concerns.
+— 50% off token usage, stacking with prompt caching (#213) — at the cost of asynchronous
+completion (typically under an hour, up to 24h). `orchestrate._run_batch` is the sole caller;
+this module only knows the batch's own lifecycle (state, submit, status, collect), never the
+vault, matching the preflight/postflight separation of concerns.
 
-Two providers are wired, dispatched by `backend` (`submit`/`status`/`collect`'s public entry
-points): Anthropic's Message Batches API (`claude-batch`, #214, inline requests via the
-`anthropic` SDK) and OpenAI's Batch API (`openai-batch`, #530, a JSONL file uploaded via `/v1/files`
-then referenced by `/v1/batches`, spoken over raw httpx — same no-new-SDK-dependency choice
-`model_client._openai_complete_async` already made, D37). The two APIs' request/response shapes
-differ enough that this is two real implementations behind one dispatcher, not a thin wrapper.
-
-State is a single `.watchdog/registry/batch-pending.json` per vault — only one batch is ever in
-flight at a time (mirroring `has_pending_finalization`'s "resolve the pending thing first"
-precedent) — durable across interruption, mirroring the research URL worklist (D46). The
-persisted state records which `backend` submitted it, so a later `watchdog dig` invocation
-resumes against the right provider even across an upgrade — state written before this field
-existed defaults to `claude-batch` on read (`orchestrate._resume_batch`).
-"""
+Two providers are wired behind `backend` (`submit`/`status`/`collect`'s dispatch): Anthropic's
+Message Batches API (`claude-batch`, #214) and OpenAI's Batch API (`openai-batch`, #530, JSONL
+over raw httpx, D37) — different enough shapes to be two real implementations, not a thin
+wrapper. State is a single `.watchdog/registry/batch-pending.json` per vault (only one batch in
+flight at a time), durable across interruption like the research URL worklist (D46); it records
+which `backend` submitted it so a later `watchdog dig` resumes against the right provider
+(state from before this field existed defaults to `claude-batch` on read)."""
 
 import datetime
 import json
@@ -56,20 +48,13 @@ def clear_state(vault: Path) -> None:
 
 def est_prompt_tokens(docs: list[dict]) -> dict[str, int]:
     """`{sha: chars/4 estimate of that doc's whole rendered prompt}`, persisted in the batch state
-    at submit time (#617).
-
-    The live path computes this inside `orchestrate._call_model`, which has the rendered prompt in
-    scope. A batch doesn't: the prompt is rendered here, at submission, and the usage record is
-    written by `_collect_batch_results` in a *later* invocation, by which point only the parsed
-    result and its usage remain. Without carrying it across, every batch-extracted call would lack
-    `est_prompt_tokens` and be skipped by `ingest_setup._model_tokenizer_calibration`, so a vault
-    that extracts exclusively on `claude-batch`/`openai-batch` could never calibrate its own
-    tokenizer ratio and would sit on the catalog constant forever.
-
-    Mirrors `_call_model`'s own normalization: a prompt is normally a string but may be a list of
-    Anthropic content blocks (A1, cache_control), and `json.dumps` gives that shape a stable text
-    form to measure — the same convention, so a batch record's estimate is comparable to a live
-    one's rather than being on its own scale."""
+    at submit time (#617). The live path computes this inside `_call_model`, which has the
+    rendered prompt in scope; a batch doesn't, since collection happens in a *later* invocation
+    with only the parsed result and usage left — without carrying it across, a vault extracting
+    exclusively via batch could never calibrate its tokenizer ratio
+    (`ingest_setup._model_tokenizer_calibration`). Mirrors `_call_model`'s own normalization
+    (string or Anthropic content-block list, A1) so a batch record's estimate is comparable to a
+    live one's."""
     return {d["sha"]: section.est_tokens(
         d["prompt"] if isinstance(d["prompt"], str) else json.dumps(d["prompt"], sort_keys=True))
         for d in docs}
@@ -118,22 +103,14 @@ async def collect(batch_id: str, api_key: str, model_id: str, backend: str = "cl
 
 async def _anthropic_submit(vault: Path, docs: list[dict], *, model: str, effort: str | None,
                             skills: dict[str, str], api_key: str, backend: str) -> str:
-    """`model` is a tier name or raw id (resolved via `model_client.resolve_model_id`); `effort`
-    is the abstract per-stage intent (D36), mapped to Claude's native value the same way a
-    single call would be. Reuses `model_client`'s task-budget/system-prompt constants directly
-    rather than duplicating them — this is the same request shape `_api_complete_async` builds
-    for a single call, just submitted as a batch of them.
-
-    `skills` maps each sha to the record-skill label its prompt was built with (D144). One batch
-    may mix skills — the skill is baked into that request's own prompt blocks, and the API treats
-    each request independently — but collection runs in a later process, so the mapping has to be
-    persisted rather than recomputed.
-
-    Sends `thinking` per request on the same `catalog_needs_thinking_param` gate the live
-    (`_api_complete_async`) and agent-sdk (`_agent_query`) paths already use (#635, D206) — this
-    path was the one Claude-calling caller left off that gate (#643), so a `thinking`-default-off
-    model extracted via `claude-batch` never actually reasoned regardless of #635 shipping.
-    """
+    """`model`/`effort` follow the same tier-resolution and abstract-intent mapping (D36) a
+    single call would use; this is the same request shape `_api_complete_async` builds, just
+    submitted as a batch. `skills` maps each sha to the record-skill label its prompt was built
+    with (D144) and must be persisted, since one batch may mix skills but collection runs in a
+    later process with no prompt left to inspect. Sends `thinking` per request on the same gate
+    the live and agent-sdk paths use (#635, D206) — this path was the one left off that gate
+    until #643, so a thinking-default-off model extracted via `claude-batch` never actually
+    reasoned even after #635 shipped."""
     model_id = model_client.resolve_model_id(model)
     effort_arg = model_client._resolve_effort("anthropic", model_id, effort)
     output_config = {"format": {"type": "json_schema", "schema": schemas.EXTRACTION}}
@@ -185,12 +162,9 @@ def _model_dump(obj) -> dict:
 
 
 def _iso(dt: datetime.datetime | None) -> str | None:
-    """A `MessageBatch` timestamp (a real `datetime`, per the SDK's own type) in the same
-    `%Y-%m-%dT%H:%M:%SZ` string shape `write_state` already stamps `submitted_at` with — so the
-    two are directly comparable without a second timestamp format anywhere in a batch's
-    lifecycle. `ended_at` is None until processing ends; passed through as None rather than a
-    placeholder string, since a caller that hasn't checked `processing_status` first shouldn't
-    be able to mistake "not finished yet" for a real timestamp."""
+    """A `MessageBatch` timestamp in the same string shape `write_state` stamps `submitted_at`
+    with, so the two are directly comparable. `None` (before processing ends) stays `None`
+    rather than a placeholder string, so it can't be mistaken for a real timestamp."""
     return dt.strftime(_TS_FMT) if dt is not None else None
 
 

--- a/src/watchdog/pipeline/ingest_setup.py
+++ b/src/watchdog/pipeline/ingest_setup.py
@@ -56,32 +56,16 @@ def scan_queue(vault: Path) -> list[dict]:
 
 
 def _real_input_tokens(totals: dict, backend: str | None = None) -> int:
-    """Total tokens the model actually processed as input for a run's calls (issue #470).
+    """Total tokens the model actually processed as input for a run's calls (#470).
 
-    On Anthropic, plain `input_tokens` badly undercounts once prompt caching is in play: a cache
-    hit or write moves the bulk of a call's input volume into `cache_read_tokens`/
-    `cache_write_tokens` instead, and those are reported as counts *additional* to
-    `input_tokens` — a sectioned extraction carrying a growing shared prefix can show
-    `input_tokens` in the single digits while the real content processed is orders of magnitude
-    larger. (The archived `claude-agent-sdk` arm is the extreme case: 18 input tokens against
-    230,155 cache-write tokens for the same six documents.) The naive chars/4 estimate this is
-    compared against counts a document's full text once regardless of how many cached/fresh calls
-    served it, so the comparison point needs the same full-volume accounting.
-
-    **Every other provider reports the opposite convention** (#617): OpenAI's `prompt_tokens`
-    already *includes* `prompt_tokens_details.cached_tokens`, and DeepSeek's already includes
-    `prompt_cache_hit_tokens` — the cached count is a breakdown OF the input total, not an
-    addition to it. Summing there double-counts every cached token. Measured on the archived
-    benchmark corpus this inflated `gpt-5.4-mini`'s apparent tokens-per-est-token by 12.6% (its
-    fitted ratio read 1.110 summed against 0.914 on `input_tokens` alone — and the *unsummed* fit
-    is the better one, r² 0.839 vs 0.747, which is the tell that the extra tokens were double
-    counting rather than signal).
-
-    So `backend` selects the convention. It is optional and defaults to the summing form, because
-    the run-level `totals` dict this is also called with has no single backend to key off — a run
-    may mix providers — and Anthropic is both the default backend and the only one where the
-    naive form is catastrophically wrong rather than mildly so. Pass it whenever the caller has a
-    single call's record in hand, as `_model_tokenizer_calibration` does."""
+    Anthropic reports a cache hit/write as counts *additional* to `input_tokens`, so they must be
+    summed in or a sectioned extraction with a growing shared prefix reads as near-zero input.
+    Every other provider reports the opposite convention (#617) — the cached count is already a
+    breakdown OF `prompt_tokens`, so summing there double-counts. `backend` selects the
+    convention; it defaults to the summing form since the run-level `totals` dict this is also
+    called with may mix providers, and Anthropic is both the default and the only backend where
+    the naive form is badly wrong rather than mildly so. Pass it when the caller has a single
+    call's record in hand, as `_model_tokenizer_calibration` does."""
     # Local import for the same circular-import reason `_model_tokenizer_calibration` has one:
     # `model_client.tokenizer_ratio` reaches back into this module.
     from watchdog.model_client import provider_for_backend
@@ -92,35 +76,15 @@ def _real_input_tokens(totals: dict, backend: str | None = None) -> int:
 
 
 def _tokens_calibration(vault: Path, max_runs: int = 3) -> float | None:
-    """Empirical correction factor for the naive chars/4 'tokens in' estimate (issue #417).
-
-    Every usage-<ts>.json written by a run that actually extracted documents now carries both
-    what was estimated for those documents at queue time (``totals.est_input_tokens``, the same
-    chars/4 heuristic ``scan_queue`` uses, summed by `orchestrate._compact_result`) and what
-    extraction really consumed (`_real_input_tokens`, #470) — their ratio is how far off the
-    heuristic ran, against this vault's own recent documents rather than a fixed global guess.
-    Averaged over the last `max_runs` such files (a blend here, unlike `cost_estimate`'s
-    deliberate low/high range for dollars: this feeds a single displayed token count, not a
-    range).
-
-    Only files carrying `est_input_tokens` are extraction runs — a standalone `watchdog bark`
-    never sets it (nothing was extracted), so it's silently skipped without a separate task-based
-    filter. A vault with no such history yet (first run since this shipped, or a vault that has
-    only ever run standalone finalizes) returns None, and callers fall back to the raw heuristic
-    rather than fabricate a correction. Not backend-aware: a queue about to extract on a different
-    provider than produced this history gets the same correction as any other — consistent with
-    `cost_estimate`'s own $/token ratio, which has never been backend-filtered either.
-
-    Not model-tokenizer-aware either (#574): this ratio already absorbs whatever tokenizer the
-    extraction model(s) behind the last `max_runs` history files actually used, since it's derived
-    empirically from their real `input_tokens`. That only stays correct while the extractor
-    doesn't cross the Claude tokenizer boundary (old tokenizer through Sonnet 4.6, new tokenizer
-    from Opus 4.8/Sonnet 5 on, #574) between the history and the upcoming run — a vault that
-    switches its extractor model across that boundary gets a calibration ratio computed against
-    the *other* tokenizer for one run's worth of history, same as switching providers already
-    does. Not scoped to the extractor model per history file to correct for this — would need
-    grouping calibration runs by model, a bigger change than this fix's scope.
-    """
+    """Empirical correction factor for the naive chars/4 'tokens in' estimate, averaged from this
+    vault's own last `max_runs` extraction usage files rather than a fixed global guess (#417):
+    the ratio of what `scan_queue` estimated to what extraction really consumed
+    (`_real_input_tokens`, #470). Only files carrying `est_input_tokens` are extraction runs (a
+    standalone `watchdog bark` never sets it), so those are skipped without a separate filter.
+    Not backend- or model-tokenizer-aware (#574) — the ratio absorbs whatever tokenizer produced
+    the history, so it drifts if the extractor model crosses the Claude tokenizer boundary
+    between that history and the upcoming run. Returns None with no history to calibrate from;
+    callers fall back to the raw heuristic rather than fabricate a correction."""
     from watchdog.pipeline import orchestrate
     ratios = []
     for uf in reversed(orchestrate.usage_files(vault)):
@@ -138,74 +102,20 @@ def _tokens_calibration(vault: Path, max_runs: int = 3) -> float | None:
 
 def _model_tokenizer_calibration(vault: Path, model: str | None, backend: str | None,
                                  max_records: int = 20, min_records: int = 3) -> float | None:
-    """Empirical, per-model correction factor for `model_client.tokenizer_ratio` (#606 Part B),
-    the same idea as `_tokens_calibration` above but scoped to one model/backend and pooled at
-    the individual-call level rather than the whole-run level.
-
-    `_tokens_calibration` compares a whole run's `totals.est_input_tokens` to its real input
-    tokens — one ratio per run, mixing every model that run happened to use. That's fine for a
-    single vault-wide "how far off is the naive heuristic" display, but the tokenizer ratio this
-    feeds (`model_client.tokenizer_ratio`) is a property of one specific model's tokenizer, not of
-    a run, so a run-level average would blend models with genuinely different tokenizers into one
-    number. Each individual usage record already carries its own `model`/`backend` (`orchestrate.
-    _record_usage`) — this scans those directly instead of `totals`.
-
-    `model`/`backend` are resolved to the catalog id the same way `tokenizer_ratio`/
-    `context_window` do (`resolve_model_id(model or DEFAULT_TIER)`), since that's what a record's
-    own `model` field stores (`ModelResult.model`/`r.model` — the resolved id, not a raw tier
-    name).
-
-    Pooled across records, not averaged per file: matching records for one model can be sparse —
-    a single file's extraction batch may contain only one or two calls to a given model — so
-    summing estimated and actual tokens across every matching record before dividing gives a
-    single stable ratio, rather than letting a file with few matches skew a per-file average as
-    much as a file with many. Scans `orchestrate.usage_files(vault)` most-recent-file-first (like
-    `_tokens_calibration`), stopping once `max_records` matching records have been collected —
-    recent history reflects the model's current tokenizer, and there's no reason to keep scanning
-    once there's enough to be stable.
-
-    Pools `extract` and `extract-section` calls together: the tokenizer ratio corrects for how
-    many real tokens a chunk of text turns into, a property of the model's tokenizer and the text
-    alone — not of which task sent that text — so a whole-document `extract` call and a single
-    section's `extract-section` call are equally valid evidence for the same ratio.
-
-    Divides by `est_prompt_tokens`, NOT `est_input_tokens` (#617, D197). This is the bug the
-    original #606 Part B version shipped with: `est_input_tokens` covers the document text only,
-    while the provider's reported input tokens cover the entire rendered prompt — schema,
-    extraction instructions, record skill, carry-forward entities, harvested candidates and the
-    document alike. Dividing one by the other measured
-    `tokenizer_ratio x (1 + prompt_overhead / document_tokens)`, and the bias was not even
-    constant: it shrank as sections grew, so a vault whose history happened to be section-heavy
-    calibrated to a larger ratio than a whole-document-heavy one for the same model and the same
-    tokenizer, and shrank its sectioning budget accordingly. Measured against corpus-v1 the
-    scaffolding is 7,200-9,300 real tokens per call, which read a true 1.09 Claude ratio as 1.41
-    and a true sub-1.0 GPT-5.4-nano ratio as 2.19.
-
-    One residue survives on `claude-agent-sdk` specifically. `est_prompt_tokens` measures the
-    prompt *this code* renders; the SDK then prepends its own system prompt and CLI preamble,
-    which we never see and therefore never estimate. Archived history puts that at roughly 930
-    real tokens per call — the three Claude backends fit the same slope (1.089-1.091) over the
-    same documents and differ only in intercept: 8,393 `claude-api`, 8,516 `claude-batch`, 9,326
-    `claude-agent-sdk`. So an SDK-backed vault calibrates a few per cent high, the same kind of
-    contamination this function was fixed for, an order of magnitude smaller. Left alone on
-    purpose: the ratio is scoped by `(model, backend)`, so the inflated figure is only ever
-    applied to SDK calls — which really do send those extra tokens — and a slightly more
-    conservative budget on the backend that sends more is the right direction. It is not evidence
-    about the tokenizer, though, which is why `model_catalog.yaml`'s constants come from
-    `count_tokens` (backend-free by construction) rather than from this.
-
-    Records written before #617 carry no `est_prompt_tokens` and are skipped rather than being
-    silently mixed in on the old denominator. A vault whose history is entirely pre-#617
-    therefore calibrates to None and falls back to the catalog constant — which is now itself a
-    measured figure (`model_catalog.yaml`, `benchmarks/tokenizer_ratio.py`), so the cold-start
-    fallback is real data rather than a vendor sentence, and the contaminated ratio stops being
-    preferred over it.
-
-    Returns `None` (not a noisy one-or-two-sample ratio) when fewer than `min_records` matching
-    records were found — a model tried once or twice in this vault shouldn't override the catalog
-    constant on a whim; callers fall back to it instead, exactly as `_tokens_calibration` falls
-    back to the raw chars/4 heuristic with no history at all. A model with no history yet trusts
-    the static catalog ratio until enough real calls accumulate to say otherwise."""
+    """Empirical, per-model correction factor for `model_client.tokenizer_ratio` (D190) — like
+    `_tokens_calibration` above, but scoped to one (model, backend) pair and pooled at the
+    individual-call level, since blending different models' tokenizers into one run-level ratio
+    would be wrong. Scans usage records most-recent-first, pools `extract`/`extract-section`
+    calls (the ratio is a property of the model and the text, not the task), and divides by
+    `est_prompt_tokens` — not `est_input_tokens`, a since-fixed bug that read a true 1.09 Claude
+    ratio as 1.41 by omitting the rest of the rendered prompt from the estimate (D198). Records
+    written before that fix carry no `est_prompt_tokens` and are skipped rather than mixed in on
+    the old denominator. `claude-agent-sdk` calibrates a few percent high regardless, since
+    `est_prompt_tokens` can't see the SDK's own preamble (D198) — left uncorrected on purpose,
+    since the ratio is scoped by `(model, backend)` and that backend really does send those extra
+    tokens. Returns None below `min_records` matching calls, so a model tried once or twice
+    doesn't override the catalog constant; callers fall back to it, same as `_tokens_calibration`
+    falls back to the raw heuristic."""
     from watchdog.model_catalog import resolve_model_id
     from watchdog.model_client import DEFAULT_TIER
     from watchdog.pipeline import orchestrate
@@ -265,26 +175,16 @@ def _output_token_ratio(vault: Path, max_runs: int, finalize_only: bool = False)
 
 
 def _catalog_cost_projection(est_tokens: int, output_ratio: float | None) -> list[dict]:
-    """Price `est_tokens` (already the calibrated 'tokens in' figure) against every model in
-    `model_catalog.yaml` at that model's own list price (#469) — unlike `cost_estimate`'s $/token
-    ratio (drawn from this vault's history of the model that actually ran), a model that has
-    never run here has no $/token history of its own to draw on, so this instead uses the
-    catalog's published per-token rates directly, scaled by `output_ratio` for the output side.
-    Priced as if every input token were a cache miss — the simplest apples-to-apples comparison,
-    and a deliberate overestimate rather than a guessed-at cache hit rate that would vary by
-    model and usage pattern. Every catalog model is included, including Claude tiers, regardless
-    of whether this vault is on subscription auth: this is list price for comparison, not a
-    projection of what you would actually be billed. Returns `[]` when there's no usage history
-    yet to derive `output_ratio` from — no dollar figure is invented from nothing.
-
-    `est_tokens` is a single figure projected uniformly across every catalog model (#469's own
-    design), which crosses the Claude tokenizer boundary (#574): it is calibrated (D135) against
-    whichever model actually produced this vault's usage history, on the old tokenizer by default
-    (the flat chars/4 heuristic itself, and Sonnet 4.6 remaining the default extractor). Each
-    row's own `tokenizer_ratio` is applied here so a new-tokenizer model (Opus 4.8, Sonnet 5) is
-    priced against its own higher real token count rather than the old-tokenizer figure verbatim
-    — accurate as long as the calibration source stayed on the old tokenizer, same caveat
-    `_tokens_calibration` documents for the single-model estimate."""
+    """Price `est_tokens` against every model in `model_catalog.yaml` at that model's own list
+    price (#469), scaled by `output_ratio` for the output side — unlike `cost_estimate`'s $/token
+    ratio (drawn from this vault's history of a model that actually ran), a model with no run
+    history here has no $/token of its own, so this prices every input token as a cache miss: a
+    deliberate overestimate rather than a guessed hit rate. Every catalog model is included
+    regardless of subscription auth — this is list price for comparison, not a real-billing
+    projection. Returns `[]` with no usage history to derive `output_ratio` from — no dollar
+    figure is invented. Each row's own `tokenizer_ratio` scales `est_tokens` so a new-tokenizer
+    model (Opus 4.8, Sonnet 5) prices against its real token count rather than the old-tokenizer
+    figure verbatim (#574, D135)."""
     if output_ratio is None:
         return []
     from watchdog.model_catalog import all_models, catalog_tokenizer_ratio, price_multiplier
@@ -321,25 +221,18 @@ def finalize_cost_estimate_all_models(vault: Path, est_tokens: int, max_runs: in
 
 def cost_estimate(vault: Path, queue_files: list[dict], backend: str | None,
                    max_runs: int = 3, usage_files: list[Path] | None = None) -> dict:
-    """Pre-flight token/cost estimate for a queue (#269): the queue's own `est_tokens` (already
-    computed by `scan_queue`, and calibrated against this vault's own extraction history — #417,
-    see `_tokens_calibration`) times this vault's own $/token history, so a batch's rough cost is
-    visible at the confirm prompt instead of discovered mid-run. The $/token ratio is read fresh
-    from each of the last `max_runs` usage-*.json files (not averaged into one number) so the
-    result can be presented as a range — extraction output varies with document density, and a
-    single false-precise figure would undercut the trust this is meant to build.
-
-    Subscription auth (``claude-agent-sdk``) never gets a dollar figure: there's no real billing
-    to project, only a session-limit fraction this can't estimate honestly from token counts
-    alone. It still gets the calibrated token estimate, though — that's what a subscriber budgets
-    a session window against. With no usage history yet (first run), the token estimate alone is
-    returned — no invented dollar figure.
+    """Pre-flight token/cost estimate for a queue (#269): the queue's calibrated `est_tokens`
+    (`scan_queue`, `_tokens_calibration`, #417) times this vault's own $/token history, read
+    fresh from the last `max_runs` usage files rather than averaged, so the result is a range —
+    extraction output varies with document density, and a single false-precise figure would
+    undercut the trust this is meant to build. Subscription auth (``claude-agent-sdk``) never
+    gets a dollar figure, only the calibrated token estimate — there's no real billing to
+    project. With no usage history yet, only the token estimate is returned.
 
     ``usage_files``, when given, replaces this vault's own history as the $/token ratio source
-    (issue #478) — for a vault that is guaranteed to have none yet by design (every benchmark arm
-    is a freshly seeded vault, `BENCHMARKING.md`), the caller can instead supply usage files
-    archived from a prior run of the same model/effort/backend combination elsewhere.
-    """
+    (#478) — for a vault guaranteed to have none yet by design (every benchmark arm is a freshly
+    seeded vault, `BENCHMARKING.md`), the caller can supply usage files archived from a prior run
+    of the same model/effort/backend combination elsewhere."""
     documents = len(queue_files)
     pages = sum(f.get("page_count") or 0 for f in queue_files)
     raw_tokens = sum(f.get("est_tokens") or 0 for f in queue_files)
@@ -371,28 +264,17 @@ def cost_estimate(vault: Path, queue_files: list[dict], backend: str | None,
 
 def finalize_cost_estimate(vault: Path, backend: str | None, max_runs: int = 3,
                            usage_files: list[Path] | None = None) -> dict:
-    """Pre-flight cost estimate for `watchdog bark` (issue #417, a #403 follow-up).
+    """Pre-flight cost estimate for `watchdog bark` (#417, a #403 follow-up) — prices the staged
+    post-ingest corpus (`result_<sha>.json`/`notes_<sha>.md` in `.watchdog/tmp/`, readable
+    directly since #403) with the same chars/4 heuristic `scan_queue` applies to queued
+    documents. The $/token ratio only draws on usage files written by a *standalone* finalize
+    (every call in `orchestrate.FINALIZE_TASKS`) — an ingest's own finalize tail shares its run's
+    usage file with extraction and would misprice in either direction, so it's excluded. No
+    dollar figure with no standalone-finalize history yet, or on subscription auth
+    (`claude-agent-sdk`, D72) — same treatment `cost_estimate` gives.
 
-    `cost_estimate` above prices an ingest queue's *documents*; finalize's real work is
-    reconciliation + synthesis over the staged post-ingest corpus already sitting in
-    `.watchdog/tmp/` (`result_<sha>.json` + `notes_<sha>.md`) — #403 made synthesis read that
-    staged corpus directly, which is what makes a token estimate here newly possible at all.
-    'Tokens in' is the same chars/4 heuristic `scan_queue` applies to queued documents, just
-    pointed at the staged corpus instead.
-
-    The $/token ratio can't reuse `cost_estimate`'s own loop: a `run()` ingest's usage file is
-    extraction-dominated and would misprice a lone `watchdog bark` in either direction. Only
-    usage-<ts>.json files written by a *standalone* finalize qualify — every one of their calls
-    has to fall in `orchestrate.FINALIZE_TASKS`, which is only true when finalize ran on its own
-    (an ingest's own finalize tail shares its run's single usage file with extraction, so it
-    never qualifies). A vault that's never run a standalone `watchdog bark` gets the doc/token
-    counts with no dollar figure, the same "not enough history yet" treatment `cost_estimate`
-    gives a first-run vault. Subscription auth (`claude-agent-sdk`) never gets a dollar figure
-    either, for the same reason `cost_estimate` withholds one (D72): no real billing to project.
-
-    ``usage_files``, when given, replaces this vault's own history (issue #478) — see
-    `cost_estimate`'s own note on the same parameter.
-    """
+    ``usage_files``, when given, replaces this vault's own history (#478) — see
+    `cost_estimate`'s own note on the same parameter."""
     tmp = vault / ".watchdog" / "tmp"
     results = sorted(tmp.glob("result_*.json"))
     docs = len(results)

--- a/src/watchdog/pipeline/merge.py
+++ b/src/watchdog/pipeline/merge.py
@@ -13,7 +13,7 @@ set-union — no LLM reasoning:
   * document_requests unioned across sections, deduped by normalized `what` text (#365)
 
 The output is shape-identical to a single-document extraction JSON, so it feeds
-straight into `watchdog post-flight` unchanged.
+straight into postflight (`pipeline/postflight.py`) unchanged.
 """
 
 import json
@@ -230,7 +230,7 @@ def run(vault: Path, sha256: str) -> dict:
 
 def main() -> None:
     if len(sys.argv) < 2:
-        sys.exit("Usage: watchdog merge-sections <sha256>")
+        sys.exit("Usage: python -m watchdog.pipeline.merge <sha256>")
     vault = Path(".").resolve()
     if not (vault / ".watchdog").is_dir():
         sys.exit("Error: must be run from inside a Watchdog vault directory")

--- a/src/watchdog/pipeline/orchestrate.py
+++ b/src/watchdog/pipeline/orchestrate.py
@@ -133,86 +133,26 @@ def _record_usage(task: str, *, model: str, backend: str, usage: dict | None,
                   est_input_tokens: int | None = None, est_prompt_tokens: int | None = None,
                   vault: Path | None = None, prompt_hash: str | None = None) -> None:
     """Append one call's usage to the run-scoped `_usage` accumulator, if one is active.
-    Tolerates both Anthropic-style (`input_tokens`/`output_tokens`) and OpenAI-compatible
-    (`prompt_tokens`/`completion_tokens`) usage dicts (D37) — the latter's cache-token fields
-    aren't modelled yet (matches `model_client._openai_cost`'s own v1 simplification).
+    Tolerates both Anthropic-style and OpenAI-compatible usage dicts (D37); takes explicit
+    fields rather than a `model_client.ModelResult` so a batch-collected item (D52, no live
+    call) can feed it too, not just `_call_model` (D64).
 
-    Takes explicit fields rather than a `model_client.ModelResult` so a batch-collected item
-    (D52, no live model call at this point) can feed it too, not just `_call_model` (D64).
-    `filename`/`detail` (e.g. a page range or section label) let a per-run usage file attribute
-    each call to a document, not just a task name (#247). `latency_s` is per-call wall-clock
-    time; batch-collected items have no live call to time, so they keep the 0.0 default (#317).
-    `effort` records the reasoning-effort tier the call was made with (or None if the model/task
-    doesn't take one), and `auth_mode` ("subscription"/"api-key") which billing lane paid for it
-    — both surfaced per call by `watchdog usage` (#319). `end_ts` is the call's completion time
-    (epoch seconds); paired with `latency_s` it gives each call a [start, end] interval, so
-    `watchdog usage` can report wall-clock elapsed per stage — the real time a concurrently-run
-    stage took — alongside the summed per-call time (#317 follow-up).
+    Most fields are copied onto the record only when the caller has them, so backends/tasks
+    that don't produce a given field leave the record shaped exactly as before (D124 `pruned`,
+    D125 `failed`, #354/#547 `reasoning_tokens`, #402 `api_ms`/`num_turns`, #563 `rate_limit`,
+    batch-only `stop_reason`/`batch_meta`). `filename`/`detail` attribute a call to a document,
+    not just a task name (#247); `latency_s`/`end_ts` give each call a wall-clock interval for
+    `watchdog usage` (#317); `effort`/`auth_mode` are surfaced the same way (#319).
 
-    `api_ms`/`num_turns` (#402) are the `claude-agent-sdk` harness's own timing — time actually
-    spent in API requests vs. the call's wall-clock `latency_s`, and the internal request count.
-    They're only added to the record when `usage` carries them, so records for every other
-    backend stay exactly as they were — a large `latency_s` − `api_ms` gap is the signature of
-    the harness throttling/backing off internally rather than the model itself being slow.
+    `est_input_tokens` (#606) is the naive chars/4 estimate for the document text alone;
+    `est_prompt_tokens` (#617) is the same estimate over the WHOLE rendered prompt (schema,
+    instructions, skill, carry-forward, document). Conflating the two undercounts the real
+    prompt overhead (~7,200-9,300 tokens/call on corpus-v1) and misreads the tokenizer ratio —
+    `est_prompt_tokens` is the correct denominator `ingest_setup._model_tokenizer_calibration`
+    needs, and unlike `est_input_tokens` it's set for every task.
 
-    `pruned` (D124): dotted/bracketed paths of any JSON keys the model emitted outside the
-    schema and that `model_client._prune_unknown` removed rather than failing validation over.
-    Only added when non-empty, so systematic schema drift stays visible in `watchdog usage`
-    without cluttering every ordinary record.
-
-    `failed` (D125): True when this record is a call that ultimately raised `ModelError` rather
-    than returning — every attempt still spent real tokens, so it's recorded like any other call
-    (and counted in the same subtotals) rather than vanishing from telemetry.
-
-    `reasoning_tokens` (#354), read from `usage["completion_tokens_details"]["reasoning_tokens"]`
-    when present (OpenAI reasoning models report it directly; Gemini's is reconstructed from its
-    token counts by `model_client._fold_in_hidden_reasoning`, #547), is copied onto the record —
-    the chain-of-thought share
-    of `output_tokens`, which had been arriving on every such call since D108 and thrown
-    away; it's the field that diagnosed the reasoning-starvation failure. Only added when it's
-    non-zero — OpenAI reports a 0 here for its *chat* models, which carries no more information
-    than the key's absence does — so every other backend's record shape is untouched.
-
-    `usage["stop_reason"]`, when present (currently only `batch_extract.collect`'s items carry
-    it), is copied to the record — a batch call's only truncation signal, since it has no
-    continuation/repair path a live call gets. `batch_meta`
-    (`{batch_id, submitted_at, ended_at, collected_at}`, from `_resume_batch`) is copied onto the
-    record when given, so a batch-collected item's usage row carries its own full lifecycle
-    instead of that living only in the transient `batch-pending.json` state that's deleted once
-    collection succeeds.
-
-    `rate_limit` (#563), when given, is the provider's own rate-limit response headers off this
-    call (`model_client._rate_limit_headers` — `limit_tokens`/`remaining_tokens`/`reset_tokens`),
-    copied onto the record so a run's usage file carries the provider's ground truth for what it
-    counted against the caller's per-minute budget alongside the tokens we ourselves logged.
-
-    `est_input_tokens` (#606 Part B), when given, is this call's own naive chars/4 estimate
-    (`section.est_tokens_from_pages`/`section.est_tokens`) for the DOCUMENT TEXT it sent —
-    mirroring how the *run-level* `totals.est_input_tokens` is already added in
-    `_write_usage_file`/`_end_usage_run`, but per call rather than summed once across a whole run.
-    Only set on `extract`/`extract-section` calls, the only tasks sectioning currently cares
-    about; every other task's record simply lacks the key, as before.
-
-    `est_prompt_tokens` (#617) is the same chars/4 estimate over the ENTIRE RENDERED PROMPT —
-    schema, extraction instructions, record skill, carry-forward entities, harvested candidates
-    and the document text alike. The distinction is the whole point, and getting it wrong is what
-    #617 was opened about: the provider's reported `input_tokens` counts the entire prompt, so
-    comparing it against document-text-only `est_input_tokens` measures
-    `tokenizer_ratio x (1 + prompt_overhead / document_tokens)` rather than the tokenizer ratio —
-    a bias that isn't even constant, since it shrinks as sections get bigger. Measured against
-    corpus-v1, that scaffolding is 7,200-9,300 real tokens per call, enough to read a true 1.09
-    ratio as 1.41. `est_prompt_tokens` is the like-for-like denominator that makes
-    `ingest_setup._model_tokenizer_calibration` a real tokenizer measurement; unlike
-    `est_input_tokens` it is set for EVERY task, since `_call_model` can compute it from the
-    prompt it already has without the caller passing anything.
-
-    `vault`/`prompt_hash` (#611) feed the global telemetry store (`telemetry_db.record_call`) in
-    addition to this run's own `_usage`/JSON file — `vault` attributes the row (the store is
-    global, not per-vault, D50/#611), `prompt_hash` is a sha256 of the actual prompt text sent,
-    computed by `_call_model` (which has it in scope) and None for the batch-collection call site
-    (no live prompt at collection time). The telemetry write is best-effort: any failure is
-    caught and logged as a WARN via `_log`, never allowed to fail or slow down the ingest it's
-    observing."""
+    `vault`/`prompt_hash` (D50/#611) feed the global telemetry store in addition to this run's
+    own usage file; that write is best-effort and never allowed to fail the ingest it observes."""
     if _usage is None:
         return
     u = usage or {}
@@ -288,32 +228,18 @@ async def _call_model(*, task, prompt, schema, model=None, backend=None,
                       ) -> "model_client.ModelResult":
     """Thin wrapper around `model_client.acomplete_json` that also records this call's usage
     (A2) — every reasoning call in the orchestrator goes through here instead of the client
-    directly, so telemetry can't silently miss a call site. `filename`/`detail` are passed
-    through to `_record_usage` unchanged (#247). `vault` (D124) is used to log a WARN line to
-    `ingest.log` when the call's JSON carried unexpected keys that were pruned rather than
-    failing validation, and (#611) to attribute this call's row in the global telemetry store —
-    pass it whenever a vault is in scope. `est_input_tokens` (#606 Part
-    B) is likewise passed straight through to `_record_usage`, when the caller has one — see its
-    own docstring.
+    directly, so telemetry can't silently miss a call site. `vault` both logs a WARN to
+    `ingest.log` when JSON keys were pruned (D124) and attributes the call in the global
+    telemetry store (#611) — pass it whenever a vault is in scope.
 
-    A `ModelError` that carries usage/cost (D125 — the JSON-validation-failure and truncation
-    paths in `acomplete_json`, the only ones where an attempt actually reached the model) is
-    still recorded, flagged `failed=True`, before re-raising unchanged — every attempt spent
-    real tokens even though none produced a usable result, and that spend used to vanish.
+    A `ModelError` that still carries usage/cost (D125 — validation-failure/truncation paths
+    that reached the model) is recorded with `failed=True` before re-raising, since that attempt
+    spent real tokens even though it produced nothing usable.
 
-    `prompt_hash` (#611) is a sha256 of `prompt` itself, computed once here rather than in
-    `_record_usage` since this is the one place the actual rendered prompt text is in scope.
-    `prompt` is normally a string, but a caller may instead pass a list of Anthropic content
-    blocks (A1, cache_control) — `json.dumps` gives a stable, hashable text form for that shape
-    too, without needing to special-case it.
-
-    `est_prompt_tokens` (#617) rides on that same observation: the rendered prompt is in scope
-    exactly here, so the whole-prompt chars/4 estimate is computed once alongside the hash rather
-    than threaded through every call site the way `est_input_tokens` is. That is what makes it
-    universal — every task gets it for free, including the ones that never pass an
-    `est_input_tokens` — and it is the like-for-like denominator
-    `ingest_setup._model_tokenizer_calibration` needs; see `_record_usage`'s docstring for why
-    the document-only estimate was the wrong one to divide by."""
+    `prompt_hash` and `est_prompt_tokens` are computed once here, the one place the actual
+    rendered prompt (string, or a list of Anthropic content blocks, A1) is in scope, rather than
+    threaded through every call site — see `_record_usage`'s docstring for why `est_prompt_tokens`
+    (#617) is the denominator that matters, not `est_input_tokens` (#606)."""
     prompt_text = prompt if isinstance(prompt, str) else json.dumps(prompt, sort_keys=True)
     prompt_hash = hashlib.sha256(prompt_text.encode("utf-8")).hexdigest()
     est_prompt_tokens = section.est_tokens(prompt_text)
@@ -1232,27 +1158,18 @@ async def _extract_sectioned(vault, sha, pf, skill_text, plan, model, skill_labe
                              effort=None, backend=None, brief=None, verify_pass=False):
     """Sequential per-section extraction with carry-forward, then deterministic merge.
 
-    Each section's result is checkpointed to disk as it completes (#498) and replayed on a retry
-    that lands on the same plan, so a rate limit, Ctrl-C, or a failed post-flight doesn't discard
-    already-paid-for sections. Checkpoints are cleared once post-flight finally succeeds.
+    Each section's result is checkpointed to disk as it completes and replayed on a retry that
+    lands on the same plan, so a rate limit, Ctrl-C, or a failed post-flight doesn't discard
+    already-paid-for sections (#498); checkpoints clear once post-flight finally succeeds.
+    One repair attempt re-calls just section 1 if post-flight rejects on
+    morgue_entity_id/morgue_document_type, the fields only it is ever asked to supply — a later
+    section's output could never have fixed these anyway (#505).
 
-    One repair attempt if post-flight rejects on morgue_entity_id/morgue_document_type — the
-    fields only section 1 is ever asked to supply. Mirrors _simple_extract's repair loop, but
-    re-calls just section 1 rather than re-running the whole document, since a later section's
-    output could never have fixed these anyway (#505).
-
-    A truncated extract-section call gets one re-split retry (#540): the whole-document fallback
-    below `_extract_document`'s whole-doc branch never reached this already-sectioned path, so a
-    truncation here used to fail the document outright with no recovery at all. `parts`/
-    `entities_seen`/`carry` are rebuilt with `c.get("parts") or [c["parsed"]]` so a checkpoint
-    written before #540 (single `parsed`, no `parts`) still replays unchanged.
-
-    A *starved* extract-section call (#558) — reasoning ate the whole output budget, an input-size
-    problem the re-split above can't fix — gets a different one-shot retry instead: the same
-    section, re-run one effort level down via `_lower_effort`. Before #558 this shared the
-    re-split's bound: `ModelError.truncated` alone couldn't tell the two failures apart, so a
-    starved section was "recovered" by re-splitting into halves that starved again, and the
-    document failed outright exactly as it would with no recovery at all."""
+    Two distinct failures get two distinct one-shot retries, since neither is fixable by the
+    other's fix: a truncated call (input too large) gets a re-split into two sections (#540); a
+    *starved* call (reasoning alone ate the output budget — an input-size problem re-splitting
+    can't touch) gets the same section re-run one effort level down via `_lower_effort` instead
+    (#558)."""
     sections = plan["sections"]
     checkpoints = _load_section_checkpoints(vault, sha, sections)
     # Keyed by planned-section index rather than a flat list (#540): a re-split section contributes
@@ -2390,32 +2307,21 @@ def _batch_exact_fold(vault: Path, shas: list[str]) -> None:
     """Fold exact-name entity duplicates across a batch of staged extractions, before any of
     them commits to the vault (#403 phase 2).
 
-    Documents extract in parallel from a pre-flight snapshot taken at launch, so two documents
-    referencing the same real-world entity can coin different ids (e.g. 'ernst-and-young-inc'
-    vs 'ernst-young-inc'). This used to be reconciled by `write_vault._reconcile_entity_ids`
-    running per-document inside the registry lock, against a fresh read of the live registry —
-    the one place that saw entities written by concurrent extraction tasks earlier in the batch.
-    Now that commit is a separate, serial pass (phase 1), the same cross-document visibility is
-    available up front: walk the given `shas` in order (the caller passes them pre-sorted, see
-    D126) over a throwaway in-memory registry copy, reconciling each document's entities against
-    it with the same `_reconcile_entity_ids` and then folding that document's (already-
-    reconciled) entities into the copy with the same `_new_entity`/`_merge_entity` used at real
-    commit time — so later documents in the batch match against earlier ones exactly as they did
-    under the old per-document call. The real registry on disk is never touched here; the commit
-    pass still does the actual writes. Mutates each staged `.watchdog/extracted/<sha>.json` in
-    place (id remaps, alias appends, role-target remaps) so the commit pass that follows replays
-    already-folded entities.
-
-    `_add_reverse_role` is deliberately not simulated — it only appends roles onto entities
-    already in the registry copy and never mints a new id, so it cannot affect name/type/alias
-    matching for any later document.
+    Documents extract in parallel from a pre-flight snapshot, so two documents referencing the
+    same real-world entity can coin different ids (e.g. 'ernst-and-young-inc' vs
+    'ernst-young-inc'). Since commit is now a separate, serial pass (phase 1), this walks `shas`
+    in pre-sorted order (D126) over a throwaway in-memory registry copy, reconciling and folding
+    each document's entities with the same `_reconcile_entity_ids`/`_new_entity`/`_merge_entity`
+    real commit uses — so later documents match against earlier ones exactly as before, but the
+    real registry on disk is never touched here. Mutates each staged
+    `.watchdog/extracted/<sha>.json` in place (id remaps, alias appends, role-target remaps) so
+    the commit pass that follows replays already-folded entities. `_add_reverse_role` is
+    deliberately not simulated — it never mints a new id, so it can't affect matching.
 
     Also rewrites `morgue_entity_id` and every `document.key_facts[].entities` tag through the
-    same remap (#513) — both name an entity id by the same convention as `entities[].id` but sit
-    outside `_reconcile_entity_ids`'s own view, so without this they'd go stale whenever the
-    entity a document is filed under (or a fact is tagged against) gets folded into a different
-    canonical id later in the same batch.
-    """
+    same remap (#513) — both sit outside `_reconcile_entity_ids`'s own view, so without this
+    they'd go stale whenever the entity they name gets folded into a different id later in the
+    batch."""
     from watchdog.pipeline.write_vault import _merge_entity, _new_entity, _reconcile_entity_ids
 
     # Freshly parsed from disk, so this is already an in-memory copy independent of the real
@@ -2661,46 +2567,22 @@ async def finalize(vault: Path, *, post_model: str = "haiku", brief: str | None 
     post-ingest over the current on-disk state: file contradictions, synthesize multi-mention
     entities, reconcile the timeline, and write the briefing/hot.md/log.
 
-    Called at the tail of every ingest run (with this run's results in memory) and
-    standalone by ``watchdog bark`` (reading persisted ``result_*.json``) to complete a
-    post-ingest an earlier rate limit or interrupt left unfinished. On a clean pass the consumed
-    inputs (fragments, results, scratchpads) are cleared; if any step failed they are left in
-    place so a later finalize can retry.
+    One code path covers three entry points: the tail of every ingest run, standalone
+    ``watchdog bark`` (reading persisted ``result_*.json``), and resuming a post-ingest an
+    earlier rate limit/interrupt left unfinished. Order (#403 phase 3): exact-name fold →
+    pre-commit reconciliation → the commit pass (#403 phase 1, sorted sha order) → post-ingest.
+    On a clean pass the consumed inputs are cleared; a failed step leaves them in place so a
+    later finalize can retry. If reconciliation itself fails, nothing in this batch commits —
+    every staged artifact is left exactly as it was, still pending.
 
-    #403 phase 3 order: exact-name fold → pre-commit reconciliation (entity-duplicate resolution,
-    over the staged batch — ``_reconcile_pre_commit``) → the commit pass (#403 phase 1,
-    ``_commit_pending``, which replays ``write_vault.run`` over every
-    ``.watchdog/extracted/<sha>.json`` not yet in the registry, in sorted sha order) → post-ingest
-    (contradictions, synthesis, timeline, briefing). This is what covers this function's three
-    entry paths (ingest's tail, standalone ``watchdog bark``, and a resumed run after a
-    rate-limit stop) with one code path.
-
-    If reconciliation itself fails (rate limit / model error), nothing in this batch commits —
-    every staged artifact is left exactly as it was, still pending, so a later ``watchdog
-    finalize`` retries the whole sequence rather than committing half-reconciled state.
-
-    `force_shas` (#424) are shas that were force-re-extracted and already have a
-    `registry/documents.json` entry from an earlier ingest — `_pending_commits` would otherwise
-    treat them as already committed and silently drop them from this batch. Passing them here
-    puts them back through the commit pass (`_commit_extracted` overwrites their existing document
-    note and registry entry in place, the same replace-not-append path a repair retry of an
-    already-committed document already relied on) and the reconciliation bundle, so their touched
-    entities are re-synthesized along with the rest of this batch.
-
-    `skip_briefing` (#410) skips only the briefing model call — synthesis and the timeline still
-    run. Not an error, so it never sets `briefing_error`/leaves inputs pending the way a genuine
-    briefing failure does.
-
-    `finalizer_overrides` (#433) routes individual post-ingest stages to a different model than
-    `post_model`/`post_backend` — see `_reconcile_pre_commit` and `_post_ingest` for the keys it
-    accepts and how each falls back when absent.
-
-    `benchmark_arm_id` (#611) tags this run's telemetry rows in the global store when
-    `run_benchmark.py` is the caller (via `cmd_finalize`); None for an ordinary standalone
-    `watchdog bark`. Ignored when this call is nested inside `run()` (`standalone_usage` False
-    below) — `run()`'s own `_begin_usage_run` call already set the tag for the whole run,
-    extraction and finalize tail alike.
-    """
+    `force_shas` (#424) are already-committed shas being force-re-extracted, which
+    `_pending_commits` would otherwise silently drop as "already done" — passing them here puts
+    them back through both the commit pass (overwriting in place) and reconciliation.
+    `skip_briefing` (#410) skips only the briefing call, not synthesis/timeline, and isn't
+    treated as an error. `finalizer_overrides` (#433) routes individual post-ingest stages to a
+    model other than `post_model`/`post_backend`. `benchmark_arm_id` (#611) tags this run's
+    telemetry when `run_benchmark.py` is the caller; ignored when nested inside `run()`, which
+    already set the tag for the whole run."""
     global _usage
     standalone_usage = _usage is None   # not nested inside `run` — this call owns the usage file
     if standalone_usage:
@@ -2760,51 +2642,26 @@ async def run(vault: Path, *, concurrency: int = DEFAULT_CONCURRENCY,
               benchmark_arm_id: str | None = None) -> dict:
     """Extract every queued document (bounded by `concurrency`), then post-ingest.
 
-    `extract_model` drives extraction (whole-doc + section, and the sectioned-doc digest); `post_model` drives
-    synthesis/timeline/briefing; `classify_model` the cheap document classifier,
-    which sees the first `classify_pages` pages of each document. `pinned_skill`
-    (a path to a skill file) skips classification and uses that skill for every document.
-    `extract_effort`/`post_effort`/`classify_effort` (`low`/`medium`/`high`) tune reasoning depth
-    for the extraction, post-ingest, and classify stages respectively — classify gained this knob
-    (D221) since some models it can be routed to (e.g. the benchmark-recommended
-    openai:gpt-5.6-luna) actually support it; D36's original "no knob" was true only of Haiku,
-    the classifier's default, which rejects the parameter outright, and still applies to it —
-    `classify_effort` simply no-ops there like the others do on an effortless model.
-    `*_backend` selects a non-default backend per stage (None → route by auth mode); a
-    non-Claude backend's `*_model` is that provider's raw model id (D37).
-    `wait` only changes the rate-limit notice text — the caller (`cmd_ingest`) owns the
-    actual sleep-and-resume loop; this function always stops cleanly on a rate limit.
-    `skip_finalize` (#384) stops the run after extraction — post-ingest (reconciliation,
-    synthesis, timeline, briefing) is never called, and none of its inputs
-    (`result_*.json`, `notes_*.md`) are cleared. That leaves
-    `has_pending_finalization(vault)` True so a later `watchdog bark` — possibly with a
-    different `--finalizer-model`, and possibly against a copy of the vault — can pick up
-    exactly where extraction left off.
-    `force` (#424) re-extracts every queued document even when a cached artifact or a committed
-    vault note already exists for its sha — `cmd_ingest` always pairs this with
-    `skip_finalize=True` so it can gate the overwrite of already-committed documents (via
-    `finalize`'s own `force_shas`) before anything is recommitted.
-    `skip_briefing` (#410) passes straight through to `finalize` — post-ingest still runs
-    reconciliation, synthesis, and the timeline, it just skips the briefing model call.
-    `finalizer_overrides` (#433) passes straight through to `finalize` — see its docstring for
-    the per-stage model/backend keys it accepts.
-    `resume_hint` (#441, D138) is the command a "re-run to resume/collect later" notice names —
-    `cmd_ingest` passes `watchdog dig` for a `dig` run and bare `watchdog` for the guided walk or
-    the deprecated `ingest`, so the extraction-side notices point back at the right entry point.
-    `verify` (#535) adds a second, cheap read of each document (or section) that lists the
-    material facts the extraction missed, merged deterministically by `pipeline.verify`. Off by
-    default and unsupported on `claude-batch`, which is asynchronous by construction — a
-    verification call needs the extraction it is verifying to already exist, and a batch's
-    results arrive in a later process, hours later, with no cached prefix left to read.
-    `extract_token_budget` (#563 admission control, D185) pins the tokens-per-minute ceiling a new
-    document's dispatch is held back against; `None` (the default) auto-discovers it from the
-    most recent call's `rate_limit.limit_tokens` instead — real for every backend except
-    `claude-agent-sdk` (Claude subscription auth), which never reports it, making this the only
-    lever on that path. Not consulted on a batch backend, which has no per-document dispatch loop
-    to gate.
-    `benchmark_arm_id` (#611) tags this run's telemetry rows in the global store — set by
-    `run_benchmark.py` via `cmd_extract`/`cmd_ingest`, None for an ordinary ingest.
-    """
+    `extract_model`/`post_model`/`classify_model` drive extraction, synthesis/timeline/briefing,
+    and the cheap classifier (first `classify_pages` pages) respectively; `pinned_skill` skips
+    classification entirely. `extract_effort`/`post_effort`/`classify_effort` tune reasoning
+    depth per stage — `classify_effort` (D221) no-ops on Haiku (the classifier's default, which
+    rejects the parameter, per D36) but applies on a model that supports it. `*_backend` selects
+    a non-default backend per stage; a non-Claude backend's `*_model` is that provider's raw
+    model id (D37).
+
+    `skip_finalize` (#384) stops after extraction without clearing post-ingest inputs, leaving
+    `has_pending_finalization(vault)` True so a later `watchdog bark` can pick up where it left
+    off. `force` (#424) re-extracts every queued document even if cached/committed — always
+    paired by `cmd_ingest` with `skip_finalize=True` so `finalize`'s own `force_shas` gates the
+    overwrite. `skip_briefing` (#410) and `finalizer_overrides` (#433) pass straight through to
+    `finalize` (see its docstring). `resume_hint` (#441, D138) is the command a resume notice
+    names. `verify` (#535) adds a second cheap pass listing missed facts; unsupported on
+    `claude-batch`, whose results arrive in a later process with no cached prefix to verify
+    against. `extract_token_budget` (#563, D185) pins the tokens/minute ceiling new-document
+    dispatch is held against; `None` auto-discovers it from the last call's rate-limit headers,
+    the only lever available on `claude-agent-sdk` (which never reports one). `benchmark_arm_id`
+    (#611) tags this run's telemetry when `run_benchmark.py` is the caller."""
     queue_dir = vault / ".watchdog" / "queue"
     shas = [f.stem for f in sorted(queue_dir.glob("*.json"))] if queue_dir.exists() else []
     config_snapshot = {

--- a/src/watchdog/pipeline/postflight.py
+++ b/src/watchdog/pipeline/postflight.py
@@ -511,7 +511,7 @@ def run(vault: Path, extraction_path: Path, warn=None) -> dict:
 
 def main() -> None:
     import argparse
-    parser = argparse.ArgumentParser(description="Watchdog post-flight processor")
+    parser = argparse.ArgumentParser(description="Watchdog postflight processor")
     parser.add_argument("--extraction", required=True, help="Path to extraction JSON")
     args = parser.parse_args()
 

--- a/src/watchdog/pipeline/preflight.py
+++ b/src/watchdog/pipeline/preflight.py
@@ -92,7 +92,7 @@ def run(vault: Path, sha256: str) -> dict:
 
 def main() -> None:
     if len(sys.argv) < 2:
-        sys.exit("Usage: watchdog pre-flight <sha256>")
+        sys.exit("Usage: python -m watchdog.pipeline.preflight <sha256>")
 
     vault = Path(".").resolve()
     if not (vault / ".watchdog").is_dir():

--- a/src/watchdog/pipeline/prompts.py
+++ b/src/watchdog/pipeline/prompts.py
@@ -91,30 +91,13 @@ def _document_block(text: str, cache_document: bool, ttl: str) -> dict:
 def build_verify_prompt(base: list[dict], *, key_facts: list[dict],
                         entities: list[dict]) -> list[dict]:
     """The verification call's prompt: the extraction call's own blocks, unchanged, plus one
-    appended block (#535).
-
-    Taking `base` rather than rebuilding from the same inputs is the mechanism, not a
-    convenience — a shared prompt prefix only pays off if it is byte-identical, and the surest
-    way to guarantee that is to send the identical objects. It also means neither builder can
-    drift out of prefix-compatibility with this one: whatever the extractor was shown, the
-    verifier is shown too, including the extraction instructions themselves (the verifier needs
-    to know what "material fact" was defined to mean before it can say what is missing).
-
-    What that byte-identical prefix is worth depends on the backend. On `claude-api` it is the
-    whole cost case: `cache_control` is honoured on the wire, so the verifier re-reads the
-    document at the 0.1x rate. On OpenAI it buys the run-stable head of the prompt
-    (instructions + brief + skill, routed by the same `prompt_cache_key` as every other call
-    sharing that skill — `model_client._prompt_cache_key`) but never the document, which is the
-    bulk of it: each call's own structured-output schema is serialized as a prefix to the system
-    message, so extraction's prefix and this one diverge before either reaches the document text
-    (#562, D181).
-
-    `key_facts` is what the extractor produced; `entities` (id + name only) bounds the ids a
-    candidate fact may tag, so the verifier picks from the extraction's own graph rather than
-    coining ids that resolve to nothing. Only `basis`/`page`/`date`/`entities`/`fact`/`quote`
-    are carried through — the facts are sent as-is, since the verifier has to compare against
-    exactly what was recorded.
-    """
+    appended block (D172). Taking `base` rather than rebuilding from the same inputs guarantees
+    the shared prefix is byte-identical — the whole cost case on `claude-api`, where
+    `cache_control` lets the verifier re-read the document at the 0.1x rate; on OpenAI it only
+    buys the run-stable instructions/brief/skill head, never the document, since each call's own
+    structured-output schema diverges the prefix before the document text (D181). `entities` (id
+    + name only) bounds the ids a candidate fact may tag, so the verifier picks from the
+    extraction's own graph rather than coining ids that resolve to nothing."""
     known_ids = "\n".join(f"- {e.get('id')} | {e.get('name')}" for e in entities if e.get("id"))
     return base + [{"type": "text", "text": (
         f"\n{_text('verify')}\n\n"
@@ -159,23 +142,15 @@ def build_extract_prompt(*, pages_text: str, skill_text: str, sidecar: str | Non
                          processing: dict | None = None,
                          candidates: str | None = None,
                          cache_document: bool = False, model: str | None = None) -> list[dict]:
-    # Document identity (sha256/filename/original_path/page_count) and provenance
-    # (source/obtained) are stamped onto the result by Python — see
-    # orchestrate._stamp_document — so they are deliberately not asked of the model here.
+    # Document identity/provenance are stamped onto the result by Python (orchestrate.
+    # _stamp_document), not asked of the model. No vault state enters this prompt (D118):
+    # extraction is a pure function of the document, its skill, the brief, and its sidecar —
+    # entity resolution and contradiction detection moved to the finalizer's reconciliation pass.
     #
-    # No vault state enters this prompt (#381/D118): extraction is a pure function of the
-    # document, its skill, the brief, and its sidecar. Entity resolution and contradiction
-    # detection — the two jobs the old EXISTING_ENTITIES / EXISTING_TIMELINE blocks fed — moved
-    # to the finalizer's reconciliation pass, which is the only stage that sees all the claims
-    # at once. That also removes the prompt's single biggest and fastest-growing volatile block:
-    # every page of every document used to carry the vault's accumulated entity context.
-    #
-    # Returned as content blocks, not one string (A1): block 1 (instructions + brief) is
-    # constant for the whole run; block 2 (the domain skill) is constant per document type and
-    # carries the cache breakpoint, so blocks 1+2 together are the cacheable prefix — every
-    # extraction call sharing a skill within a run re-pays only the 0.1x cache-read rate for it.
-    # Block 3 is per-document volatile data and is never cached. `cache_ttl` is "1h" for batch
-    # submissions (#214) — see _cache_block.
+    # Returned as content blocks (block 1 instructions+brief, block 2 the skill carrying the
+    # cache breakpoint, block 3 per-document volatile data never cached) so calls sharing a skill
+    # within a run re-pay only the 0.1x cache-read rate for blocks 1+2. `cache_ttl` is "1h" for
+    # batch submissions (#214) — see `_cache_block`.
     stable = [_text("extract_instructions")]
     if _wants_scaffold(model):
         stable.append(f"\n{_text('extract_scaffold')}")
@@ -206,16 +181,11 @@ def build_section_prompt(*, pages_text: str, skill_text: str, carry_forward: str
                          processing: dict | None = None,
                          candidates: str | None = None, cache_ttl: str = "1h",
                          cache_document: bool = False, model: str | None = None) -> list[dict]:
-    # Same cache-block split as build_extract_prompt (A1): instructions + brief + skill lead,
-    # since those are the only parts stable across every section of one run — the section
-    # label/metadata-mode note, carry-forward, and section text change on every call, so they
-    # move after the skill block instead of leading (as in the old single-string layout) to
-    # keep the cacheable prefix at the front of the content array. `cache_ttl` defaults to "1h",
-    # unlike build_extract_prompt's "5m" default: a sectioned document's calls were originally
-    # always back-to-back within a few minutes, so 5m was plenty, but per-section checkpointing
-    # (#498) means a retry can now land on this document's next section anywhere from seconds to
-    # well past an hour later (a rate-limit backoff, a Ctrl-C resumed the next day) — the same
-    # reasoning that gave the batch-submission path (#214) its own "1h" override applies here too.
+    # Same cache-block split as build_extract_prompt: instructions + brief + skill lead as the
+    # stable prefix; section label, carry-forward, and section text change every call, so they
+    # come after. `cache_ttl` defaults to "1h" here (not "5m") because per-section checkpointing
+    # (#498) means a retry can land on the next section anywhere from seconds to well past an
+    # hour later.
     stable = [_text("extract_instructions")]
     if _wants_scaffold(model):
         stable.append(f"\n{_text('extract_scaffold')}")

--- a/src/watchdog/pipeline/reconcile.py
+++ b/src/watchdog/pipeline/reconcile.py
@@ -1,46 +1,17 @@
 """
-Post-ingest reconciliation — entity resolution + contradiction detection (#381/D118).
-
-These are the two jobs extraction is structurally unable to do, and for the same reason: both
-need claims **side by side**, and extraction reads one document at a time. Extraction used to
-attempt both against a snapshot of the entity registry taken when that document's own extraction
-began — which meant a document could only ever be compared against the documents that happened to
-land ahead of it, and documents in the same concurrency wave could not see each other at all.
-
-The finalizer is the only stage that sees the whole entity set, so both jobs live here. It runs
-once per ingest, over the staged batch's extraction artifacts unioned with the registry, which
-makes it concurrency-immune, order-immune, and near-constant in cost (one call, like the briefing
-— it does not scale with page count).
+Post-ingest reconciliation — entity resolution + contradiction detection, run once per ingest
+over the whole entity set rather than inside extraction, since both jobs need claims **side by
+side** and extraction only ever sees one document at a time (D118 has the full rationale,
+including the blocking algorithm that keeps entity-pair comparison off a quadratic path).
 
 **Merges run before commit, contradictions after (#403 phase 3).** `build_bundle` and
-`apply_merges` read `.watchdog/extracted/<sha>.json` — the staged, not-yet-committed batch — so a
-confirmed duplicate between two documents landing in the same ingest is folded in the staged JSON
-itself; write_vault then commits the two as one entity and no post-commit note surgery (redirect
-stub, backup, "Merged from" provenance) is ever produced for a same-batch duplicate. A duplicate
-against an *already-committed* entity still gets that surgery (`merge_entities.run`), since that
-entity's note genuinely exists. Contradictions need the committed notes/documents to validate
-against (`contradiction.run` checks both doc slugs exist in `registry/documents.json`), so
-`apply_contradictions` runs after the commit pass, using the merge remap `apply_merges` returned.
-
-**The split with the deterministic writer.** `write_vault._reconcile_entity_ids` already folds
-*exact* normalized-name duplicates together, in-lock, at write time — that pass is untouched and
-still does the bulk of the work. What it deliberately will not do is collapse names that differ by
-a token ("Laurentian University" / "Laurentian University of Sudbury"), because auto-merging those
-carries real false-positive risk. Those are exactly the judgement calls, and they are what this
-module sends to the model.
-
-**Bundle size.** Naively, entity resolution is every entity against every other entity — one call
-that grows quadratically and eventually will not fit a context window. So Python blocks the field
-first (`candidate_pairs`): only pairs sharing a canonical type, with one name a token-subset of the
-other, identical in tokens (a word-order or stopword variant), or a high token overlap, and with at
-least one side touched by *this* run, are ever sent. The model confirms or rejects each pair by
-index. The contradiction half is bounded by the same recurrence gate synthesis uses (D26): an
-entity needs claims in two documents before two of its claims can disagree.
-
-I1 holds throughout: the model only ever answers *which* — which pairs are the same thing, which
-claims conflict. Every write is done by deterministic code that already exists — `merge_entities.
-run` for a merge, `contradiction.run` for a callout — so a model that names a nonexistent document
-or a stale entity id produces a skipped item and a warning, never a bad note.
+`apply_merges` read the staged, not-yet-committed batch (`.watchdog/extracted/<sha>.json`), so a
+duplicate between two documents landing in the same ingest is folded before `write_vault` ever
+commits them — no post-commit note surgery (redirect stub, backup, "Merged from" provenance) is
+needed for a same-batch duplicate. A duplicate against an *already-committed* entity still gets
+that surgery (`merge_entities.run`), since that entity's note already exists. Contradictions need
+the committed notes/documents to validate against, so `apply_contradictions` runs after the commit
+pass, using the merge remap `apply_merges` returned.
 """
 
 import json
@@ -216,26 +187,19 @@ def _staged_artifacts(vault: Path, shas: list[str]) -> list[tuple[str, dict]]:
 def build_bundle(vault: Path, shas: list[str]) -> dict:
     """Assemble the one reconciliation call's input: candidate duplicate pairs, and the claim
     ledger of every entity that could hold a contradiction — reconstructed from the staged batch
-    (`.watchdog/extracted/<sha>.json`, post exact-fold) unioned with the registry, rather than
-    from the committed vault (#403 phase 3). This runs *before* the commit pass, so a confirmed
-    merge between two of this batch's own documents can be applied as a staged id rewrite instead
-    of post-commit note surgery — see the module docstring.
+    unioned with the registry, rather than from the committed vault, so a same-batch merge can be
+    applied as a staged id rewrite instead of post-commit note surgery (#403 phase 3; see the
+    module docstring).
 
-    A **working entity map** — a deep copy of the registry, folded with each staged artifact's
-    entities via the same `write_vault._new_entity`/`_merge_entity` the real commit will use
-    (mirroring `orchestrate._batch_exact_fold`'s own pattern) — stands in for "the registry as it
-    will look once this batch commits", without writing anything. `touched` is every entity id
-    those staged artifacts contribute (replaces the old fragment-queue-based `_touched_ids`, which
-    only existed post-commit).
+    Builds a **working entity map** — a deep copy of the registry folded with each staged
+    artifact's entities, via the same `write_vault._new_entity`/`_merge_entity` the real commit
+    uses — standing in for "the registry once this batch commits," without writing anything.
 
-    The claim ledger is normally the entity note's ``## Analysis`` section — `write_vault` appends
-    a source-attributed block to it per document (`*<date>, via [[documents/<slug>|<title>]]:*`,
-    then that document's claims with page links). Pre-commit, that block does not exist yet for
-    this batch's own claims, so it is reconstructed here: the existing note's ``## Analysis`` (if
-    the entity was already committed before this batch) plus one rendered block per staged
-    document that touched it, in the same shape. This claims text feeds the model question only —
-    it is never written to disk — so a faithful-enough reconstruction is fine even though it will
-    not be byte-identical to what `write_vault` eventually renders.
+    The **claim ledger** is normally an entity note's ``## Analysis`` section, which `write_vault`
+    appends to per document at commit time. Pre-commit that block doesn't exist yet for this
+    batch's own claims, so it's reconstructed here from the existing note (if any) plus one
+    rendered block per staged document that touched the entity — close enough to feed the model,
+    even though it won't be byte-identical to what `write_vault` eventually writes.
     """
     entities_path = vault / ".watchdog" / "registry" / "entities.json"
     original_reg = _read_json_or(entities_path, {})
@@ -313,25 +277,18 @@ def build_bundle(vault: Path, shas: list[str]) -> dict:
 
 
 def _rewrite_staged_ids(vault: Path, shas: list[str], merge_id: str, keep_id: str) -> str | None:
-    """Rewrite `merge_id` -> `keep_id` across every staged artifact in the batch: every entity
-    ``id`` and every role ``target_id``, so any of this batch's own claims for the loser land on
-    the survivor once the commit pass replays `write_vault.run` over the (now-rewritten) staged
-    JSON — rather than resurrecting the merged-away id. Preserves the folded name as an alias on
-    the surviving staged entity, mirroring `write_vault._reconcile_entity_ids`.
+    """Rewrite `merge_id` -> `keep_id` across every staged artifact in the batch — entity `id`,
+    role `target_id`, `morgue_entity_id`, and `document.key_facts[].entities` tags (#513) — so the
+    loser's claims land on the survivor once the commit pass replays `write_vault.run`, rather
+    than resurrecting the merged-away id. Preserves the folded name as an alias, mirroring
+    `write_vault._reconcile_entity_ids`.
 
     Called for both merge-taxonomy branches (#403 phase 3): it *is* the merge when the loser was
-    never committed (nothing else would ever fold it), and it is a supplementary step alongside
-    `merge_entities.run` when the loser was already committed (that surgery only touches the
-    registry/notes on disk, not this batch's still-staged JSON).
+    never committed, and a supplementary step alongside `merge_entities.run` when it was already
+    committed (that surgery only touches disk, not this batch's still-staged JSON).
 
-    Also rewrites `morgue_entity_id` and every `document.key_facts[].entities` tag that names
-    `merge_id` (#513) — both name an entity id by the same convention as `entities[].id` /
-    `role.target_id` but sit outside this remap's original scope, so without this a document
-    filed under (or a fact tagged against) the merged-away id would go stale once the survivor
-    takes over.
-
-    Returns the merged-away entity's display name as it appeared in the batch (for the caller's
-    reporting), or None if the batch never staged it at all.
+    Returns the merged-away entity's display name (for the caller's reporting), or None if the
+    batch never staged it.
     """
     extracted_dir = vault / ".watchdog" / "extracted"
     merge_name = None
@@ -378,30 +335,25 @@ def apply_merges(vault: Path, shas: list[str], parsed: dict, bundle: dict, warn)
     """Apply every confirmed merge from a pre-commit reconciliation call (#403 phase 3), before
     any of this batch has been written to the vault.
 
-    Each confirmed merge names `keep_id` and (implicitly, the pair's other id) `merge_id`. At this
-    point each id is either **committed** (a key in `registry/entities.json` right now — including
-    a staged entity phase 2's exact fold already remapped onto an existing registry id) or
-    **batch-only** (only ever seen in this batch's staged JSON so far):
+    Each confirmed merge names `keep_id` and `merge_id`. At this point each id is either
+    **committed** (already a key in `registry/entities.json`) or **batch-only** (seen only in this
+    batch's staged JSON so far):
 
-    1. **Normalize direction:** if exactly one of the two is committed, force it to `keep` —
-       swapping the model's choice if needed — since the already-written entity always survives
-       and the new one folds onto it (its name stays primary; the folded name becomes an alias).
-       If both or neither are committed, honour the model's `keep_id`.
-    2. **Loser is batch-only:** a plain staged id rewrite (`_rewrite_staged_ids`) — no note, no
-       registry entry, so there is nothing for `merge_entities.run` to operate on. At commit,
-       `write_vault` merges the two staged entities into one naturally. This is the common case (a
-       duplicate caught within one ingest).
-    3. **Loser is committed** (so both are): the full `merge_entities.run` surgery, exactly as
-       before phase 3 — stub + backup + provenance ARE produced, since both entities really
-       existed — *plus* the same staged id rewrite, so any of this batch's own claims about the
-       loser land on the survivor rather than resurrecting the merged-away id.
+    1. **Normalize direction:** if exactly one id is committed, force it to `keep` — the
+       already-written entity always survives, its name stays primary. If both or neither are
+       committed, honour the model's `keep_id`.
+    2. **Loser is batch-only:** a plain staged id rewrite (`_rewrite_staged_ids`) — no note or
+       registry entry exists yet, so `write_vault` merges the two staged entities naturally at
+       commit. The common case.
+    3. **Loser is committed** (so both are): the full `merge_entities.run` surgery (stub, backup,
+       provenance), plus the same staged id rewrite, so this batch's own claims about the loser
+       land on the survivor rather than resurrecting the merged-away id.
 
-    Merges chain (a→b then b→c): each is resolved against an accumulating remap, following an
-    already-merged id to its current survivor. Returns
+    Merges chain (a→b then b→c) against an accumulating remap, flattened so every key points
+    straight at its final survivor. Returns
     ``{"merged": [...], "remap": {...}, "contradictions": parsed.get("contradictions") or []}`` —
-    the remap is flattened (every key points straight at its final survivor) for
-    `apply_contradictions`, which the caller runs later, post-commit; contradictions are carried
-    through unapplied — they need the committed vault to validate against.
+    contradictions are carried through unapplied, since they need the committed vault to validate
+    against (the caller applies them post-commit).
     """
     entities_path = vault / ".watchdog" / "registry" / "entities.json"
     registry_ids = set(_read_json_or(entities_path, []))

--- a/src/watchdog/pipeline/requests.py
+++ b/src/watchdog/pipeline/requests.py
@@ -1,12 +1,9 @@
 """Document-request ledger (#365).
 
-Ingest already told the journalist "you should get the hearing transcript this order cites" —
-but only as prose buried in the briefing's leads, indistinguishable from an open-ended
-investigative thread. A **document request** is a different kind of object: a concrete,
-known-to-exist artifact to go and acquire (a document type, the specific thing, why it matters,
-and often where to get it), not a thread to investigate. Splitting it out follows §I1: the model
-authors the content (``type``/``what``/``why_it_matters``/``likely_source``); Python stamps the
-id and provenance.
+A document request is a concrete, known-to-exist artifact to go acquire (a document type, the
+specific thing, why it matters, often where to get it) — distinct from an open-ended
+investigative lead. Splitting it out follows §I1: the model authors the content
+(``type``/``what``/``why_it_matters``/``likely_source``); Python stamps the id and provenance.
 
 Ledger at ``.watchdog/registry/requests.json``::
 
@@ -16,23 +13,14 @@ Ledger at ``.watchdog/registry/requests.json``::
         "added": "<iso>"
     }}}
 
-Request ids (``rid``, built by ``resolutions.request_id``) are content-keyed on the normalized
-``what`` text alone — vault-wide, not per source document (#416) — so re-recording the same
-request, whether a repair retry of the same document or a second document citing the same
-artifact under the same wording, converges onto one entry instead of duplicating; each citing
-document is appended to that entry's ``sources`` rather than spawning a new one. That only
-catches identical wording, though — a paraphrase of the same real document still lands as a
-separate entry, which ``orchestrate._post_ingest``'s document-request dedup pass (#416, D159)
-catches with a model call over the current open set, judging which entries name the same
-real-world document; ``merge_duplicates`` performs the fold. Resolution is otherwise manual —
-a ticked checkbox or ``watchdog resolve``, never auto-closed by matching a newly-ingested
-document — and a resolved or rendered request is never re-fed into any *other* model prompt
-(briefing bundle, pre-flight digests, extraction): the dedup pass is a narrow, bounded exception
-to that D111 rule, scoped to judging sameness among requests themselves, the same code/model
-split (§I1) entity reconciliation and timeline dedup already use. ``write_requests`` renders the
-still-open entries to the vault-root ``requests.md`` (a current-state view, overwritten each
-ingest, not an event log).
-"""
+Entries are content-keyed and deduped on the normalized ``what`` text — see `record` for the
+mechanism. That only catches identical wording; a paraphrase of the same real document lands as
+a separate entry, caught by a later model-judged dedup pass (``orchestrate._post_ingest``, #416,
+D159). Resolution is otherwise manual (a ticked checkbox or ``watchdog resolve``, never
+auto-closed), and a resolved/rendered request is never re-fed into any other model prompt — the
+dedup pass is D111's one narrow, bounded exception. ``write_requests`` renders the still-open
+entries to the vault-root ``requests.md`` (a current-state view, overwritten each ingest, not an
+event log)."""
 
 import datetime
 import json

--- a/src/watchdog/pipeline/section.py
+++ b/src/watchdog/pipeline/section.py
@@ -58,41 +58,15 @@ _CHARS_PER_TOKEN = 4                # cheap heuristic
 _THRESHOLD_FRACTION = 0.6
 _BUDGET_FRACTION = 0.3
 
-# Sectioning is sized from the input window alone (#555, D202). It used to be additionally capped
-# by an output-derived input ceiling (#343, #542): predict a call's *total* (reasoning + visible)
-# output from its input size with an affine fit, then invert that fit against the model's wire
-# `max_output_tokens` envelope to find the largest input whose answer would still fit. That whole
-# apparatus — `_OUTPUT_DENSITY_BY_EFFORT`, `_invert_output_ceiling`, and the
-# `_MIN`/`_MAX_OUTPUT_CAPPED_BUDGET` clamps around it — is gone, for three measured reasons.
-#
-# It never bound. Across 673 archived extraction calls, peak output as a share of the model's own
-# wire envelope was 14% (gemini-3.5-flash medium), 27% (gpt-5.4-nano medium), 16% (gpt-5.6-luna
-# high). The only calls that ever reached a cap were gpt-5.4-mini at high effort, and they reached
-# the *old* 96,000 wire cap that #598 has since raised to 115,200. Nine of the fifteen catalogued
-# models share one `max_output_tokens` (128,000) and six paginate past it, so the ceiling could
-# not have distinguished between models even where it did apply.
-#
-# The fit pooled models that behave nothing alike. gpt-5.4-mini at high effort emits ~2.4 tokens
-# of chain-of-thought per input token; gemini-3.5-flash at the same effort emits essentially none
-# (per-model slope -0.002). Pooling let gpt-5.4-mini's appetite set Gemini's budget — which is how
-# one model came to get 50,000 at low effort and 5,660 at high, a 9x swing driven by a different
-# vendor's reasoning volume. That, not the ceilings, produced the spread #555 was filed about.
-#
-# And the inversion is ill-conditioned wherever the slope is near zero: dividing an envelope by a
-# marginal rate of -0.002 yields an unbounded budget, so the formula degenerates on exactly the
-# models it was meant to protect. `_MAX_OUTPUT_CAPPED_BUDGET` (50,000) was the constant holding
-# that degeneracy back — and it, rather than any property of the model, was what actually set the
-# budget on every ceiling-governed backend.
-#
-# Truncation is now handled where it is observable instead of predicted: `orchestrate`'s bounded
-# re-split (#540) halves a section that actually did truncate, and the starvation retry (#558)
-# drops one effort level. Both act on what happened; the fit acted on a guess with R² 0.05-0.37.
-#
-# Consequence worth stating plainly, because it looks like an omission: `effort` no longer affects
-# sectioning at all, and is no longer a parameter here. Effort changes how much a model *thinks*,
-# not how much room a call needs — and with the envelope no longer in the arithmetic there is
-# nothing left for it to scale. `output_ceiling_for_sectioning` still exists and still governs the
-# wire `max_tokens` sent on every call; it simply no longer feeds back into input sizing.
+# Sectioning is sized from the input window alone (D202) — no output-derived cap. An earlier
+# version predicted a call's total output from its input and clamped the input budget to fit the
+# model's output envelope; deleted because the clamp never bound in practice, pooled models with
+# wildly different reasoning volumes into one fit (producing #555's headline spread), and was
+# ill-conditioned wherever the fit's slope was near zero. Truncation is now handled where it's
+# observable instead of predicted (bounded re-split on actual truncation, a starvation retry that
+# drops one effort level). `effort` is consequently no longer a parameter here — it no longer has
+# anything left to scale; `output_ceiling_for_sectioning` still exists and governs wire
+# `max_tokens`, but no longer feeds back into input sizing.
 
 
 def _config_get(key: str, default):


### PR DESCRIPTION
## Summary
- Fixes nine comments/help strings still naming removed or deprecated CLI surfaces — `watchdog pre-flight`/`post-flight`/`merge-sections` (all removed as subcommands in #645, though `preflight.py`/`postflight.py`/`merge.py` remain real `python -m` entry points), `watchdog ingest` where `dig`/`bark` is now the recommended path, and a `/watchdog-health` reference in `cmd/vault.py` inconsistent with the three sibling error paths in the same file that already say `watchdog doctor`.
- A file-by-file read (not grep) of all 68 files / ~26,400 lines in `src/watchdog`, done across eight parallel passes for #390's documentation/comment-firming effort, found the dominant problem isn't staleness — it's docstrings that grew to 20-80 lines by accumulating each issue's rationale inline instead of pointing at `DECISIONS.md`. Trimmed the worst offenders toward a WHY sentence plus the citation(s) already in the text: `orchestrate.py`'s `_record_usage` (89→19 lines), `ingest_setup.py`'s `_model_tokenizer_calibration` (70→13), `pipeline/section.py`'s 35-line inline sectioning-history comment (→9), plus smaller trims across `model_client.py`, `batch_extract.py`, `reconcile.py`, `prompts.py`, `requests.py`, `cmd/setup.py`, `cmd/auth.py`, `cmd/reindex.py`, `model_catalog.py`.
- Every `D<n>`/`#issue` citation was checked against `DECISIONS.md` before trimming around it — this is compression, not a rewrite of the rationale. Spot-checked several (D202, D118, D168/D171/D209) directly against the cut prose to confirm nothing uncited was lost.
- `write_vault.py`'s 53-line module docstring was deliberately left alone: it's a wire-format schema reference for the `postflight`→`write_vault` contract, not narrative history, and `docs/vault.md` documents the rendered vault rather than this internal JSON shape — moving it there would misplace an implementation detail into a journalist-facing page.
- Net: 397 insertions / 901 deletions across 19 files.

## Test plan
- [x] `python3 -m py_compile` on all 19 changed files
- [x] `python3 -c "ast.parse(...)"` on all 19 changed files
- Docstring/comment-only change (no logic touched) — skips the test suite and `ruff` per this project's own CLAUDE.md carve-out for edits that touch no runnable logic.

Related: #390. Complements #660/#661/#662, which cover the CLAUDE.md ingest-workflow fix, the ARCHITECTURE.md/DECISIONS.md polish pass, and the new `docs/methodology.md` respectively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DooQppPvxWCWuDgX6fSzVG