### PR TITLE
Deduplicate the test job into a composite action

### DIFF
--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -1,0 +1,23 @@
+name: Run test suite
+description: >
+  Installs Watchdog's test dependencies (keeping docling's heavy tree out of CI) and runs pytest
+  with a per-test timeout. Used by both ci.yml and publish.yml so the dependency list only needs
+  updating in one place.
+
+runs:
+  using: composite
+  steps:
+    # `--no-deps` keeps docling's heavy tree (torch, onnxruntime) out; everything the tests
+    # actually import is listed explicitly below. python-docx/python-pptx/openpyxl/Pillow/
+    # defusedxml are here so the file_metadata tests (#369) run rather than `importorskip`
+    # themselves into a silent pass — a skipped entity-bomb test is worth nothing. anthropic is
+    # here for the same reason (#563): test_model_client.py's rate-limit header capture tests are
+    # the first to call _api_complete_async against the real SDK's classes rather than bypassing
+    # it via _ABACKENDS.
+    - name: Install package and dev dependencies
+      shell: bash
+      run: pip install --no-deps -e . && pip install pyyaml pypdf argcomplete numpy pytest pytest-timeout jsonschema httpx truststore nh3 python-docx python-pptx openpyxl Pillow defusedxml anthropic
+
+    - name: Run tests
+      shell: bash
+      run: pytest --timeout=60

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,14 +46,4 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: pip
 
-      # `--no-deps` keeps docling's heavy tree out of CI; everything the tests actually import is
-      # listed explicitly below. python-docx/python-pptx/openpyxl/Pillow/defusedxml are here so the
-      # file_metadata tests (#369) run rather than `importorskip` themselves into a silent pass —
-      # a skipped entity-bomb test is worth nothing. anthropic is here for the same reason (#563):
-      # test_model_client.py's rate-limit header capture tests are the first to call
-      # _api_complete_async against the real SDK's classes rather than bypassing it via _ABACKENDS.
-      - name: Install package and dev dependencies
-        run: pip install --no-deps -e . && pip install pyyaml pypdf argcomplete numpy pytest pytest-timeout jsonschema httpx truststore nh3 python-docx python-pptx openpyxl Pillow defusedxml anthropic
-
-      - name: Run tests
-        run: pytest --timeout=60
+      - uses: ./.github/actions/run-tests

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,14 +22,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: pip
 
-      # Mirrors ci.yml's test job: `--no-deps` keeps docling's heavy tree (torch, onnxruntime) out
-      # of the release gate; everything the tests actually import is listed explicitly below. Keep
-      # this list in sync with ci.yml's.
-      - name: Install package and dev dependencies
-        run: pip install --no-deps -e . && pip install pyyaml pypdf argcomplete numpy pytest pytest-timeout jsonschema httpx truststore nh3 python-docx python-pptx openpyxl Pillow defusedxml anthropic
-
-      - name: Run tests
-        run: pytest --timeout=60
+      - uses: ./.github/actions/run-tests
 
   build:
     needs: test

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     strategy:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
@@ -19,12 +20,16 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          cache: pip
 
+      # Mirrors ci.yml's test job: `--no-deps` keeps docling's heavy tree (torch, onnxruntime) out
+      # of the release gate; everything the tests actually import is listed explicitly below. Keep
+      # this list in sync with ci.yml's.
       - name: Install package and dev dependencies
-        run: pip install -e ".[dev]"
+        run: pip install --no-deps -e . && pip install pyyaml pypdf argcomplete numpy pytest pytest-timeout jsonschema httpx truststore nh3 python-docx python-pptx openpyxl Pillow defusedxml anthropic
 
       - name: Run tests
-        run: pytest
+        run: pytest --timeout=60
 
   build:
     needs: test


### PR DESCRIPTION
## Summary
- `ci.yml` and `publish.yml` each carried their own copy of the install-deps-and-run-pytest steps for the test job, so a dependency change (already happened several times — `anthropic` for #563, `python-docx`/`python-pptx`/`openpyxl`/`Pillow`/`defusedxml` for #369) meant updating both files in lockstep.
- Pulled the shared steps into `.github/actions/run-tests`, a composite action both workflows' `test` jobs now call. Future dependency changes land in one place.
- Along the way, fixed the actual discrepancy this started from: `publish.yml`'s test job ran `pip install -e ".[dev]"` (full dev install, pulling in docling's heavy tree — torch, onnxruntime) with no per-test timeout, where `ci.yml` deliberately avoids both. Now both run identically: the lightweight explicit dependency list, `pytest --timeout=60`, `timeout-minutes: 10`, `cache: pip`.

**Why a composite action and not `publish.yml` calling `ci.yml` directly via `workflow_call`:** considered it, but `ci.yml`'s `concurrency` group keys on `github.event.pull_request.number`, which is empty on a tag-push trigger — every release would collapse into the same concurrency group, and `cancel-in-progress: true` would cancel concurrent releases against each other. A composite action sidesteps that: each workflow keeps its own job/matrix/concurrency setup, only the shared "install deps, run pytest" steps move into one file.

## Test plan
- [x] YAML syntax validated on all three files.
- [x] This PR's own CI run exercises the new composite action for real (PRs run the workflow version on their own branch).
- [ ] Next tag push exercises `publish.yml`'s use of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DooQppPvxWCWuDgX6fSzVG