### PR TITLE
Explain the Luna recommendation and how to set it up

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ For a closer look at what happens to a single document — the OCR pipeline, the
 
 A Claude Pro subscription (US$20/month) is enough for most journalism work.
 
-Watchdog benchmarks its own model and effort defaults against real court and financial filings rather than picking one on reputation alone — see [Benchmarks](https://github.com/tomcardoso/watchdog/blob/main/docs/benchmarks.md) for the full results. The current top recommendation for extraction is OpenAI's GPT-5.6 Luna, at roughly $1 per 1,000 pages; Claude stays the zero-setup default.
+Watchdog benchmarks its own model and effort defaults against real court and financial filings rather than picking one on reputation alone — see [Benchmarks](https://github.com/tomcardoso/watchdog/blob/main/docs/benchmarks.md) for the full results. The current top recommendation for extraction is OpenAI's GPT-5.6 Luna, at roughly $1 per 1,000 pages; Claude stays the zero-setup default. See [the install guide](https://github.com/tomcardoso/watchdog/blob/main/docs/install.md#optional-using-gpt-56-luna-for-extraction) for how to set it up.
 
 ## Installation
 

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -18,6 +18,8 @@ working investigator runs day to day.
 
 ## What to expect
 
+None of the numbers below need to reach 100% for Watchdog to be useful. Its job is to surface facts, entities, and connections for a journalist to check against the source — not to hand over a courtroom-ready read on the first pass. A cheap model that reliably catches most of what's on a page is doing real work, and that's what these numbers are actually comparing: which cheap option catches the most for the price, not who clears some accuracy bar first. It also means the recommendation these numbers lead to isn't fixed — cheap models keep improving, and it will move as the benchmark catches up to new ones.
+
 Recall below is the *judged* kind: a person or a model checks each extraction against the
 source document (RUNBOOK.md step 6), rather than just checking whether a figure happens to
 match. That mechanical, figure-matching check is faster and free, but it misses roughly
@@ -52,10 +54,11 @@ surfaced how far it actually trails here — a reminder that a model's rank can 
 check produced it.
 
 This isn't the full field — every model here is at one particular effort level, checked the slow
-and reliable way. Nothing here is a recommendation to run one model over another; it's what the
-check has actually found for each configuration measured, no more. `benchmarks/FINDINGS.md` has
-the fuller narrative behind it: all six documents, the hand-checks that verify the judge, and
-what's true only of this corpus.
+and reliable way. This table alone isn't a ranking to act on by itself; it's what the check has
+actually found for each configuration measured, no more. [Controlling cost](configuration.md#controlling-cost)
+is where these findings turn into an actual pick. `benchmarks/FINDINGS.md` has the fuller
+narrative behind it: all six documents, the hand-checks that verify the judge, and what's true
+only of this corpus.
 
 ## The wider sweep
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -129,6 +129,21 @@ watchdog about
 
 You should see Watchdog's version number and project links. If you see `watchdog: command not found` instead, head to [Troubleshooting](troubleshooting.md#watchdog-command-not-found).
 
+## Optional: using GPT-5.6 Luna for extraction
+
+Claude on your existing subscription is the default and needs nothing extra — skip this section if that's enough for you. It stops being enough once you're feeding Watchdog real volume: subscription auth shares one Claude Code session's rate limit, and a run of even a handful of documents can trip it — one traced case hit it at just six documents ingested at once, and the run stalls waiting out the limit rather than failing outright. Routing extraction to a metered API key instead avoids that, and lets documents run many at a time rather than a few.
+
+Watchdog benchmarks its own model recommendations against real court and financial filings rather than picking one on reputation — see [Benchmarks](benchmarks.md) for the numbers and the reasoning behind them. The current pick for extraction is OpenAI's GPT-5.6 Luna, at roughly $1 per 1,000 pages. That's today's answer, not a permanent one — cheap models keep improving, and this recommendation will move as better ones come along.
+
+To set it up:
+
+1. Go to [platform.openai.com](https://platform.openai.com), sign in or create an account, and open **API keys** in the left sidebar.
+2. Add a payment method under **Settings → Billing**. Unlike Claude's flat monthly subscription, OpenAI's API is pay-as-you-go with no free tier, so a card on file is required before a key can make any paid calls.
+3. Click **Create new secret key** and copy it — it's shown only once.
+4. Run `watchdog setup` (or, if you've already set up, `watchdog configure extractor_model`) and paste the key when it offers to route ingestion to a metered provider.
+
+See [Model backends](configuration.md#model-backends) for routing the other pipeline stages the same way, and [Controlling cost](configuration.md#controlling-cost) for the full cost picture.
+
 ## Optional: audio and video transcription
 
 Watchdog can transcribe audio and video files if you install support for it. This requires **ffmpeg** and adds roughly 2 GB of dependencies.


### PR DESCRIPTION
## Summary
- New `docs/install.md` section, "Optional: using GPT-5.6 Luna for extraction" — the concrete reason to switch off Claude subscription auth for volume ingest (throttling, traced to issue #400), how to create an OpenAI account and API key, and where it plugs into `watchdog setup`/`watchdog configure`.
- `docs/benchmarks.md`: added framing that recall doesn't need to hit 100% for Watchdog to be useful — the benchmark is about which cheap model catches the most for the price, not clearing an accuracy bar — and that the Luna recommendation isn't permanent as cheaper models improve.
- Softened `benchmarks.md`'s "nothing here is a recommendation" line, which was in tension with the recommendation already stated elsewhere (README, configuration.md), and pointed it at `configuration.md#controlling-cost` where the actual pick lives.

README and configuration.md already stated the Luna recommendation itself, so left untouched to avoid duplicating it a third time.

## Test plan
- [x] Doc-only change, no runnable code touched — no test/lint run needed.
- [x] Read through once more for tone/accuracy before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DooQppPvxWCWuDgX6fSzVG