### PR TITLE
Link refreshed "one document" artifact from methodology and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ your vault        linked notes in Obsidian; ask questions in Claude Code
 
 After ingest, you read the briefing, explore the vault in Obsidian, and ask questions inside Claude Code — `/watchdog-query Who are the directors of Shell Co Ltd?` — with every answer cited back to a page.
 
+For a closer look at what happens to a single document — the OCR decision, the sectioning, the model calls — see [this illustrated walkthrough](https://claude.ai/code/artifact/d16050d6-3357-411c-9b88-26271a330435).
+
 ## What you need
 
 - macOS, Linux or Windows

--- a/docs/methodology.md
+++ b/docs/methodology.md
@@ -76,4 +76,5 @@ Chew, search, and the two models above never leave your computer and never cost 
 - [Getting started](getting-started.md) — the practical walkthrough, from creating a vault to reading your first briefing.
 - [Configuration](configuration.md) — which model runs each stage, what it costs, and how to change either.
 - [Investigating](investigating.md) — everything you do with a vault day to day, once documents are in it.
+- [One document, from dropped file to result](https://claude.ai/code/artifact/d16050d6-3357-411c-9b88-26271a330435) — an illustrated walkthrough of chew and dig for a single document, with diagrams of the sectioning and OCR decisions and the token budgets involved.
 - `ARCHITECTURE.md`, in the project repository — the precise technical reference this page is a plain-English companion to.


### PR DESCRIPTION
## Summary
- Refreshed the "One Document Through Watchdog" artifact against current code (separately from this PR — it's a hosted artifact, not a repo file) and linked it from `docs/methodology.md`'s "Where to go from here" and the README's "How it works" section, per #390.
- The refresh itself found real drift worth noting: page-scoped OCR (D192/#605) had landed since the artifact was written but was still described as future work; the diagram showed a single converged `verify` step when it actually runs inside each extraction lane before that call's own post-flight check; and both budget sections described an effort-driven sectioning/output-ceiling mechanism that D202 (#555) and D197 (#598) have since deleted entirely — sectioning and output limits are now flat and effort-independent everywhere.

## Test plan
- [x] Docs-only change (a repo-relative link addition in two `.md` files) — no runnable code touched, so no test/lint run, per this repo's own carve-out for non-executing text changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)