### PR TITLE
Fix watchdog configure column misalignment for long key names

### DIFF
--- a/src/watchdog/cmd/setup.py
+++ b/src/watchdog/cmd/setup.py
@@ -635,6 +635,11 @@ _CONFIGURE_KEYS = {
     },
 }
 
+# Column width for the `watchdog configure` key listing (both the plain listing and the wizard
+# menu) — derived from the longest key name so a future key can't silently break alignment the
+# way a hardcoded width did (section_token_threshold, finalizer_reconciliation_model, ...).
+_KEY_COL_WIDTH = max(len(k) for k in _CONFIGURE_KEYS)
+
 # Display grouping for the `watchdog configure` listing (presentation only — set/get is
 # unaffected). Each section owns an ordered list of keys; any key missing from every
 # section is still shown, under "Other", so a newly added key never silently disappears.
@@ -1148,7 +1153,7 @@ def _wizard_menu(config: dict, initial_sel: int = 0):
 
     Built on the shared `interactive.pick()` (raw-mode with a numbered fallback)."""
     def _label(k):
-        return f"{k:<22} {_display_value(k, config.get(k), config)}"
+        return f"{k:<{_KEY_COL_WIDTH}} {_display_value(k, config.get(k), config)}"
 
     items: list = []   # str (selectable key label) or interactive.Header
     keys: list = []    # keys, parallel to the selectable items in `items`
@@ -1214,8 +1219,8 @@ def cmd_configure(args) -> None:
 
         def _print_key(k):
             meta = _CONFIGURE_KEYS[k]
-            print(f"  {_DIM}{k:<26}{_RESET} {_display_value(k, config.get(k), config)}")
-            print(f"  {' ' * 26} {_DIM}{meta['short']}{_RESET}")
+            print(f"  {_DIM}{k:<{_KEY_COL_WIDTH}}{_RESET} {_display_value(k, config.get(k), config)}")
+            print(f"  {' ' * _KEY_COL_WIDTH} {_DIM}{meta['short']}{_RESET}")
             print()
 
         shown = set()


### PR DESCRIPTION
## Summary
- `watchdog configure`'s plain listing and its interactive wizard menu each padded key names to a hardcoded column width (26 and 22 characters respectively) to align values in a column.
- Several keys already exceed both: `section_token_threshold` (23), `section_overlap_tokens` (22), `empty_extraction_min_words` (26), and every `finalizer_*_model` override (24–30) — `finalizer_reconciliation_model` at 30 chars broke even the wider of the two widths. Their values ran together with just one space instead of lining up.
- Replaced both hardcoded widths with one `_KEY_COL_WIDTH` derived from the longest key in `_CONFIGURE_KEYS`, shared by both listing functions, so a future key addition can't silently break alignment again.

Found live while setting up a real vault for a Luna-high-effort extraction test — `watchdog configure`'s output showed the misalignment on `section_token_threshold` and several other keys.

## Test plan
- [x] `pipx run ruff check src tests` — clean.
- [x] Full suite: 2637 passed.
- [x] Verified visually: `watchdog configure` now aligns every key including the previously-broken ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DooQppPvxWCWuDgX6fSzVG