### PR TITLE
Bump version to 1.0.0, drop alpha framing

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@ Watchdog is a command-line tool for journalists who accumulate large sets of pub
 
 The vault lives in [Obsidian](https://obsidian.md), a free note-taking app, as ordinary files on your computer. The information-extraction work is carried by an LLM (be that Claude, ChatGPT, Gemini, DeepSeek, etc.). The questions run in [Claude Code](https://claude.ai/download), Anthropic's AI assistant for the terminal.
 
-> **This project is still a work in progress.** The core pipeline works and has been tested on macOS with real investigation documents. It is not yet battle-hardened. Feedback and contributions are welcome.
-
 ## Public records only
 
 Watchdog is careful with your files. The originals never leave your computer, and all document conversion runs locally. But the extracted text of each document is sent to a cloud AI model for analysis, and there is no way to take that back. So Watchdog is only for documents that are public, or presumptively public.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,14 +6,14 @@ build-backend = "hatchling.build"
 # Note: "watchdog" is taken on PyPI (filesystem events library).
 # Package name is "watchdog-intel"; the CLI command is still "watchdog".
 name = "watchdog-intel"
-version = "0.1.0"
+version = "1.0.0"
 description = "Investigative journalism document intelligence — drop records, find connections"
 readme = "README.md"
 license = { file = "LICENSE" }
 requires-python = ">=3.10"
 keywords = ["journalism", "documents", "ocr", "investigative", "obsidian", "public-records"]
 classifiers = [
-    "Development Status :: 4 - Beta",
+    "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Other Audience",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,14 +6,14 @@ build-backend = "hatchling.build"
 # Note: "watchdog" is taken on PyPI (filesystem events library).
 # Package name is "watchdog-intel"; the CLI command is still "watchdog".
 name = "watchdog-intel"
-version = "0.1.0a6"
+version = "0.1.0"
 description = "Investigative journalism document intelligence — drop records, find connections"
 readme = "README.md"
 license = { file = "LICENSE" }
 requires-python = ">=3.10"
 keywords = ["journalism", "documents", "ocr", "investigative", "obsidian", "public-records"]
 classifiers = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 4 - Beta",
     "Intended Audience :: Other Audience",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
## Summary
- Bumps version from `0.1.0a6` to `1.0.0` in `pyproject.toml`.
- Bumps the PyPI Development Status classifier from Alpha to Production/Stable, matching the maturity signal of dropping the alpha framing and pushing to PyPI for real users.
- Removes the "still a work in progress" banner from README.md.

## Test plan
- [x] No runnable code touched (version string, classifier, README prose) — no test/lint run needed.
- [ ] After merge: push tag `v1.0.0` to trigger `.github/workflows/publish.yml` (test → build → GitHub release → PyPI publish).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DooQppPvxWCWuDgX6fSzVG