### PR TITLE
Verification pass at medium/high effort: helps at medium, barely at high

### DIFF
--- a/benchmarks/FINDINGS.md
+++ b/benchmarks/FINDINGS.md
@@ -794,6 +794,55 @@ unjudged. The Gemini finding is one arm at one effort tier; it says this specifi
 configuration disagreed sharply with its own numeric-slice score, not that Gemini models
 generally do.
 
+### The verification pass helps at medium effort, barely moves the needle at high effort — and the numeric slice would have overstated the high-effort regression (2026-09-03, #535)
+
+The 2026-08-09 finding above answered this question for `low` effort only ("no evidence of a
+recall gain that would justify 2× cost"). Two new arms, `gpt-luna-med-verify` and
+`gpt-luna-high-verify` (`benchmark.yaml`'s verify-pass sweep), fill in the two effort tiers that
+finding didn't cover, run against the noverify baselines already on record (`gpt-luna-med`/
+`gpt-luna-high`, run `2026-08-31-1645`) — no need to re-run those, only the two new verify arms
+were live calls.
+
+**Numeric-anchor slice first** (`score_index.py`, ~1/3 of key items, free and immediate): verify
+adds +5pts to facts recall at both tiers, but splits on `must_not_miss` — a +20pt jump at medium
+effort (42%→62%) against what looked like a real regression at high effort (74%→64%, −10pts).
+That asymmetry was surprising enough on its own to justify the judge pass below rather than
+trusting a scorer that only sees a third of the picture.
+
+**Judge pass**: four arms blinded per document (X/Y/Z/A3 — `build_packets.py`'s scheme for more
+than three), Sonnet, one subagent per document, six documents. Hand-check passed: X
+(`gpt-luna-high-verify`, unmasked after grading) was judged `ungrounded` on the pension order's
+"Chief Justice Morawetz" fact/signature-block items — confirmed directly against the vault's own
+`key_facts`, which mentions Morawetz exactly once, in a sentence that never says he made or
+signed the order; only the entity tag names him. Every judgment file independently verified
+complete against its packet (every item, every label, valid tier, non-empty note) before
+aggregating, not just accepted on the subagents' own self-report.
+
+| Arm | Judged facts | Judged must_not_miss | Cost/page |
+|---|---|---|---|
+| `gpt-luna-med` (noverify) | 45% (113/251) | 36% (45/126) | ~$0.0004 |
+| `gpt-luna-med-verify` | **52%** (130/251) | **52%** (65/126) | ~$0.0006 |
+| `gpt-luna-high` (noverify) | 64% (160/251) | **60%** (75/126) | ~$0.0007 |
+| `gpt-luna-high-verify` | **66%** (165/251) | 56% (71/126) | ~$0.0009 |
+
+**The judge pass confirms the shape the numeric slice showed, at a smaller magnitude on the
+regression.** At medium effort, verify is an unambiguous win: +7pts facts, +16pts
+`must_not_miss`, for 50% more cost per page. At high effort, verify's facts gain shrinks to
++2pts and `must_not_miss` drops 4pts (60%→56%) rather than the numeric slice's apparent 10-point
+drop — real, but smaller, and within the range a single run per arm can produce on its own
+(#581 found up to a 3× spread in facts extracted between independent samples of the *same*
+arm). **The numeric-only slice would have been directionally right but overstated the size of
+the high-effort regression by more than double** — exactly the failure mode RUNBOOK.md's judge
+step exists to catch, just this time on magnitude rather than on which arm wins.
+
+**Reading this together with the low-effort finding**: verification's value is effort-dependent,
+not a flat yes/no. It earns its cost cleanly at `medium`. At `high`, the model is already
+catching most of what verify would add, so the second pass mostly reconfirms rather than
+recovers — and on this run's numbers, spending it doesn't clearly pay for itself. Shipping
+`verify_extraction` on by default for the `low`/`high` tiers stays unjustified by this data;
+`medium` is the one tier where a case for turning it on could be made, and even there this is
+one run of each arm, not a settled number.
+
 ## Corrections logged along the way
 
 - The original `bench-ex-sonnet-high`/`bench-ex-sonnet-med` vaults (run 2026-07-15, before #403's

--- a/benchmarks/FINDINGS.md
+++ b/benchmarks/FINDINGS.md
@@ -835,6 +835,21 @@ arm). **The numeric-only slice would have been directionally right but overstate
 the high-effort regression by more than double** — exactly the failure mode RUNBOOK.md's judge
 step exists to catch, just this time on magnitude rather than on which arm wins.
 
+**The high-effort regression is base-extraction variance, not verify actively removing
+anything.** `merge_candidates` only ever adds facts (`verify.py`) — there is no code path back
+from a merged extraction to a smaller one. Checked directly: of the 13 `must_not_miss` items
+that flip from hit (`gpt-luna-high`) to miss (`gpt-luna-high-verify`) in the judge's per-item
+verdicts, all 13 are items `gpt-luna-high-verify`'s own *base* extraction call never stated in
+the first place — not one is a case of verify's second pass overwriting or contradicting a
+correct fact. Verify's own job is to catch exactly this, and on these 13 items it didn't:
+`noverify`/`verify` are two independent API calls to the same model at the same effort, so a gap
+this size is consistent with #581's already-documented up-to-3× spread between independent
+samples of one arm, landing on this particular draw's base call rather than being caused by
+verify running at all. One pattern recurs enough to be more than noise, though: **Justice
+Morawetz's signature block is missed the identical way in three separate documents**
+(initial order, pension order, and the hand-checked item above) — tagged as an entity every
+time but never promoted into a stated fact, in both the base call and verify's own re-read.
+
 **Reading this together with the low-effort finding**: verification's value is effort-dependent,
 not a flat yes/no. It earns its cost cleanly at `medium`. At `high`, the model is already
 catching most of what verify would add, so the second pass mostly reconfirms rather than

--- a/benchmarks/benchmark.yaml
+++ b/benchmarks/benchmark.yaml
@@ -91,6 +91,11 @@ extractor_sweep:
     - {id: gpt-mini-low-noverify,   extractor_model: "openai:gpt-5.4-mini", extractor_effort: low, verify: false, concurrency: 3}
     - {id: gpt-luna-low-verify,     extractor_model: "openai:gpt-5.6-luna", extractor_effort: low, verify: true, concurrency: 3}
     - {id: gpt-luna-low-noverify,   extractor_model: "openai:gpt-5.6-luna", extractor_effort: low, verify: false, concurrency: 3}
+    #
+    # Verify-only follow-up on the med/high tiers (no noverify twin): the plain gpt-luna-med/
+    # gpt-luna-high arms above already carry a recent noverify baseline on the full corpus.
+    - {id: gpt-luna-med-verify,     extractor_model: "openai:gpt-5.6-luna", extractor_effort: medium, verify: true, concurrency: 3}
+    - {id: gpt-luna-high-verify,    extractor_model: "openai:gpt-5.6-luna", extractor_effort: high, verify: true, concurrency: 3}
 
 finalizer_sweep:
   vault_prefix: bench-fn

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -70,9 +70,13 @@ A few things this benchmark doesn't cover yet:
   several of them already.
 - **Whether the verification pass earns its keep.** The optional second read
   (`verify_extraction`, see [Configuration](configuration.md#the-verification-pass)) reliably adds
-  facts; what has not been measured is how many of those facts are worth a reporter's attention
-  rather than restatements or trivia. Until that number exists, the pass stays off by default —
-  a recall gain that quietly fills your fact lists with noise is not an improvement.
+  facts, and effort turns out to matter more than expected: at `low` effort, the added facts were
+  mostly restatements rather than new material, and a judge pass found no recall gain worth 2x the
+  cost. At `medium` effort a judge pass found a real, sizeable recall gain for 50% more cost; at
+  `high` effort the gain narrows to nearly nothing, since the model is already catching most of
+  what a second pass would add (`benchmarks/FINDINGS.md`, 2026-09-03). The pass stays off by
+  default — this data makes a case for turning it on at `medium` specifically, not across the
+  board, and it's one run of each arm so far, not a settled number.
 - **Running this automatically.** Right now a maintainer runs the benchmark by hand when a new
   model or effort combination is worth checking. Wiring it into a scheduled or on-demand GitHub
   Actions run is a reasonable next step, once it's clear how often that's actually useful.


### PR DESCRIPTION
## Summary
- Adds `gpt-luna-med-verify`/`gpt-luna-high-verify` to `benchmark.yaml`'s verify-pass A/B group, filling in the two effort tiers the existing low-effort verify finding (2026-08-09, #535) didn't cover.
- Runs both arms against the full 6-document corpus and scores against the existing noverify baselines already on record (`gpt-luna-med`/`gpt-luna-high`, run `2026-08-31-1645`) — no need to re-run those.
- Numeric-anchor slice showed a surprising split: verify helps facts recall at both tiers (+5pts each) but `must_not_miss` moves in opposite directions — +20pts at medium effort, an apparent -10pts at high effort.
- A blinded four-arm judge pass (six Sonnet subagents, one per document; hand-checked against raw vault files; every judgment file independently re-verified complete against its packet before aggregating, not just accepted on self-report) confirms the same shape at smaller magnitude: **+7/+16pts at medium** effort (a clear win for ~50% more cost/page), **+2/-4pts at high** effort (real, but the numeric-only slice overstated the regression by more than double).
- `docs/benchmarks.md`'s Roadmap item on this is updated to reflect the finding rather than left as an open question — verification's value turns out to be effort-dependent, which is new information the old bullet didn't have room for.

## Test plan
- [x] Docs/benchmark-findings only — `benchmark.yaml`'s new arms were already exercised by the live run this PR's findings are based on; `FINDINGS.md`/`docs/benchmarks.md` are non-executing text, so no test/lint run per this repo's own carve-out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)