### PR TITLE
Show the commands for setting Luna as the global default

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -140,13 +140,19 @@ To set it up:
 1. Go to [platform.openai.com](https://platform.openai.com), sign in or create an account, and open **API keys** in the left sidebar.
 2. Add a payment method under **Settings → Billing**. Unlike Claude's flat monthly subscription, OpenAI's API is pay-as-you-go with no free tier, so a card on file is required before a key can make any paid calls.
 3. Click **Create new secret key** and copy it — it's shown only once.
-4. Run `watchdog setup` and paste the key when it offers to route ingestion to a metered provider, then pick Luna once when asked for a model — that single pick applies to all three ingest stages (classifier, extractor, finalizer). If you've already set up, or want to change the pick later, set each stage directly instead:
+4. Run `watchdog setup` and paste the key when it offers to route ingestion to a metered provider, then pick Luna once when asked for a model — that single pick routes all three ingest stages (classifier, extractor, finalizer) to Luna. It does not set the recommended effort levels, and neither does picking the models any other way — that always needs doing separately:
+
+   ```bash
+   watchdog configure classifier_effort low
+   watchdog configure extractor_effort high
+   watchdog configure finalizer_effort high
+   ```
+
+   If you'd rather skip `watchdog setup`'s wizard, or want to change the pick later, set the models directly too:
 
    ```bash
    watchdog configure classifier_model openai:gpt-5.6-luna
-   watchdog configure classifier_effort low
    watchdog configure extractor_model openai:gpt-5.6-luna
-   watchdog configure extractor_effort high
    watchdog configure finalizer_model openai:gpt-5.6-luna
    ```
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -140,18 +140,19 @@ To set it up:
 1. Go to [platform.openai.com](https://platform.openai.com), sign in or create an account, and open **API keys** in the left sidebar.
 2. Add a payment method under **Settings → Billing**. Unlike Claude's flat monthly subscription, OpenAI's API is pay-as-you-go with no free tier, so a card on file is required before a key can make any paid calls.
 3. Click **Create new secret key** and copy it — it's shown only once.
-4. Run `watchdog setup` and paste the key when it offers to route ingestion to a metered provider — this sets Luna up for the current stage only (extraction). To set it as your standing default, or if you've already set up, run:
+4. Run `watchdog setup` and paste the key when it offers to route ingestion to a metered provider, then pick Luna once when asked for a model — that single pick applies to all three ingest stages (classifier, extractor, finalizer). If you've already set up, or want to change the pick later, set each stage directly instead:
 
    ```bash
    watchdog configure classifier_model openai:gpt-5.6-luna
    watchdog configure classifier_effort low
    watchdog configure extractor_model openai:gpt-5.6-luna
    watchdog configure extractor_effort high
+   watchdog configure finalizer_model openai:gpt-5.6-luna
    ```
 
-   Every future `watchdog dig` uses these until you change them again — no per-run flags needed. `watchdog configure` with no arguments shows every setting's current value, including these.
+   Every future `watchdog dig`/`watchdog bark` uses these until you change them again — no per-run flags needed. `watchdog configure` with no arguments shows every setting's current value, including these; `watchdog configure <key>` also works to route just one stage somewhere different, if you want a mix.
 
-See [Model backends](configuration.md#model-backends) for routing the other pipeline stages (including the post-ingest finalizer) the same way, and [Controlling cost](configuration.md#controlling-cost) for the full cost picture.
+See [Model backends](configuration.md#model-backends) for routing a stage to a different provider entirely, and [Controlling cost](configuration.md#controlling-cost) for the full cost picture.
 
 ## Optional: audio and video transcription
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -140,9 +140,18 @@ To set it up:
 1. Go to [platform.openai.com](https://platform.openai.com), sign in or create an account, and open **API keys** in the left sidebar.
 2. Add a payment method under **Settings → Billing**. Unlike Claude's flat monthly subscription, OpenAI's API is pay-as-you-go with no free tier, so a card on file is required before a key can make any paid calls.
 3. Click **Create new secret key** and copy it — it's shown only once.
-4. Run `watchdog setup` (or, if you've already set up, `watchdog configure extractor_model`) and paste the key when it offers to route ingestion to a metered provider.
+4. Run `watchdog setup` and paste the key when it offers to route ingestion to a metered provider — this sets Luna up for the current stage only (extraction). To set it as your standing default, or if you've already set up, run:
 
-See [Model backends](configuration.md#model-backends) for routing the other pipeline stages the same way, and [Controlling cost](configuration.md#controlling-cost) for the full cost picture.
+   ```bash
+   watchdog configure classifier_model openai:gpt-5.6-luna
+   watchdog configure classifier_effort low
+   watchdog configure extractor_model openai:gpt-5.6-luna
+   watchdog configure extractor_effort high
+   ```
+
+   Every future `watchdog dig` uses these until you change them again — no per-run flags needed. `watchdog configure` with no arguments shows every setting's current value, including these.
+
+See [Model backends](configuration.md#model-backends) for routing the other pipeline stages (including the post-ingest finalizer) the same way, and [Controlling cost](configuration.md#controlling-cost) for the full cost picture.
 
 ## Optional: audio and video transcription
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -140,20 +140,21 @@ To set it up:
 1. Go to [platform.openai.com](https://platform.openai.com), sign in or create an account, and open **API keys** in the left sidebar.
 2. Add a payment method under **Settings → Billing**. Unlike Claude's flat monthly subscription, OpenAI's API is pay-as-you-go with no free tier, so a card on file is required before a key can make any paid calls.
 3. Click **Create new secret key** and copy it — it's shown only once.
-4. Run `watchdog setup` and paste the key when it offers to route ingestion to a metered provider, then pick Luna once when asked for a model — that single pick routes all three ingest stages (classifier, extractor, finalizer) to Luna. It does not set the recommended effort levels, and neither does picking the models any other way — that always needs doing separately:
+4. Run `watchdog setup` and paste the key when it offers to route ingestion to a metered provider, then pick Luna once when asked for a model — that single pick routes all three ingest stages (classifier, extractor, finalizer) to Luna. By default, model effort levels for the classify/extract/finalize model steps are set to low/medium/high, respectively, but benchmarks have found that Luna extractions perform best with effort set to `high`. To do this, run the following command:
 
    ```bash
-   watchdog configure classifier_effort low
    watchdog configure extractor_effort high
-   watchdog configure finalizer_effort high
    ```
 
-   If you'd rather skip `watchdog setup`'s wizard, or want to change the pick later, set the models directly too:
+   If want to change your choice of model or effort level later, you can set the models directly by running `watchdog configure` and tweaking the configuration interactively, or by running the following commands:
 
    ```bash
    watchdog configure classifier_model openai:gpt-5.6-luna
+   watchdog configure classifier_effort low
    watchdog configure extractor_model openai:gpt-5.6-luna
+   watchdog configure extractor_effort high
    watchdog configure finalizer_model openai:gpt-5.6-luna
+   watchdog configure finalizer_effort high
    ```
 
    Every future `watchdog dig`/`watchdog bark` uses these until you change them again — no per-run flags needed. `watchdog configure` with no arguments shows every setting's current value, including these; `watchdog configure <key>` also works to route just one stage somewhere different, if you want a mix.


### PR DESCRIPTION
## Summary
- The Luna section in `docs/install.md` walked through getting an OpenAI key but only gestured at "run `watchdog configure extractor_model` afterward" for actually routing to it — no concrete commands.
- It also didn't mention that `watchdog setup`'s offer to route to a metered provider only covers extraction, not classification — someone who just answers that prompt ends up with Luna extraction but Haiku classification, not the full recommended combo.
- Now shows the exact `watchdog configure` commands for both `classifier_model`/`classifier_effort` and `extractor_model`/`extractor_effort`, matching what `configuration.md`'s "Controlling cost" section already recommends, plus a pointer to the finalizer stage for anyone who wants it fully end-to-end.

Prompted by actually setting this up live in a real vault this session and noticing the docs didn't say how.

## Test plan
- [x] Doc-only change, no runnable code touched — no test/lint run needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DooQppPvxWCWuDgX6fSzVG